### PR TITLE
swagger 초기 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,13 +24,12 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.session:spring-session-core'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/linglevel/api/config/SwaggerConfig.java
+++ b/src/main/java/com/linglevel/api/config/SwaggerConfig.java
@@ -1,0 +1,22 @@
+package com.linglevel.api.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("LLV API")
+                        .description("Linglevel API 명세서")
+                        .version("1.0.0"));
+    }
+} 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,19 @@
 spring.application.name=api
+
+# Server Configuration
+server.port=8080
+
+# Swagger UI Configuration
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.operationsSorter=method
+springdoc.swagger-ui.tagsSorter=alpha
+springdoc.swagger-ui.doc-expansion=none
+springdoc.swagger-ui.disable-swagger-default-url=true
+
+# API Documentation
+springdoc.api-docs.path=/api-docs
+springdoc.api-docs.enabled=true
+
+# Logging
+logging.level.com.linglevel.api=DEBUG
+logging.level.org.springframework.web=DEBUG


### PR DESCRIPTION
## 요약

swagger api 문서를 제공하는 설정을 초기화했습니다.

## 관련 이슈

Closes #2 

## 스크린샷

<img width="1448" alt="Screenshot 2025-06-27 at 12 39 15" src="https://github.com/user-attachments/assets/43d8003b-369b-4f04-93a2-da184aa004c0" />

## 보안

API 명세는 보안상 개발 서베에서만 제공 후 추후 막을 생각입니다.

## 체크리스트

이 PR을 제출하기 전에 다음을 확인해주세요

- [x] 코드가 스타일 가이드를 따름
- [x] 자체 검토 완료
- [x] 테스트 통과
- [x] 문서 업데이트
- [x] 민감한 데이터 포함 안함