### PR TITLE
Feat: change model bookProgress

### DIFF
--- a/api.md
+++ b/api.md
@@ -48,7 +48,7 @@
 #### **Error Response (401 Unauthorized)**
 ```json
 {
-  "error": "Invalid Google authorization code."
+  "message": "Invalid Google authorization code."
 }
 ```
 
@@ -79,7 +79,7 @@ Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.
 #### **Error Response (401 Unauthorized)**
 ```json
 {
-  "error": "Invalid or expired refresh token."
+  "message": "Invalid or expired refresh token."
 }
 ```
 
@@ -102,7 +102,7 @@ Authorization: Bearer {AccessToken}
 #### **Error Response (401 Unauthorized)**
 ```json
 {
-  "error": "Invalid or expired token."
+  "message": "Invalid or expired token."
 }
 ```
 
@@ -130,7 +130,7 @@ Authorization: Bearer {AccessToken}
 #### **Error Response (401 Unauthorized)**
 ```json
 {
-  "error": "Invalid or expired token."
+  "message": "Invalid or expired token."
 }
 ```
 
@@ -217,18 +217,18 @@ GET /api/v1/books?keyword=prince&tags=children&sort_by=view_count
 #### **Error Response (400 Bad Request)**
 ```json
 {
-  "error": "Invalid sort_by parameter. Must be one of: view_count, average_rating, created_at."
+  "message": "Invalid sort_by parameter. Must be one of: view_count, average_rating, created_at."
 }
 ```
 
 #### **Error Response (400 Bad Request) - 잘못된 태그 형식**
 ```json
 {
-  "error": "Invalid tags format. Tags should be comma-separated strings."
+  "message": "Invalid tags format. Tags should be comma-separated strings."
 }
 ```
 
-### `GET /books/{book_id}`
+### `GET /books/{bookId}`
 
 특정 책의 상세 정보를 조회합니다.
 
@@ -236,7 +236,7 @@ GET /api/v1/books?keyword=prince&tags=children&sort_by=view_count
 
 | 파라미터  | 타입     | 설명             |
 | :-------- | :------- | :--------------- |
-| `book_id` | String | 조회할 책의 고유 ID |
+| `bookId` | String | 조회할 책의 고유 ID |
 
 #### **Success Response (200 OK)**
 ```json
@@ -261,7 +261,7 @@ GET /api/v1/books?keyword=prince&tags=children&sort_by=view_count
 #### **Error Response (404 Not Found)**
 ```json
 {
-  "error": "Book not found."
+  "message": "Book not found."
 }
 ```
 
@@ -269,7 +269,7 @@ GET /api/v1/books?keyword=prince&tags=children&sort_by=view_count
 
 ## 📖 챕터 (Chapters)
 
-### `GET /books/{book_id}/chapters`
+### `GET /books/{bookId}/chapters`
 
 특정 책에 포함된 챕터 목록을 페이지네이션으로 조회합니다.
 
@@ -277,7 +277,7 @@ GET /api/v1/books?keyword=prince&tags=children&sort_by=view_count
 
 | 파라미터  | 타입     | 설명             |
 | :-------- | :------- | :--------------- |
-| `book_id` | String | 조회할 책의 고유 ID |
+| `bookId` | String | 조회할 책의 고유 ID |
 
 #### **Query Parameters**
 
@@ -341,11 +341,11 @@ GET /api/v1/books/60d0fe4f5311236168a109ca/chapters?page=1&limit=20
 #### **Error Response (404 Not Found)**
 ```json
 {
-  "error": "Book not found."
+  "message": "Book not found."
 }
 ```
 
-### `GET /books/{book_id}/chapters/{chapter_id}`
+### `GET /books/{bookId}/chapters/{chapterId}`
 
 특정 챕터의 상세 정보를 조회합니다.
 
@@ -353,8 +353,8 @@ GET /api/v1/books/60d0fe4f5311236168a109ca/chapters?page=1&limit=20
 
 | 파라미터     | 타입     | 설명               |
 | :----------- | :------- | :----------------- |
-| `book_id`    | String | 조회할 책의 고유 ID   |
-| `chapter_id` | String | 조회할 챕터의 고유 ID |
+| `bookId`    | String | 조회할 책의 고유 ID   |
+| `chapterId` | String | 조회할 챕터의 고유 ID |
 
 #### **Success Response (200 OK)**
 ```json
@@ -374,14 +374,14 @@ GET /api/v1/books/60d0fe4f5311236168a109ca/chapters?page=1&limit=20
 #### **Error Response (404 Not Found)**
 ```json
 {
-  "error": "Book not found."
+  "message": "Book not found."
 }
 ```
 
 #### **Error Response (404 Not Found)**
 ```json
 {
-  "error": "Chapter not found."
+  "message": "Chapter not found."
 }
 ```
 
@@ -389,7 +389,7 @@ GET /api/v1/books/60d0fe4f5311236168a109ca/chapters?page=1&limit=20
 
 ## 📑 청크 (Chunks)
 
-### `GET /books/{book_id}/chapters/{chapter_id}/chunks`
+### `GET /books/{bookId}/chapters/{chapterId}/chunks`
 
 특정 책의 특정 챕터에 속한 텍스트 청크(Chunk)들을 난이도별로 조회합니다.
 
@@ -397,14 +397,14 @@ GET /api/v1/books/60d0fe4f5311236168a109ca/chapters?page=1&limit=20
 
 | 파라미터     | 타입     | 설명               |
 | :----------- | :------- | :----------------- |
-| `book_id`    | String | 조회할 책의 고유 ID   |
-| `chapter_id` | String | 조회할 챕터의 고유 ID |
+| `bookId`    | String | 조회할 책의 고유 ID   |
+| `chapterId` | String | 조회할 챕터의 고유 ID |
 
 #### **Query Parameters**
 
 | 파라미터     | 타입    | 필수 | 설명                                   |
 | :----------- | :------ | :--- | :------------------------------------- |
-| `difficulty` | String  | 예   | `A1`, `A2`, `B1` 등 청크의 난이도. |
+| `difficulty` | String  | 예   | `a0`, `a1`, `a2`, `b1`, `b2`, `c1`, `c2` 등 청크의 난이도. |
 | `page`       | Integer | 아니요 | 페이지 번호 (기본값: `1`).                 |
 | `limit`      | Integer | 아니요 | 페이지 당 항목 수 (기본값: `10`, 최댓값 `50`).          |
 
@@ -440,11 +440,11 @@ GET /api/v1/books/60d0fe4f5311236168a109ca/chapters?page=1&limit=20
 #### **Error Response (404 Not Found)**
 ```json
 {
-  "error": "Chapter not found."
+  "message": "Chapter not found."
 }
 ```
 
-### `GET /books/{book_id}/chapters/{chapter_id}/chunks/{chunk_id}`
+### `GET /books/{bookId}/chapters/{chapterId}/chunks/{chunkId}`
 
 특정 청크의 상세 정보를 조회합니다.
 
@@ -452,9 +452,9 @@ GET /api/v1/books/60d0fe4f5311236168a109ca/chapters?page=1&limit=20
 
 | 파라미터     | 타입     | 설명               |
 | :----------- | :------- | :----------------- |
-| `book_id`    | String | 조회할 책의 고유 ID   |
-| `chapter_id` | String | 조회할 챕터의 고유 ID |
-| `chunk_id`   | String | 조회할 청크의 고유 ID |
+| `bookId`    | String | 조회할 책의 고유 ID   |
+| `chapterId` | String | 조회할 챕터의 고유 ID |
+| `chunkId`   | String | 조회할 청크의 고유 ID |
 
 #### **Success Response (200 OK) - 텍스트 청크**
 ```json
@@ -483,21 +483,21 @@ GET /api/v1/books/60d0fe4f5311236168a109ca/chapters?page=1&limit=20
 #### **Error Response (404 Not Found)**
 ```json
 {
-  "error": "Book not found."
+  "message": "Book not found."
 }
 ```
 
 #### **Error Response (404 Not Found)**
 ```json
 {
-  "error": "Chapter not found."
+  "message": "Chapter not found."
 }
 ```
 
 #### **Error Response (404 Not Found)**
 ```json
 {
-  "error": "Chunk not found."
+  "message": "Chunk not found."
 }
 ```
 
@@ -505,7 +505,7 @@ GET /api/v1/books/60d0fe4f5311236168a109ca/chapters?page=1&limit=20
 
 ## 📈 읽기 진도 (Reading Progress)
 
-### `PUT /books/{book_id}/progress`
+### `PUT /books/{bookId}/progress`
 
 사용자의 읽기 진도를 업데이트합니다. 특정 챕터의 특정 청크까지 읽었음을 기록합니다.
 
@@ -518,7 +518,7 @@ Authorization: Bearer {AccessToken}
 
 | 파라미터  | 타입     | 설명             |
 | :-------- | :------- | :--------------- |
-| `book_id` | String | 읽고 있는 책의 고유 ID |
+| `bookId` | String | 읽고 있는 책의 고유 ID |
 
 #### **Request Body**
 
@@ -545,25 +545,25 @@ Authorization: Bearer {AccessToken}
 #### **Error Response (404 Not Found)**
 ```json
 {
-  "error": "Book not found."
+  "message": "Book not found."
 }
 ```
 
 #### **Error Response (404 Not Found)**
 ```json
 {
-  "error": "Chapter not found in this book."
+  "message": "Chapter not found in this book."
 }
 ```
 
 #### **Error Response (400 Bad Request)**
 ```json
 {
-  "error": "Invalid chunkNumber. Must be a positive integer."
+  "message": "Invalid chunkId. Must be a valid chunk identifier."
 }
 ```
 
-### `GET /books/{book_id}/progress`
+### `GET /books/{bookId}/progress`
 
 사용자의 특정 책에 대한 읽기 진도를 조회합니다.
 
@@ -576,7 +576,7 @@ Authorization: Bearer {AccessToken}
 
 | 파라미터  | 타입     | 설명             |
 | :-------- | :------- | :--------------- |
-| `book_id` | String | 조회할 책의 고유 ID |
+| `bookId` | String | 조회할 책의 고유 ID |
 
 #### **Success Response (200 OK)**
 ```json
@@ -594,7 +594,7 @@ Authorization: Bearer {AccessToken}
 #### **Error Response (404 Not Found)**
 ```json
 {
-  "error": "Book not found."
+  "message": "Book not found."
 }
 ```
 
@@ -625,7 +625,7 @@ Authorization: Bearer {AccessToken}
       "chapterId": "60d0fe4f5311236168a109cb",
       "chunkId": "60d0fe4f53112389248a182db",
       "currentReadChapterNumber": 1,
-      "progressChapterPercentage": 15.5,
+      "progressPercentage": 15.5,
       "updatedAt": "2024-01-15T10:30:00"
     }
   ],

--- a/src/main/java/com/linglevel/api/books/controller/BooksController.java
+++ b/src/main/java/com/linglevel/api/books/controller/BooksController.java
@@ -45,10 +45,10 @@ public class BooksController {
             @ApiResponse(responseCode = "404", description = "책을 찾을 수 없음",
                     content = @Content(schema = @Schema(implementation = ExceptionResponseDTO.class)))
     })
-    @GetMapping("/{book_id}")
+    @GetMapping("/{bookId}")
     public ResponseEntity<BookResponse> getBook(
             @Parameter(description = "책 ID", example = "60d0fe4f5311236168a109ca")
-            @PathVariable String book_id) {
+            @PathVariable String bookId) {
         // TODO: 단일 책 조회 로직 구현
          throw new UnsupportedOperationException("Not implemented yet");
     }
@@ -59,10 +59,10 @@ public class BooksController {
             @ApiResponse(responseCode = "404", description = "책을 찾을 수 없음",
                     content = @Content(schema = @Schema(implementation = ExceptionResponseDTO.class)))
     })
-    @GetMapping("/{book_id}/chapters")
+    @GetMapping("/{bookId}/chapters")
     public ResponseEntity<PageResponseDTO<ChapterResponse>> getChapters(
             @Parameter(description = "책 ID", example = "60d0fe4f5311236168a109ca")
-            @PathVariable String book_id,
+            @PathVariable String bookId,
             @ParameterObject @ModelAttribute GetChaptersRequest request) {
         // TODO: 챕터 목록 조회 로직 구현
         throw new UnsupportedOperationException("Not implemented yet");
@@ -74,12 +74,12 @@ public class BooksController {
             @ApiResponse(responseCode = "404", description = "책 또는 챕터를 찾을 수 없음",
                     content = @Content(schema = @Schema(implementation = ExceptionResponseDTO.class)))
     })
-    @GetMapping("/{book_id}/chapters/{chapter_id}")
+    @GetMapping("/{bookId}/chapters/{chapterId}")
     public ResponseEntity<ChapterResponse> getChapter(
             @Parameter(description = "책 ID", example = "60d0fe4f5311236168a109ca")
-            @PathVariable String book_id,
+            @PathVariable String bookId,
             @Parameter(description = "챕터 ID", example = "60d0fe4f5311236168a109cb")
-            @PathVariable String chapter_id) {
+            @PathVariable String chapterId) {
         // TODO: 단일 챕터 조회 로직 구현
         throw new UnsupportedOperationException("Not implemented yet");
     }
@@ -92,12 +92,12 @@ public class BooksController {
             @ApiResponse(responseCode = "400", description = "잘못된 난이도 레벨",
                     content = @Content(schema = @Schema(implementation = ExceptionResponseDTO.class)))
     })
-    @GetMapping("/{book_id}/chapters/{chapter_id}/chunks")
+    @GetMapping("/{bookId}/chapters/{chapterId}/chunks")
     public ResponseEntity<PageResponseDTO<ChunkResponse>> getChunks(
             @Parameter(description = "책 ID", example = "60d0fe4f5311236168a109ca")
-            @PathVariable String book_id,
+            @PathVariable String bookId,
             @Parameter(description = "챕터 ID", example = "60d0fe4f5311236168a109cb")
-            @PathVariable String chapter_id,
+            @PathVariable String chapterId,
             @ParameterObject @ModelAttribute GetChunksRequest request) {
         // TODO: 청크 목록 조회 로직 구현
         throw new UnsupportedOperationException("Not implemented yet");
@@ -109,14 +109,14 @@ public class BooksController {
             @ApiResponse(responseCode = "404", description = "책, 챕터 또는 청크를 찾을 수 없음",
                     content = @Content(schema = @Schema(implementation = ExceptionResponseDTO.class)))
     })
-    @GetMapping("/{book_id}/chapters/{chapter_id}/chunks/{chunk_id}")
+    @GetMapping("/{bookId}/chapters/{chapterId}/chunks/{chunkId}")
     public ResponseEntity<ChunkResponse> getChunk(
             @Parameter(description = "책 ID", example = "60d0fe4f5311236168a109ca")
-            @PathVariable String book_id,
+            @PathVariable String bookId,
             @Parameter(description = "챕터 ID", example = "60d0fe4f5311236168a109cb")
-            @PathVariable String chapter_id,
+            @PathVariable String chapterId,
             @Parameter(description = "청크 ID", example = "60d0fe4f5311236168a109cd")
-            @PathVariable String chunk_id) {
+            @PathVariable String chunkId) {
         // TODO: 단일 청크 조회 로직 구현
         throw new UnsupportedOperationException("Not implemented yet");
     }
@@ -129,10 +129,10 @@ public class BooksController {
             @ApiResponse(responseCode = "400", description = "잘못된 청크 번호",
                     content = @Content(schema = @Schema(implementation = ExceptionResponseDTO.class)))
     })
-    @PutMapping("/{book_id}/progress")
+    @PutMapping("/{bookId}/progress")
     public ResponseEntity<ProgressResponse> updateProgress(
             @Parameter(description = "책 ID", example = "60d0fe4f5311236168a109ca")
-            @PathVariable String book_id,
+            @PathVariable String bookId,
             @RequestBody ProgressUpdateRequest request) {
         // TODO: 읽기 진도 업데이트 로직 구현
         throw new UnsupportedOperationException("Not implemented yet");
@@ -144,10 +144,10 @@ public class BooksController {
             @ApiResponse(responseCode = "404", description = "책을 찾을 수 없음",
                     content = @Content(schema = @Schema(implementation = ExceptionResponseDTO.class)))
     })
-    @GetMapping("/{book_id}/progress")
+    @GetMapping("/{bookId}/progress")
     public ResponseEntity<ProgressResponse> getProgress(
             @Parameter(description = "책 ID", example = "60d0fe4f5311236168a109ca")
-            @PathVariable String book_id) {
+            @PathVariable String bookId) {
         // TODO: 읽기 진도 조회 로직 구현
         throw new UnsupportedOperationException("Not implemented yet");
     }

--- a/src/main/java/com/linglevel/api/books/dto/ProgressResponse.java
+++ b/src/main/java/com/linglevel/api/books/dto/ProgressResponse.java
@@ -23,8 +23,11 @@ public class ProgressResponse {
     @Schema(description = "챕터 ID", example = "60d0fe4f5311236168a109cb")
     private String chapterId;
     
-    @Schema(description = "총 청크 수", example = "30")
-    private Integer totalChunks;
+    @Schema(description = "청크 ID", example = "60d0fe4f53112389248a182db")
+    private String chunkId;
+    
+    @Schema(description = "현재 읽은 챕터 번호", example = "1")
+    private Integer currentReadChapterNumber;
     
     @Schema(description = "현재 읽은 청크 번호", example = "5")
     private Integer currentReadChunkNumber;

--- a/src/main/java/com/linglevel/api/books/dto/ProgressUpdateRequest.java
+++ b/src/main/java/com/linglevel/api/books/dto/ProgressUpdateRequest.java
@@ -15,6 +15,6 @@ public class ProgressUpdateRequest {
     @Schema(description = "챕터 ID", example = "60d0fe4f5311236168a109cb")
     private String chapterId;
     
-    @Schema(description = "읽은 청크 번호", example = "5")
-    private Integer chunkNumber;
+    @Schema(description = "청크 ID", example = "60d0fe4f5311236168c172db")
+    private String chunkId;
 } 

--- a/src/main/java/com/linglevel/api/users/controller/UsersController.java
+++ b/src/main/java/com/linglevel/api/users/controller/UsersController.java
@@ -4,7 +4,6 @@ import com.linglevel.api.common.dto.ExceptionResponseDTO;
 import com.linglevel.api.common.dto.PageResponseDTO;
 import com.linglevel.api.users.dto.GetMyBooksProgressRequest;
 import com.linglevel.api.users.dto.UserBooksProgressResponse;
-import com.linglevel.api.users.exception.UsersErrorCode;
 import com.linglevel.api.users.exception.UsersException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;

--- a/src/main/java/com/linglevel/api/users/dto/UserBooksProgressResponse.java
+++ b/src/main/java/com/linglevel/api/users/dto/UserBooksProgressResponse.java
@@ -23,13 +23,13 @@ public class UserBooksProgressResponse {
     @Schema(description = "챕터 ID", example = "60d0fe4f5311236168a109cb")
     private String chapterId;
     
+    @Schema(description = "청크 ID", example = "60d0fe4f53112389248a182db")
+    private String chunkId;
+    
     @Schema(description = "현재 읽은 챕터 번호", example = "1")
     private Integer currentReadChapterNumber;
     
-    @Schema(description = "현재 읽은 청크 번호", example = "5")
-    private Integer currentReadChunkNumber;
-    
-    @Schema(description = "진행률", example = "15.5")
+    @Schema(description = "챕터 진행률", example = "15.5")
     private Double progressPercentage;
     
     @Schema(description = "업데이트 일시", example = "2024-01-15T10:30:00")


### PR DESCRIPTION
## 요약

`book`을 읽는 진행 정보를 저장하는 필드를 실제 식별자 `id`와 순서를 나타내는 `number` 두가지 기준 모두로 저장하도록 변경하고, API를 수정했습니다.

## 관련 이슈

closes #13 

## 체크리스트

이 PR을 제출하기 전에 다음을 확인해주세요

- [ x ] 코드가 스타일 가이드를 따름
- [ x ] 자체 검토 완료
- [ x ] 테스트 통과
- [ x ] 문서 업데이트
- [ x ] 민감한 데이터 포함 안함