### PR TITLE
Feat: calculate reading time

### DIFF
--- a/src/main/java/com/linglevel/api/books/repository/ChapterRepository.java
+++ b/src/main/java/com/linglevel/api/books/repository/ChapterRepository.java
@@ -5,10 +5,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChapterRepository extends MongoRepository<Chapter, String> {
     Page<Chapter> findByBookId(String chapterId, Pageable pageable);
+    
+    List<Chapter> findByBookIdOrderByChapterNumber(String bookId);
     
     Optional<Chapter> findFirstByBookIdOrderByChapterNumberAsc(String chapterId);
 


### PR DESCRIPTION
## 요약

읽기시간을 계산하는 기능을 추가했습니다.

## 관련 이슈

Closes #23 

## 구현

평균 분당 500글자를 읽는다는 가정하에 글자수를 기준으로 계산했습니다.

## 성능

자주 호출되는 API는 아니지만 stream이 3중 반복문을 돌게 됩니다. 성능상 추후 최적화가 필요할 수 있습니다.

## 체크리스트

이 PR을 제출하기 전에 다음을 확인해주세요

- [x] 코드가 스타일 가이드를 따름
- [x] 자체 검토 완료
- [x] 테스트 통과
- [x] 문서 업데이트
- [x] 민감한 데이터 포함 안함