### PR TITLE
Fix: no require email on suggestion form

### DIFF
--- a/src/main/java/com/linglevel/api/suggestions/dto/SuggestionRequest.java
+++ b/src/main/java/com/linglevel/api/suggestions/dto/SuggestionRequest.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class SuggestionRequest {
-    @Schema(description = "건의자 이메일", example = "user@example.com", required = true)
+    @Schema(description = "건의자 이메일", example = "user@example.com")
     private String email;
 
     @Schema(description = "건의 태그 (쉼표로 구분)", example = "bug,ui,feature")


### PR DESCRIPTION
건의사항 제공시 `email`은 필수사항에서 제외해야합니다.