### PR TITLE
Fix: no require email on suggestion form

### DIFF
--- a/src/main/java/com/linglevel/api/suggestions/dto/SuggestionRequest.java
+++ b/src/main/java/com/linglevel/api/suggestions/dto/SuggestionRequest.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class SuggestionRequest {
-    @Schema(description = "건의자 이메일", example = "user@example.com", required = true)
+    @Schema(description = "건의자 이메일", example = "user@example.com")
     private String email;
 
     @Schema(description = "건의 태그 (쉼표로 구분)", example = "bug,ui,feature")


### PR DESCRIPTION
# 요약
`SuggestionRequest` 클래스에 `email`과 `tags`를 작성하지 않는 경우 기본값을 사용하도록 제공합니다.

# 참조
#25 