### PR TITLE
Fix: remove sentry code context

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,14 +5,6 @@ plugins {
 	id "io.sentry.jvm.gradle" version "5.10.0"
 }
 
-sentry {
-	includeSourceContext = true
-
-	org = "asap-cl"
-	projectName = "java-spring-boot"
-	authToken = System.getenv("SENTRY_AUTH_TOKEN")
-}
-
 springBoot {
 	buildInfo()
 }


### PR DESCRIPTION
# 원인
- sentry는 디버깅을 위한 code context를 build 타임에 서버측에 제공합니다.
- build 타임에 sentry 인증과 관련된 키가 없어 빌드에 실패합니다.

# 해결
- code context 기능을 사용하지 않도록 조치했습니다.

closes #103 