### PR TITLE
Feat: implement TestContainers with AbstractDatabaseTest for MongoDB

### DIFF
--- a/.github/workflows/pr-run-test.yml
+++ b/.github/workflows/pr-run-test.yml
@@ -19,5 +19,8 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
+      - name: Setup Docker for TestContainers
+        uses: docker/setup-buildx-action@v2
+
       - name: Run tests
         run: ./gradlew test

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.testcontainers:mongodb:1.21.3'
+	testImplementation 'org.testcontainers:junit-jupiter:1.21.3'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/test/java/com/linglevel/api/ApiApplicationTests.java
+++ b/src/test/java/com/linglevel/api/ApiApplicationTests.java
@@ -1,10 +1,11 @@
 package com.linglevel.api;
 
+import com.linglevel.api.common.AbstractDatabaseTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class ApiApplicationTests {
+class ApiApplicationTests extends AbstractDatabaseTest {
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/com/linglevel/api/common/AbstractDatabaseTest.java
+++ b/src/test/java/com/linglevel/api/common/AbstractDatabaseTest.java
@@ -1,0 +1,39 @@
+package com.linglevel.api.common;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+
+/**
+ * 데이터베이스 TestContainers를 사용하는 테스트의 추상 클래스
+ *
+ * 모든 테스트가 하나의 MongoDB 컨테이너를 공유하여 안정성과 성능을 보장합니다.
+ *
+ * 사용법:
+ * @DataMongoTest
+ * class MyRepositoryTest extends AbstractDatabaseTest {
+ *     // TestContainers 설정 불필요, 상속받음
+ * }
+ */
+public abstract class AbstractDatabaseTest {
+
+    private static MongoDBContainer mongoContainer;
+
+    static {
+        mongoContainer = new MongoDBContainer("mongo:6.0").withReuse(true);
+        mongoContainer.start();
+    }
+
+    @DynamicPropertySource
+    static void configureDatabaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", mongoContainer::getReplicaSetUrl);
+
+        // 추가 데이터베이스 설정이 필요한 경우 여기서 일괄 관리
+        // registry.add("spring.data.mongodb.database", () -> "test-db");
+    }
+
+    // 컨테이너 정리를 위한 메서드 (필요 시)
+    public static MongoDBContainer getMongoContainer() {
+        return mongoContainer;
+    }
+}

--- a/src/test/java/com/linglevel/api/user/ticket/repository/TicketTransactionRepositoryTest.java
+++ b/src/test/java/com/linglevel/api/user/ticket/repository/TicketTransactionRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.linglevel.api.user.ticket.repository;
 
+import com.linglevel.api.common.AbstractDatabaseTest;
 import com.linglevel.api.user.ticket.entity.TicketTransaction;
 import com.linglevel.api.user.ticket.entity.TransactionStatus;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,7 +18,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.*;
 
 @DataMongoTest
-class TicketTransactionRepositoryTest {
+class TicketTransactionRepositoryTest extends AbstractDatabaseTest {
 
     @Autowired
     private TicketTransactionRepository ticketTransactionRepository;

--- a/src/test/java/com/linglevel/api/user/ticket/repository/UserTicketRepositoryTest.java
+++ b/src/test/java/com/linglevel/api/user/ticket/repository/UserTicketRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.linglevel.api.user.ticket.repository;
 
+import com.linglevel.api.common.AbstractDatabaseTest;
 import com.linglevel.api.user.ticket.entity.UserTicket;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DataMongoTest
-class UserTicketRepositoryTest {
+class UserTicketRepositoryTest extends AbstractDatabaseTest {
 
     @Autowired
     private UserTicketRepository userTicketRepository;


### PR DESCRIPTION
## Summary
MongoDB 의존성을 testcontainers 라이브러리를 통해 테스트 컨테이너를 올려 동작하도록 수정했습니다.

## Related Issues
#151 