### PR TITLE
Feat: increase pagination limit from 100 to 200 and unify validation

### DIFF
--- a/api.md
+++ b/api.md
@@ -144,7 +144,7 @@ Authorization: Bearer {AccessToken}
 | `tags`    | String  | 아니요                       | 검색할 태그들 (쉼표로 구분, 예: "philosophy,children"). 제공 시 해당 태그가 포함된 책만 조회. |
 | `keyword` | String  | 아니요                       | 검색할 책 제목 또는 작가 이름 (부분 일치 검색). 제공 시 키워드가 포함된 책만 조회. |
 | `page`    | Integer | 아니요 (기본값: `1`)           | 조회할 페이지 번호.                                                |
-| `limit`   | Integer | 아니요 (기본값: `10`, 최댓값: `100`)          | 페이지 당 항목 수.                                                 |
+| `limit`   | Integer | 아니요 (기본값: `10`, 최댓값: `200`)          | 페이지 당 항목 수.                                                 |
 
 #### **Success Response (200 OK)**
 ```json
@@ -341,7 +341,7 @@ X-API-Key: {TempApiKey}
 | 파라미터 | 타입    | 필수 | 설명                      |
 | :------- | :------ | :--- | :------------------------ |
 | `page`   | Integer | 아니요 (기본값: `1`)          | 조회할 페이지 번호                |
-| `limit`  | Integer | 아니요 (기본값: `10`, 최댓값: `100`) | 페이지 당 항목 수                |
+| `limit`  | Integer | 아니요 (기본값: `10`, 최댓값: `200`) | 페이지 당 항목 수                |
 
 #### **Success Response (200 OK)**
 ```json
@@ -669,7 +669,7 @@ Authorization: Bearer {AccessToken}
 | 파라미터 | 타입    | 필수 | 설명                      |
 | :------- | :------ | :--- | :------------------------ |
 | `page`   | Integer | 아니요 (기본값: `1`) | 조회할 페이지 번호 |
-| `limit`  | Integer | 아니요 (기본값: `10`, 최댓값: `100`) | 페이지 당 항목 수 |
+| `limit`  | Integer | 아니요 (기본값: `10`, 최댓값: `200`) | 페이지 당 항목 수 |
 
 #### **Success Response (200 OK)**
 ```json
@@ -775,7 +775,7 @@ Authorization: Bearer {AccessToken}
 | 파라미터 | 타입    | 필수 | 설명                      |
 | :------- | :------ | :--- | :------------------------ |
 | `page`   | Integer | 아니요 (기본값: `1`)          | 조회할 페이지 번호                |
-| `limit`  | Integer | 아니요 (기본값: `10`, 최댓값: `100`) | 페이지 당 항목 수                |
+| `limit`  | Integer | 아니요 (기본값: `10`, 최댓값: `200`) | 페이지 당 항목 수                |
 | `search` | String  | 아니요                       | 검색할 단어 (부분 일치 검색)         |
 
 #### **Success Response (200 OK)**
@@ -875,7 +875,7 @@ Authorization: Bearer {AccessToken}
 | 파라미터 | 타입    | 필수 | 설명                      |
 | :------- | :------ | :--- | :------------------------ |
 | `page`   | Integer | 아니요 (기본값: `1`)          | 조회할 페이지 번호                |
-| `limit`  | Integer | 아니요 (기본값: `10`, 최댓값: `100`) | 페이지 당 항목 수                |
+| `limit`  | Integer | 아니요 (기본값: `10`, 최댓값: `200`) | 페이지 당 항목 수                |
 | `search` | String  | 아니요                       | 검색할 단어 (부분 일치 검색)         |
 
 #### **Success Response (200 OK)**
@@ -1045,7 +1045,7 @@ Authorization: Bearer {AccessToken}
 | `tags`    | String  | 아니요                       | 검색할 태그들 (쉼표로 구분, 예: "technology,business"). 제공 시 해당 태그가 포함된 기사만 조회.   |
 | `keyword` | String  | 아니요                       | 검색할 기사 제목 또는 작가 이름 (부분 일치 검색). 제공 시 키워드가 포함된 기사만 조회.                  |
 | `page`    | Integer | 아니요 (기본값: `1`)           | 조회할 페이지 번호.                                                           |
-| `limit`   | Integer | 아니요 (기본값: `10`, 최댓값: `100`)          | 페이지 당 항목 수.                                                           |
+| `limit`   | Integer | 아니요 (기본값: `10`, 최댓값: `200`)          | 페이지 당 항목 수.                                                           |
 
 #### **Success Response (200 OK)**
 ```json
@@ -1213,7 +1213,7 @@ X-API-Key: {TempApiKey}
 | :----------- | :------ | :--- | :------------------------------------- |
 | `difficulty` | String  | 예   | `a0`, `a1`, `a2`, `b1`, `b2`, `c1`, `c2` 등 청크의 난이도. |
 | `page`       | Integer | 아니요 | 페이지 번호 (기본값: `1`).                 |
-| `limit`      | Integer | 아니요 | 페이지 당 항목 수 (기본값: `10`, 최댓값 `100`).          |
+| `limit`      | Integer | 아니요 | 페이지 당 항목 수 (기본값: `10`, 최댓값 `200`).          |
 
 #### **Success Response (200 OK)**
 ```json
@@ -1809,7 +1809,7 @@ Authorization: Bearer {AccessToken}
 | :-------- | :------ | :--- | :--------------------------------------------------- |
 | `status`  | String  | 아니요 | `PENDING`, `PROCESSING`, `COMPLETED`, `FAILED` 상태별 필터링 |
 | `page`    | Integer | 아니요 (기본값: `1`) | 조회할 페이지 번호 |
-| `limit`   | Integer | 아니요 (기본값: `10`, 최댓값: `100`) | 페이지 당 항목 수 |
+| `limit`   | Integer | 아니요 (기본값: `10`, 최댓값: `200`) | 페이지 당 항목 수 |
 
 #### **Success Response (200 OK)**
 ```json
@@ -1929,7 +1929,7 @@ Authorization: Bearer {AccessToken}
 | `tags`    | String  | 아니요                       | 검색할 태그들 (쉼표로 구분, 예: \"technology,beginner\"). 제공 시 해당 태그가 포함된 콘텐츠만 조회 |
 | `keyword` | String  | 아니요                       | 검색할 콘텐츠 제목 또는 작가 이름 (부분 일치 검색) |
 | `page`    | Integer | 아니요 (기본값: `1`)           | 조회할 페이지 번호 |
-| `limit`   | Integer | 아니요 (기본값: `10`, 최댓값: `100`)          | 페이지 당 항목 수 |
+| `limit`   | Integer | 아니요 (기본값: `10`, 최댓값: `200`)          | 페이지 당 항목 수 |
 
 #### **Success Response (200 OK)**
 ```json
@@ -2119,7 +2119,7 @@ Authorization: Bearer {AccessToken}
 | :----------- | :------ | :--- |:-------------------------------------------------------|
 | `difficulty` | String  | 예   | `a0`, `a1`, `a2`, `b1`, `b2`, `c1`, `c2` 등 청크의 난이도 |
 | `page`       | Integer | 아니요 | 페이지 번호 (기본값: `1`) |
-| `limit`      | Integer | 아니요 | 페이지 당 항목 수 (기본값: `10`, 최댓값 `100`) |
+| `limit`      | Integer | 아니요 | 페이지 당 항목 수 (기본값: `10`, 최댓값 `200`) |
 
 #### **Success Response (200 OK)**
 ```json
@@ -2466,7 +2466,7 @@ Authorization: Bearer {AccessToken}
 | 파라미터 | 타입    | 필수 | 설명                      |
 | :------- | :------ | :--- | :------------------------ |
 | `page`   | Integer | 아니요 (기본값: `1`) | 조회할 페이지 번호 |
-| `limit`  | Integer | 아니요 (기본값: `10`, 최댓값: `100`) | 페이지 당 항목 수 |
+| `limit`  | Integer | 아니요 (기본값: `10`, 최댓값: `200`) | 페이지 당 항목 수 |
 
 #### **Success Response (200 OK)**
 ```json
@@ -2655,7 +2655,7 @@ POST /api/v1/custom-contents/requests
 | 파라미터 | 타입    | 필수 | 설명                      |
 | :------- | :------ | :--- | :------------------------ |
 | `page`   | Integer | 아니요 (기본값: `1`)          | 조회할 페이지 번호                |
-| `limit`  | Integer | 아니요 (기본값: `10`, 최댓값: `100`) | 페이지 당 항목 수                |
+| `limit`  | Integer | 아니요 (기본값: `10`, 최댓값: `200`) | 페이지 당 항목 수                |
 
 #### **Success Response (200 OK)**
 ```json
@@ -3065,7 +3065,7 @@ X-API-Key: {TempApiKey}
 | :----------- | :------ | :--- | :----------------------------- |
 | `countryCode` | String | 아니요 | 국가 코드로 필터링 (`KR`, `US`, `JP` 등) |
 | `page`        | Integer | 아니요 (기본값: `1`) | 조회할 페이지 번호 |
-| `limit`       | Integer | 아니요 (기본값: `10`, 최댓값: `100`) | 페이지 당 항목 수 |
+| `limit`       | Integer | 아니요 (기본값: `10`, 최댓값: `200`) | 페이지 당 항목 수 |
 
 #### **Success Response (200 OK)**
 

--- a/src/main/java/com/linglevel/api/bookmark/controller/BookmarksController.java
+++ b/src/main/java/com/linglevel/api/bookmark/controller/BookmarksController.java
@@ -23,6 +23,7 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/v1/bookmarks")
@@ -42,7 +43,7 @@ public class BookmarksController {
     })
     @GetMapping("/words")
     public ResponseEntity<PageResponse<BookmarkedWordResponse>> getBookmarkedWords(
-            @ParameterObject @ModelAttribute GetBookmarkedWordsRequest request,
+            @ParameterObject @Valid @ModelAttribute GetBookmarkedWordsRequest request,
             Authentication authentication) {
         String username = authentication.getName();
         User user = userRepository.findByUsername(username).orElseThrow();

--- a/src/main/java/com/linglevel/api/bookmark/dto/GetBookmarkedWordsRequest.java
+++ b/src/main/java/com/linglevel/api/bookmark/dto/GetBookmarkedWordsRequest.java
@@ -1,6 +1,8 @@
 package com.linglevel.api.bookmark.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,14 +19,17 @@ public class GetBookmarkedWordsRequest {
             example = "1",
             minimum = "1",
             defaultValue = "1")
+    @Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.")
     @Builder.Default
     private Integer page = 1;
     
     @Schema(description = "페이지 크기",
             example = "10",
             minimum = "1",
-            maximum = "100",
+            maximum = "200",
             defaultValue = "10")
+    @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.")
+    @Max(value = 200, message = "페이지 크기는 200 이하여야 합니다.")
     @Builder.Default
     private Integer limit = 10;
     

--- a/src/main/java/com/linglevel/api/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/linglevel/api/bookmark/service/BookmarkService.java
@@ -33,7 +33,6 @@ public class BookmarkService {
     private final WordService wordService;
 
     public Page<BookmarkedWordResponse> getBookmarkedWords(String userId, int page, int limit, String search) {
-        limit = Math.min(limit, 100);
         Pageable pageable = PageRequest.of(page - 1, limit, Sort.by(Sort.Direction.DESC, "bookmarkedAt"));
         
         if (search != null && !search.trim().isEmpty()) {

--- a/src/main/java/com/linglevel/api/content/article/controller/ArticleController.java
+++ b/src/main/java/com/linglevel/api/content/article/controller/ArticleController.java
@@ -23,6 +23,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/v1/articles")
@@ -76,7 +77,7 @@ public class ArticleController {
     public ResponseEntity<PageResponse<ArticleChunkResponse>> getArticleChunks(
             @Parameter(description = "기사 ID", example = "60d0fe4f5311236168a109ca")
             @PathVariable String articleId,
-            @ParameterObject @ModelAttribute GetArticleChunksRequest request) {
+            @ParameterObject @Valid @ModelAttribute GetArticleChunksRequest request) {
         
         PageResponse<ArticleChunkResponse> response = articleChunkService.getArticleChunks(articleId, request);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/linglevel/api/content/article/dto/GetArticleChunksRequest.java
+++ b/src/main/java/com/linglevel/api/content/article/dto/GetArticleChunksRequest.java
@@ -3,6 +3,8 @@ package com.linglevel.api.content.article.dto;
 import com.linglevel.api.content.common.DifficultyLevel;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -23,14 +25,17 @@ public class GetArticleChunksRequest {
             example = "1",
             minimum = "1",
             defaultValue = "1")
+    @Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.")
     @Builder.Default
     private Integer page = 1;
 
     @Schema(description = "페이지 크기",
             example = "10",
             minimum = "1",
-            maximum = "100",
+            maximum = "200",
             defaultValue = "10")
+    @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.")
+    @Max(value = 200, message = "페이진 크기는 200 이하여야 합니다.")
     @Builder.Default
     private Integer limit = 10;
 }

--- a/src/main/java/com/linglevel/api/content/book/controller/BooksController.java
+++ b/src/main/java/com/linglevel/api/content/book/controller/BooksController.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
 
 
 
@@ -47,7 +48,7 @@ public class BooksController {
     })
     @GetMapping
     public ResponseEntity<PageResponse<BookResponse>> getBooks(
-            @ParameterObject @ModelAttribute GetBooksRequest request) {
+            @ParameterObject @Valid @ModelAttribute GetBooksRequest request) {
         PageResponse<BookResponse> response = bookService.getBooks(request);
         return ResponseEntity.ok(response);
     }
@@ -76,7 +77,7 @@ public class BooksController {
     public ResponseEntity<PageResponse<ChapterResponse>> getChapters(
             @Parameter(description = "책 ID", example = "60d0fe4f5311236168a109ca")
             @PathVariable String bookId,
-            @ParameterObject @ModelAttribute GetChaptersRequest request) {
+            @ParameterObject @Valid @ModelAttribute GetChaptersRequest request) {
         PageResponse<ChapterResponse> response = chapterService.getChapters(bookId, request);
         return ResponseEntity.ok(response);
     }
@@ -111,7 +112,7 @@ public class BooksController {
             @PathVariable String bookId,
             @Parameter(description = "챕터 ID", example = "60d0fe4f5311236168a109cb")
             @PathVariable String chapterId,
-            @ParameterObject @ModelAttribute GetChunksRequest request) {
+            @ParameterObject @Valid @ModelAttribute GetChunksRequest request) {
         PageResponse<ChunkResponse> response = chunkService.getChunks(bookId, chapterId, request);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/linglevel/api/content/book/controller/BooksProgressController.java
+++ b/src/main/java/com/linglevel/api/content/book/controller/BooksProgressController.java
@@ -20,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/v1/books")
@@ -69,7 +70,7 @@ public class BooksProgressController {
     })
     @GetMapping("/progress")
     public ResponseEntity<PageResponse<BooksProgressResponse>> getAllProgress(
-            @ParameterObject @ModelAttribute GetBooksProgressRequest request) {
+            @ParameterObject @Valid @ModelAttribute GetBooksProgressRequest request) {
         // PageResponse<BooksProgressResponse> response = progressService.getAllProgress(request);
         // TODO: 추후 구현
         throw new UnsupportedOperationException("Not implemented yet");

--- a/src/main/java/com/linglevel/api/content/book/dto/GetBooksProgressRequest.java
+++ b/src/main/java/com/linglevel/api/content/book/dto/GetBooksProgressRequest.java
@@ -1,6 +1,8 @@
 package com.linglevel.api.content.book.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,14 +19,17 @@ public class GetBooksProgressRequest {
             example = "1",
             minimum = "1",
             defaultValue = "1")
+    @Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.")
     @Builder.Default
     private Integer page = 1;
     
     @Schema(description = "페이지 크기",
             example = "10",
             minimum = "1",
-            maximum = "100",
+            maximum = "200",
             defaultValue = "10")
+    @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.")
+    @Max(value = 200, message = "페이지 크기는 200 이하여야 합니다.")
     @Builder.Default
     private Integer limit = 10;
 } 

--- a/src/main/java/com/linglevel/api/content/book/dto/GetBooksRequest.java
+++ b/src/main/java/com/linglevel/api/content/book/dto/GetBooksRequest.java
@@ -1,6 +1,8 @@
 package com.linglevel.api.content.book.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -32,14 +34,17 @@ public class GetBooksRequest {
             example = "1",
             minimum = "1",
             defaultValue = "1")
+    @Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.")
     @Builder.Default
     private Integer page = 1;
     
     @Schema(description = "페이지 크기",
             example = "10",
             minimum = "1",
-            maximum = "100",
+            maximum = "200",
             defaultValue = "10")
+    @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.")
+    @Max(value = 200, message = "페이지 크기는 200 이하여야 합니다.")
     @Builder.Default
     private Integer limit = 10;
 } 

--- a/src/main/java/com/linglevel/api/content/book/dto/GetChaptersRequest.java
+++ b/src/main/java/com/linglevel/api/content/book/dto/GetChaptersRequest.java
@@ -1,6 +1,8 @@
 package com.linglevel.api.content.book.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,14 +19,17 @@ public class GetChaptersRequest {
             example = "1",
             minimum = "1",
             defaultValue = "1")
+    @Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.")
     @Builder.Default
     private Integer page = 1;
     
     @Schema(description = "페이지 크기",
             example = "10",
             minimum = "1",
-            maximum = "100",
+            maximum = "200",
             defaultValue = "10")
+    @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.")
+    @Max(value = 200, message = "페이지 크기는 200 이하여야 합니다.")
     @Builder.Default
     private Integer limit = 10;
 } 

--- a/src/main/java/com/linglevel/api/content/book/service/BookService.java
+++ b/src/main/java/com/linglevel/api/content/book/service/BookService.java
@@ -111,8 +111,8 @@ public class BookService {
         Sort sort = createSort(request.getSortBy());
 
         Pageable pageable = PageRequest.of(
-            request.getPage() - 1, 
-            Math.min(request.getLimit(), 100),
+            request.getPage() - 1,
+            request.getLimit(),
             sort
         );
 

--- a/src/main/java/com/linglevel/api/content/book/service/ChapterService.java
+++ b/src/main/java/com/linglevel/api/content/book/service/ChapterService.java
@@ -32,8 +32,8 @@ public class ChapterService {
         }
 
         Pageable pageable = PageRequest.of(
-            request.getPage() - 1, 
-            Math.min(request.getLimit(), 100),
+            request.getPage() - 1,
+            request.getLimit(),
             Sort.by("chapterNumber").ascending()
         );
 

--- a/src/main/java/com/linglevel/api/content/custom/service/CustomContentRequestService.java
+++ b/src/main/java/com/linglevel/api/content/custom/service/CustomContentRequestService.java
@@ -137,10 +137,9 @@ public class CustomContentRequestService {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new CustomContentException(CustomContentErrorCode.USER_NOT_FOUND));
         
-        int limit = Math.min(request.getLimit(), 100);
         Pageable pageable = PageRequest.of(
-                request.getPage() - 1, 
-                limit,
+                request.getPage() - 1,
+                request.getLimit(),
                 Sort.by(Sort.Direction.DESC, "createdAt")
         );
 

--- a/src/main/java/com/linglevel/api/crawling/controller/CrawlingController.java
+++ b/src/main/java/com/linglevel/api/crawling/controller/CrawlingController.java
@@ -18,6 +18,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -53,11 +55,13 @@ public class CrawlingController {
     @GetMapping("/crawling-dsl/domains")
     public ResponseEntity<PageResponse<DomainsResponse>> getDomains(
             @Parameter(description = "조회할 페이지 번호", example = "1")
+            @Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.")
             @RequestParam(defaultValue = "1") int page,
-            @Parameter(description = "페이지 당 항목 수 (최대 100)", example = "10")
+            @Parameter(description = "페이지 당 항목 수 (최대 200)", example = "10")
+            @Min(value = 1, message = "페이지 당 항목 수는 1 이상이어야 합니다.")
+            @Max(value = 200, message = "페이지 당 항목 수는 200 이하여야 합니다.")
             @RequestParam(defaultValue = "10") int limit) {
         
-        if (limit > 100) limit = 100;
         
         Page<DomainsResponse> domains = crawlingService.getDomains(page, limit);
         return ResponseEntity.ok(new PageResponse<>(domains.getContent(), domains));

--- a/src/main/java/com/linglevel/api/user/ticket/controller/TicketsController.java
+++ b/src/main/java/com/linglevel/api/user/ticket/controller/TicketsController.java
@@ -21,6 +21,7 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/v1/tickets")
@@ -56,7 +57,7 @@ public class TicketsController {
             content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
     })
     public ResponseEntity<PageResponse<TicketTransactionResponse>> getTicketTransactions(
-            @ParameterObject @ModelAttribute GetTicketTransactionsRequest request,
+            @ParameterObject @Valid @ModelAttribute GetTicketTransactionsRequest request,
             Authentication authentication) {
         String username = authentication.getName();
         User user = userRepository.findByUsername(username).orElseThrow();

--- a/src/main/java/com/linglevel/api/user/ticket/dto/GetTicketTransactionsRequest.java
+++ b/src/main/java/com/linglevel/api/user/ticket/dto/GetTicketTransactionsRequest.java
@@ -14,6 +14,6 @@ public class GetTicketTransactionsRequest {
     
     @Parameter(description = "페이지 당 항목 수", example = "10")
     @Min(value = 1, message = "페이지 당 항목 수는 1 이상이어야 합니다.")
-    @Max(value = 100, message = "페이지 당 항목 수는 100 이하여야 합니다.")
+    @Max(value = 200, message = "페이지 당 항목 수는 200 이하여야 합니다.")
     private Integer limit = 10;
 }

--- a/src/main/java/com/linglevel/api/word/controller/WordsController.java
+++ b/src/main/java/com/linglevel/api/word/controller/WordsController.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
 
 import com.linglevel.api.user.entity.User;
 import com.linglevel.api.user.repository.UserRepository;
@@ -42,7 +43,7 @@ public class WordsController {
     })
     @GetMapping
     public ResponseEntity<PageResponse<WordResponse>> getWords(
-            @ParameterObject @ModelAttribute GetWordsRequest request,
+            @ParameterObject @Valid @ModelAttribute GetWordsRequest request,
             Authentication authentication) {
         String username = authentication.getName();
         User user = userRepository.findByUsername(username).orElseThrow();

--- a/src/main/java/com/linglevel/api/word/dto/GetWordsRequest.java
+++ b/src/main/java/com/linglevel/api/word/dto/GetWordsRequest.java
@@ -1,6 +1,8 @@
 package com.linglevel.api.word.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,14 +19,17 @@ public class GetWordsRequest {
             example = "1",
             minimum = "1",
             defaultValue = "1")
+    @Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.")
     @Builder.Default
     private Integer page = 1;
     
     @Schema(description = "페이지 크기",
             example = "10",
             minimum = "1",
-            maximum = "100",
+            maximum = "200",
             defaultValue = "10")
+    @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.")
+    @Max(value = 200, message = "페이지 크기는 200 이하여야 합니다.")
     @Builder.Default
     private Integer limit = 10;
     

--- a/src/main/java/com/linglevel/api/word/service/WordService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordService.java
@@ -24,7 +24,6 @@ public class WordService {
     private final WordBookmarkRepository wordBookmarkRepository;
 
     public Page<WordResponse> getWords(String userId, int page, int limit, String search) {
-        limit = Math.min(limit, 100);
         Pageable pageable = PageRequest.of(page - 1, limit);
         Page<Word> words;
 


### PR DESCRIPTION
## Summary
- 페이지네이션 제한 `100` -> `200`으로 증가
- bean validation을 통한 limit 검증 방식으로 통합

## 연관 이슈
#157 