### PR TITLE
Feat: add max progress tracking with hierarchical comparison logic

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -2,7 +2,7 @@ name: Dev Deployment
 
 on:
   push:
-    branches: [ develop, feat/progress ]
+    branches: [ develop, feat/max-progress ]
 
 jobs:
   build:

--- a/api.md
+++ b/api.md
@@ -755,56 +755,6 @@ Authorization: Bearer {AccessToken}
 }
 ```
 
-### `POST /books/{bookId}/progress/reset`
-
-사용자의 특정 책에 대한 읽기 진도를 초기화합니다. 처음부터 다시 읽기를 원할 때 사용합니다.
-
-#### **Request Headers**
-```
-Authorization: Bearer {AccessToken}
-```
-
-#### **Path Parameters**
-
-| 파라미터  | 타입     | 설명             |
-| :-------- | :------- | :--------------- |
-| `bookId` | String | 초기화할 책의 고유 ID |
-
-#### **Success Response (200 OK)**
-```json
-{
-  "message": "Progress reset successfully.",
-  "id": "60d0fe4f5311236168a109d1",
-  "bookId": "60d0fe4f5311236168a109cb",
-  "currentReadChapterNumber": 0,
-  "currentReadChunkNumber": 0,
-  "maxReadChapterNumber": 3,
-  "maxReadChunkNumber": 8,
-  "isCompleted": false,
-  "updatedAt": "2024-01-15T10:30:00"
-}
-```
-
-**동작:**
-- `currentReadChapterNumber`와 `currentReadChunkNumber`를 0으로 초기화
-- `maxReadChapterNumber`와 `maxReadChunkNumber`는 유지 (학습 기록 보존)
-- `isCompleted`는 false로 설정
-- 처음부터 다시 읽을 수 있지만, 최대 진행 기록은 보존됩니다
-
-#### **Error Response (404 Not Found)**
-```json
-{
-  "message": "Book not found."
-}
-```
-
-#### **Error Response (404 Not Found)**
-```json
-{
-  "message": "Progress not found for this book."
-}
-```
-
 ### `DELETE /books/{bookId}/progress`
 
 사용자의 특정 책에 대한 읽기 진도를 완전히 삭제합니다. 진행기록 자체를 제거하고 싶을 때 사용합니다.
@@ -831,10 +781,6 @@ Authorization: Bearer {AccessToken}
 - 데이터베이스에서 진행기록 레코드를 완전히 삭제
 - current와 max 필드를 포함한 모든 진행 데이터가 삭제됨
 - 이후 해당 책을 읽으면 새로운 진행기록이 생성됨
-
-**Reset vs Delete:**
-- **Reset**: current를 0으로 초기화하지만 max는 유지 (학습 기록 보존)
-- **Delete**: 진행기록을 완전히 삭제 (모든 기록 제거)
 
 #### **Error Response (404 Not Found)**
 ```json
@@ -1627,54 +1573,6 @@ Authorization: Bearer {AccessToken}
 }
 ```
 
-### `POST /articles/{articleId}/progress/reset`
-
-사용자의 특정 기사에 대한 읽기 진도를 초기화합니다. 처음부터 다시 읽기를 원할 때 사용합니다.
-
-#### **Request Headers**
-```
-Authorization: Bearer {AccessToken}
-```
-
-#### **Path Parameters**
-
-| 파라미터  | 타입     | 설명             |
-| :-------- | :------- | :--------------- |
-| `articleId` | String | 초기화할 기사의 고유 ID |
-
-#### **Success Response (200 OK)**
-```json
-{
-  "message": "Progress reset successfully.",
-  "id": "60d0fe4f5311236168a109d1",
-  "articleId": "60d0fe4f5311236168a109cb",
-  "currentReadChunkNumber": 0,
-  "maxReadChunkNumber": 8,
-  "isCompleted": false,
-  "updatedAt": "2024-01-15T10:30:00"
-}
-```
-
-**동작:**
-- `currentReadChunkNumber`를 0으로 초기화
-- `maxReadChunkNumber`는 유지 (학습 기록 보존)
-- `isCompleted`는 false로 설정
-- 처음부터 다시 읽을 수 있지만, 최대 진행 기록은 보존됩니다
-
-#### **Error Response (404 Not Found)**
-```json
-{
-  "message": "Article not found."
-}
-```
-
-#### **Error Response (404 Not Found)**
-```json
-{
-  "message": "Progress not found for this article."
-}
-```
-
 ### `DELETE /articles/{articleId}/progress`
 
 사용자의 특정 기사에 대한 읽기 진도를 완전히 삭제합니다. 진행기록 자체를 제거하고 싶을 때 사용합니다.
@@ -1701,10 +1599,6 @@ Authorization: Bearer {AccessToken}
 - 데이터베이스에서 진행기록 레코드를 완전히 삭제
 - current와 max 필드를 포함한 모든 진행 데이터가 삭제됨
 - 이후 해당 기사를 읽으면 새로운 진행기록이 생성됨
-
-**Reset vs Delete:**
-- **Reset**: current를 0으로 초기화하지만 max는 유지 (학습 기록 보존)
-- **Delete**: 진행기록을 완전히 삭제 (모든 기록 제거)
 
 #### **Error Response (404 Not Found)**
 ```json
@@ -2805,54 +2699,6 @@ Authorization: Bearer {AccessToken}
 }
 ```
 
-### `POST /custom-contents/{customId}/progress/reset`
-
-사용자의 특정 커스텀 콘텐츠에 대한 읽기 진도를 초기화합니다. 처음부터 다시 읽기를 원할 때 사용합니다.
-
-#### **Request Headers**
-```
-Authorization: Bearer {AccessToken}
-```
-
-#### **Path Parameters**
-
-| 파라미터  | 타입     | 설명             |
-| :-------- | :------- | :--------------- |
-| `customId` | String | 초기화할 커스텀 콘텐츠의 고유 ID |
-
-#### **Success Response (200 OK)**
-```json
-{
-  "message": "Progress reset successfully.",
-  "id": "60d0fe4f5311236168a109d1",
-  "customId": "60d0fe4f5311236168a109cb",
-  "currentReadChunkNumber": 0,
-  "maxReadChunkNumber": 5,
-  "isCompleted": false,
-  "updatedAt": "2024-01-15T10:30:00"
-}
-```
-
-**동작:**
-- `currentReadChunkNumber`를 0으로 초기화
-- `maxReadChunkNumber`는 유지 (학습 기록 보존)
-- `isCompleted`는 false로 설정
-- 처음부터 다시 읽을 수 있지만, 최대 진행 기록은 보존됩니다
-
-#### **Error Response (404 Not Found)**
-```json
-{
-  "message": "Custom content not found."
-}
-```
-
-#### **Error Response (404 Not Found)**
-```json
-{
-  "message": "Progress not found for this custom content."
-}
-```
-
 ### `DELETE /custom-contents/{customId}/progress`
 
 사용자의 특정 커스텀 콘텐츠에 대한 읽기 진도를 완전히 삭제합니다. 진행기록 자체를 제거하고 싶을 때 사용합니다.
@@ -2879,10 +2725,6 @@ Authorization: Bearer {AccessToken}
 - 데이터베이스에서 진행기록 레코드를 완전히 삭제
 - current와 max 필드를 포함한 모든 진행 데이터가 삭제됨
 - 이후 해당 콘텐츠를 읽으면 새로운 진행기록이 생성됨
-
-**Reset vs Delete:**
-- **Reset**: current를 0으로 초기화하지만 max는 유지 (학습 기록 보존)
-- **Delete**: 진행기록을 완전히 삭제 (모든 기록 제거)
 
 #### **Error Response (404 Not Found)**
 ```json

--- a/api.md
+++ b/api.md
@@ -657,6 +657,11 @@ GET /api/v1/books/60d0fe4f5311236168a109ca/chapters?progress=in_progress&page=2&
 
 사용자의 읽기 진도를 업데이트합니다. chunkId를 통해 해당 chunk가 속한 chapter를 자동으로 역추산하여 진도를 기록합니다.
 
+**진도 추적 로직:**
+- `currentReadChapterNumber`, `currentReadChunkNumber`: 현재 읽은 위치
+- `maxReadChapterNumber`, `maxReadChunkNumber`: 지금까지 읽은 최대 진행 위치
+- 새로운 청크를 읽을 때마다 current가 업데이트되고, max보다 앞서면 max도 함께 업데이트됩니다
+
 #### **Request Headers**
 ```
 Authorization: Bearer {AccessToken}
@@ -686,6 +691,8 @@ Authorization: Bearer {AccessToken}
   "chunkId": "60d0fe4f5311236168c172db",
   "currentReadChapterNumber": 1,
   "currentReadChunkNumber": 5,
+  "maxReadChapterNumber": 3,
+  "maxReadChunkNumber": 8,
   "isCompleted": false,
   "updatedAt": "2024-01-15T10:30:00"
 }
@@ -745,6 +752,101 @@ Authorization: Bearer {AccessToken}
 ```json
 {
   "message": "Book not found."
+}
+```
+
+### `POST /books/{bookId}/progress/reset`
+
+사용자의 특정 책에 대한 읽기 진도를 초기화합니다. 처음부터 다시 읽기를 원할 때 사용합니다.
+
+#### **Request Headers**
+```
+Authorization: Bearer {AccessToken}
+```
+
+#### **Path Parameters**
+
+| 파라미터  | 타입     | 설명             |
+| :-------- | :------- | :--------------- |
+| `bookId` | String | 초기화할 책의 고유 ID |
+
+#### **Success Response (200 OK)**
+```json
+{
+  "message": "Progress reset successfully.",
+  "id": "60d0fe4f5311236168a109d1",
+  "bookId": "60d0fe4f5311236168a109cb",
+  "currentReadChapterNumber": 0,
+  "currentReadChunkNumber": 0,
+  "maxReadChapterNumber": 3,
+  "maxReadChunkNumber": 8,
+  "isCompleted": false,
+  "updatedAt": "2024-01-15T10:30:00"
+}
+```
+
+**동작:**
+- `currentReadChapterNumber`와 `currentReadChunkNumber`를 0으로 초기화
+- `maxReadChapterNumber`와 `maxReadChunkNumber`는 유지 (학습 기록 보존)
+- `isCompleted`는 false로 설정
+- 처음부터 다시 읽을 수 있지만, 최대 진행 기록은 보존됩니다
+
+#### **Error Response (404 Not Found)**
+```json
+{
+  "message": "Book not found."
+}
+```
+
+#### **Error Response (404 Not Found)**
+```json
+{
+  "message": "Progress not found for this book."
+}
+```
+
+### `DELETE /books/{bookId}/progress`
+
+사용자의 특정 책에 대한 읽기 진도를 완전히 삭제합니다. 진행기록 자체를 제거하고 싶을 때 사용합니다.
+
+#### **Request Headers**
+```
+Authorization: Bearer {AccessToken}
+```
+
+#### **Path Parameters**
+
+| 파라미터  | 타입     | 설명             |
+| :-------- | :------- | :--------------- |
+| `bookId` | String | 삭제할 책의 고유 ID |
+
+#### **Success Response (200 OK)**
+```json
+{
+  "message": "Progress deleted successfully."
+}
+```
+
+**동작:**
+- 데이터베이스에서 진행기록 레코드를 완전히 삭제
+- current와 max 필드를 포함한 모든 진행 데이터가 삭제됨
+- 이후 해당 책을 읽으면 새로운 진행기록이 생성됨
+
+**Reset vs Delete:**
+- **Reset**: current를 0으로 초기화하지만 max는 유지 (학습 기록 보존)
+- **Delete**: 진행기록을 완전히 삭제 (모든 기록 제거)
+
+#### **Error Response (404 Not Found)**
+```json
+{
+  "message": "Book not found."
+}
+```
+
+#### **Error Response (404 Not Found)**
+```json
+{
+  "message": "Progress not found for this book."
 }
 ```
 
@@ -1431,6 +1533,11 @@ X-API-Key: {TempApiKey}
 
 사용자의 아티클 읽기 진도를 업데이트합니다. chunkId를 통해 특정 청크까지 읽었음을 기록합니다.
 
+**진도 추적 로직:**
+- `currentReadChunkNumber`: 현재 읽은 청크 위치
+- `maxReadChunkNumber`: 지금까지 읽은 최대 진행 위치
+- 새로운 청크를 읽을 때마다 current가 업데이트되고, max보다 앞서면 max도 함께 업데이트됩니다
+
 #### **Request Headers**
 ```
 Authorization: Bearer {AccessToken}
@@ -1458,6 +1565,7 @@ Authorization: Bearer {AccessToken}
   "articleId": "60d0fe4f5311236168a109cb",
   "chunkId": "60d0fe4f5311236168c172db",
   "currentReadChunkNumber": 5,
+  "maxReadChunkNumber": 8,
   "isCompleted": false,
   "updatedAt": "2024-01-15T10:30:00"
 }
@@ -1504,6 +1612,99 @@ Authorization: Bearer {AccessToken}
   "updatedAt": "2024-01-15T10:30:00"
 }
 ```
+
+#### **Error Response (404 Not Found)**
+```json
+{
+  "message": "Article not found."
+}
+```
+
+#### **Error Response (404 Not Found)**
+```json
+{
+  "message": "Progress not found for this article."
+}
+```
+
+### `POST /articles/{articleId}/progress/reset`
+
+사용자의 특정 기사에 대한 읽기 진도를 초기화합니다. 처음부터 다시 읽기를 원할 때 사용합니다.
+
+#### **Request Headers**
+```
+Authorization: Bearer {AccessToken}
+```
+
+#### **Path Parameters**
+
+| 파라미터  | 타입     | 설명             |
+| :-------- | :------- | :--------------- |
+| `articleId` | String | 초기화할 기사의 고유 ID |
+
+#### **Success Response (200 OK)**
+```json
+{
+  "message": "Progress reset successfully.",
+  "id": "60d0fe4f5311236168a109d1",
+  "articleId": "60d0fe4f5311236168a109cb",
+  "currentReadChunkNumber": 0,
+  "maxReadChunkNumber": 8,
+  "isCompleted": false,
+  "updatedAt": "2024-01-15T10:30:00"
+}
+```
+
+**동작:**
+- `currentReadChunkNumber`를 0으로 초기화
+- `maxReadChunkNumber`는 유지 (학습 기록 보존)
+- `isCompleted`는 false로 설정
+- 처음부터 다시 읽을 수 있지만, 최대 진행 기록은 보존됩니다
+
+#### **Error Response (404 Not Found)**
+```json
+{
+  "message": "Article not found."
+}
+```
+
+#### **Error Response (404 Not Found)**
+```json
+{
+  "message": "Progress not found for this article."
+}
+```
+
+### `DELETE /articles/{articleId}/progress`
+
+사용자의 특정 기사에 대한 읽기 진도를 완전히 삭제합니다. 진행기록 자체를 제거하고 싶을 때 사용합니다.
+
+#### **Request Headers**
+```
+Authorization: Bearer {AccessToken}
+```
+
+#### **Path Parameters**
+
+| 파라미터  | 타입     | 설명             |
+| :-------- | :------- | :--------------- |
+| `articleId` | String | 삭제할 기사의 고유 ID |
+
+#### **Success Response (200 OK)**
+```json
+{
+  "message": "Progress deleted successfully."
+}
+```
+
+**동작:**
+- 데이터베이스에서 진행기록 레코드를 완전히 삭제
+- current와 max 필드를 포함한 모든 진행 데이터가 삭제됨
+- 이후 해당 기사를 읽으면 새로운 진행기록이 생성됨
+
+**Reset vs Delete:**
+- **Reset**: current를 0으로 초기화하지만 max는 유지 (학습 기록 보존)
+- **Delete**: 진행기록을 완전히 삭제 (모든 기록 제거)
 
 #### **Error Response (404 Not Found)**
 ```json
@@ -2510,6 +2711,11 @@ Authorization: Bearer {AccessToken}
 
 사용자의 커스텀 콘텐츠 읽기 진도를 업데이트합니다. chunkId를 통해 특정 청크까지 읽었음을 기록합니다.
 
+**진도 추적 로직:**
+- `currentReadChunkNumber`: 현재 읽은 청크 위치
+- `maxReadChunkNumber`: 지금까지 읽은 최대 진행 위치
+- 새로운 청크를 읽을 때마다 current가 업데이트되고, max보다 앞서면 max도 함께 업데이트됩니다
+
 #### **Request Headers**
 ```
 Authorization: Bearer {AccessToken}
@@ -2537,6 +2743,7 @@ Authorization: Bearer {AccessToken}
   "customId": "60d0fe4f5311236168a109cb",
   "chunkId": "60d0fe4f5311236168c172db",
   "currentReadChunkNumber": 3,
+  "maxReadChunkNumber": 5,
   "isCompleted": false,
   "updatedAt": "2024-01-15T10:30:00"
 }
@@ -2583,6 +2790,99 @@ Authorization: Bearer {AccessToken}
   "updatedAt": "2024-01-15T10:30:00"
 }
 ```
+
+#### **Error Response (404 Not Found)**
+```json
+{
+  "message": "Custom content not found."
+}
+```
+
+#### **Error Response (404 Not Found)**
+```json
+{
+  "message": "Progress not found for this custom content."
+}
+```
+
+### `POST /custom-contents/{customId}/progress/reset`
+
+사용자의 특정 커스텀 콘텐츠에 대한 읽기 진도를 초기화합니다. 처음부터 다시 읽기를 원할 때 사용합니다.
+
+#### **Request Headers**
+```
+Authorization: Bearer {AccessToken}
+```
+
+#### **Path Parameters**
+
+| 파라미터  | 타입     | 설명             |
+| :-------- | :------- | :--------------- |
+| `customId` | String | 초기화할 커스텀 콘텐츠의 고유 ID |
+
+#### **Success Response (200 OK)**
+```json
+{
+  "message": "Progress reset successfully.",
+  "id": "60d0fe4f5311236168a109d1",
+  "customId": "60d0fe4f5311236168a109cb",
+  "currentReadChunkNumber": 0,
+  "maxReadChunkNumber": 5,
+  "isCompleted": false,
+  "updatedAt": "2024-01-15T10:30:00"
+}
+```
+
+**동작:**
+- `currentReadChunkNumber`를 0으로 초기화
+- `maxReadChunkNumber`는 유지 (학습 기록 보존)
+- `isCompleted`는 false로 설정
+- 처음부터 다시 읽을 수 있지만, 최대 진행 기록은 보존됩니다
+
+#### **Error Response (404 Not Found)**
+```json
+{
+  "message": "Custom content not found."
+}
+```
+
+#### **Error Response (404 Not Found)**
+```json
+{
+  "message": "Progress not found for this custom content."
+}
+```
+
+### `DELETE /custom-contents/{customId}/progress`
+
+사용자의 특정 커스텀 콘텐츠에 대한 읽기 진도를 완전히 삭제합니다. 진행기록 자체를 제거하고 싶을 때 사용합니다.
+
+#### **Request Headers**
+```
+Authorization: Bearer {AccessToken}
+```
+
+#### **Path Parameters**
+
+| 파라미터  | 타입     | 설명             |
+| :-------- | :------- | :--------------- |
+| `customId` | String | 삭제할 커스텀 콘텐츠의 고유 ID |
+
+#### **Success Response (200 OK)**
+```json
+{
+  "message": "Progress deleted successfully."
+}
+```
+
+**동작:**
+- 데이터베이스에서 진행기록 레코드를 완전히 삭제
+- current와 max 필드를 포함한 모든 진행 데이터가 삭제됨
+- 이후 해당 콘텐츠를 읽으면 새로운 진행기록이 생성됨
+
+**Reset vs Delete:**
+- **Reset**: current를 0으로 초기화하지만 max는 유지 (학습 기록 보존)
+- **Delete**: 진행기록을 완전히 삭제 (모든 기록 제거)
 
 #### **Error Response (404 Not Found)**
 ```json

--- a/src/main/java/com/linglevel/api/content/article/controller/ArticleProgressController.java
+++ b/src/main/java/com/linglevel/api/content/article/controller/ArticleProgressController.java
@@ -63,22 +63,6 @@ public class ArticleProgressController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "아티클 읽기 진도 초기화", description = "사용자의 현재 읽기 진도를 0으로 초기화합니다. 최대 진도 기록은 유지됩니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "초기화 성공", useReturnTypeSchema = true),
-            @ApiResponse(responseCode = "404", description = "아티클 또는 진도 기록을 찾을 수 없음",
-                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
-    })
-    @PostMapping("/{articleId}/progress/reset")
-    public ResponseEntity<ArticleProgressResponse> resetProgress(
-            @Parameter(description = "아티클 ID", example = "60d0fe4f5311236168a109ca")
-            @PathVariable String articleId,
-            Authentication authentication) {
-        String username = authentication.getName();
-        ArticleProgressResponse response = articleProgressService.resetProgress(articleId, username);
-        return ResponseEntity.ok(response);
-    }
-
     @Operation(summary = "아티클 읽기 진도 삭제", description = "사용자의 읽기 진도 기록을 완전히 삭제합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "삭제 성공"),

--- a/src/main/java/com/linglevel/api/content/article/controller/ArticleProgressController.java
+++ b/src/main/java/com/linglevel/api/content/article/controller/ArticleProgressController.java
@@ -63,6 +63,38 @@ public class ArticleProgressController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "아티클 읽기 진도 초기화", description = "사용자의 현재 읽기 진도를 0으로 초기화합니다. 최대 진도 기록은 유지됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "초기화 성공", useReturnTypeSchema = true),
+            @ApiResponse(responseCode = "404", description = "아티클 또는 진도 기록을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @PostMapping("/{articleId}/progress/reset")
+    public ResponseEntity<ArticleProgressResponse> resetProgress(
+            @Parameter(description = "아티클 ID", example = "60d0fe4f5311236168a109ca")
+            @PathVariable String articleId,
+            Authentication authentication) {
+        String username = authentication.getName();
+        ArticleProgressResponse response = articleProgressService.resetProgress(articleId, username);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "아티클 읽기 진도 삭제", description = "사용자의 읽기 진도 기록을 완전히 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "아티클 또는 진도 기록을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @DeleteMapping("/{articleId}/progress")
+    public ResponseEntity<Void> deleteProgress(
+            @Parameter(description = "아티클 ID", example = "60d0fe4f5311236168a109ca")
+            @PathVariable String articleId,
+            Authentication authentication) {
+        String username = authentication.getName();
+        articleProgressService.deleteProgress(articleId, username);
+        return ResponseEntity.noContent().build();
+    }
+
     @ExceptionHandler(ArticleException.class)
     public ResponseEntity<ExceptionResponse> handleArticleException(ArticleException e) {
         log.info("Article Progress Exception: {}", e.getMessage());

--- a/src/main/java/com/linglevel/api/content/article/dto/ArticleProgressResponse.java
+++ b/src/main/java/com/linglevel/api/content/article/dto/ArticleProgressResponse.java
@@ -29,6 +29,9 @@ public class ArticleProgressResponse {
     @Schema(description = "현재 읽은 청크 번호", example = "5")
     private Integer currentReadChunkNumber;
 
+    @Schema(description = "최대 읽은 청크 번호", example = "8")
+    private Integer maxReadChunkNumber;
+
     @Schema(description = "완료 여부", example = "false")
     private Boolean isCompleted;
 

--- a/src/main/java/com/linglevel/api/content/article/entity/ArticleProgress.java
+++ b/src/main/java/com/linglevel/api/content/article/entity/ArticleProgress.java
@@ -29,6 +29,8 @@ public class ArticleProgress {
 
     private Integer currentReadChunkNumber;
 
+    private Integer maxReadChunkNumber;
+
     private Boolean isCompleted = false;
 
     @LastModifiedDate

--- a/src/main/java/com/linglevel/api/content/article/exception/ArticleErrorCode.java
+++ b/src/main/java/com/linglevel/api/content/article/exception/ArticleErrorCode.java
@@ -13,6 +13,7 @@ public enum ArticleErrorCode {
     INVALID_SORT_BY(HttpStatus.BAD_REQUEST, "Invalid sort_by parameter. Must be one of: view_count, average_rating, created_at."),
     INVALID_TAGS_FORMAT(HttpStatus.BAD_REQUEST, "Invalid tags format. Tags should be comma-separated strings."),
     INVALID_DIFFICULTY_LEVEL(HttpStatus.BAD_REQUEST, "Invalid difficulty level."),
+    PROGRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "Progress not found."),
     ARTICLE_DELETION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to delete article and related data.");
 
     private final HttpStatus status;

--- a/src/main/java/com/linglevel/api/content/article/service/ArticleProgressService.java
+++ b/src/main/java/com/linglevel/api/content/article/service/ArticleProgressService.java
@@ -66,10 +66,10 @@ public class ArticleProgressService {
             articleProgress.setMaxReadChunkNumber(chunk.getChunkNumber());
         }
 
-        // 완료 조건 자동 체크
+        // 완료 조건 자동 체크 (한번 true가 되면 계속 유지)
         var article = articleService.findById(articleId);
         boolean isCompleted = chunk.getChunkNumber() >= article.getChunkCount();
-        articleProgress.setIsCompleted(isCompleted);
+        articleProgress.setIsCompleted(articleProgress.getIsCompleted() != null && articleProgress.getIsCompleted() || isCompleted);
 
         articleProgressRepository.save(articleProgress);
 

--- a/src/main/java/com/linglevel/api/content/article/service/ArticleProgressService.java
+++ b/src/main/java/com/linglevel/api/content/article/service/ArticleProgressService.java
@@ -111,30 +111,6 @@ public class ArticleProgressService {
     }
 
     @Transactional
-    public ArticleProgressResponse resetProgress(String articleId, String username) {
-        if (!articleService.existsById(articleId)) {
-            throw new ArticleException(ArticleErrorCode.ARTICLE_NOT_FOUND);
-        }
-
-        User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new UsersException(UsersErrorCode.USER_NOT_FOUND));
-
-        ArticleProgress articleProgress = articleProgressRepository.findByUserIdAndArticleId(user.getId(), articleId)
-                .orElseThrow(() -> new ArticleException(ArticleErrorCode.PROGRESS_NOT_FOUND));
-
-        // 첫 번째 청크로 초기화 (max는 유지)
-        ArticleChunk firstChunk = articleChunkService.findFirstByArticleId(articleId);
-
-        articleProgress.setChunkId(firstChunk.getId());
-        articleProgress.setCurrentReadChunkNumber(firstChunk.getChunkNumber());
-        articleProgress.setIsCompleted(false);
-
-        articleProgressRepository.save(articleProgress);
-
-        return convertToArticleProgressResponse(articleProgress);
-    }
-
-    @Transactional
     public void deleteProgress(String articleId, String username) {
         if (!articleService.existsById(articleId)) {
             throw new ArticleException(ArticleErrorCode.ARTICLE_NOT_FOUND);

--- a/src/main/java/com/linglevel/api/content/article/service/ArticleService.java
+++ b/src/main/java/com/linglevel/api/content/article/service/ArticleService.java
@@ -232,7 +232,8 @@ public class ArticleService {
                     progressPercentage = (double) currentReadChunkNumber / article.getChunkCount() * 100.0;
                 }
 
-                isCompleted = currentReadChunkNumber >= article.getChunkCount();
+                // DB에 저장된 완료 여부 사용
+                isCompleted = progress.getIsCompleted() != null ? progress.getIsCompleted() : false;
             }
         }
 

--- a/src/main/java/com/linglevel/api/content/book/controller/BooksProgressController.java
+++ b/src/main/java/com/linglevel/api/content/book/controller/BooksProgressController.java
@@ -67,6 +67,38 @@ public class BooksProgressController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "읽기 진도 초기화", description = "사용자의 현재 읽기 진도를 0으로 초기화합니다. 최대 진도 기록은 유지됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "초기화 성공", useReturnTypeSchema = true),
+            @ApiResponse(responseCode = "404", description = "책 또는 진도 기록을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @PostMapping("/{bookId}/progress/reset")
+    public ResponseEntity<ProgressResponse> resetProgress(
+            @Parameter(description = "책 ID", example = "60d0fe4f5311236168a109ca")
+            @PathVariable String bookId,
+            Authentication authentication) {
+        String username = authentication.getName();
+        ProgressResponse response = progressService.resetProgress(bookId, username);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "읽기 진도 삭제", description = "사용자의 읽기 진도 기록을 완전히 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "책 또는 진도 기록을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @DeleteMapping("/{bookId}/progress")
+    public ResponseEntity<Void> deleteProgress(
+            @Parameter(description = "책 ID", example = "60d0fe4f5311236168a109ca")
+            @PathVariable String bookId,
+            Authentication authentication) {
+        String username = authentication.getName();
+        progressService.deleteProgress(bookId, username);
+        return ResponseEntity.noContent().build();
+    }
+
     @ExceptionHandler(BooksException.class)
     public ResponseEntity<ExceptionResponse> handleBooksException(BooksException e) {
         log.info("Books Progress Exception: {}", e.getMessage());

--- a/src/main/java/com/linglevel/api/content/book/controller/BooksProgressController.java
+++ b/src/main/java/com/linglevel/api/content/book/controller/BooksProgressController.java
@@ -67,22 +67,6 @@ public class BooksProgressController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "읽기 진도 초기화", description = "사용자의 현재 읽기 진도를 0으로 초기화합니다. 최대 진도 기록은 유지됩니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "초기화 성공", useReturnTypeSchema = true),
-            @ApiResponse(responseCode = "404", description = "책 또는 진도 기록을 찾을 수 없음",
-                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
-    })
-    @PostMapping("/{bookId}/progress/reset")
-    public ResponseEntity<ProgressResponse> resetProgress(
-            @Parameter(description = "책 ID", example = "60d0fe4f5311236168a109ca")
-            @PathVariable String bookId,
-            Authentication authentication) {
-        String username = authentication.getName();
-        ProgressResponse response = progressService.resetProgress(bookId, username);
-        return ResponseEntity.ok(response);
-    }
-
     @Operation(summary = "읽기 진도 삭제", description = "사용자의 읽기 진도 기록을 완전히 삭제합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "삭제 성공"),

--- a/src/main/java/com/linglevel/api/content/book/dto/ProgressResponse.java
+++ b/src/main/java/com/linglevel/api/content/book/dto/ProgressResponse.java
@@ -31,9 +31,15 @@ public class ProgressResponse {
     
     @Schema(description = "현재 읽은 챕터 번호", example = "1")
     private Integer currentReadChapterNumber;
-    
+
     @Schema(description = "현재 읽은 청크 번호", example = "5")
     private Integer currentReadChunkNumber;
+
+    @Schema(description = "최대 읽은 챕터 번호", example = "3")
+    private Integer maxReadChapterNumber;
+
+    @Schema(description = "최대 읽은 청크 번호", example = "8")
+    private Integer maxReadChunkNumber;
 
     @Schema(description = "완료 여부", example = "false")
     private Boolean isCompleted;

--- a/src/main/java/com/linglevel/api/content/book/entity/BookProgress.java
+++ b/src/main/java/com/linglevel/api/content/book/entity/BookProgress.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
@@ -15,6 +16,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Document(collection = "bookProgress")
+@CompoundIndex(name = "idx_user_book_progress", def = "{'userId': 1, 'bookId': 1}", unique = true)
 public class BookProgress {
     @Id
     private String id;
@@ -30,6 +32,10 @@ public class BookProgress {
     private Integer currentReadChapterNumber;
 
     private Integer currentReadChunkNumber;
+
+    private Integer maxReadChapterNumber;
+
+    private Integer maxReadChunkNumber;
 
     private Boolean isCompleted = false;
 

--- a/src/main/java/com/linglevel/api/content/book/exception/BooksErrorCode.java
+++ b/src/main/java/com/linglevel/api/content/book/exception/BooksErrorCode.java
@@ -17,6 +17,7 @@ public enum BooksErrorCode {
     INVALID_TAGS_FORMAT(HttpStatus.BAD_REQUEST, "Invalid tags format. Tags should be comma-separated strings."),
     INVALID_CHUNK_NUMBER(HttpStatus.BAD_REQUEST, "Invalid chunkNumber. Must be a positive integer."),
     INVALID_PAGINATION(HttpStatus.BAD_REQUEST, "Invalid pagination parameters."),
+    PROGRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "Progress not found."),
     BOOK_IMPORT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to import book from S3."),
     BOOK_DELETION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to delete book and related data.");
     

--- a/src/main/java/com/linglevel/api/content/book/service/BookService.java
+++ b/src/main/java/com/linglevel/api/content/book/service/BookService.java
@@ -206,14 +206,8 @@ public class BookService {
                     progressPercentage = (double) currentReadChapterNumber / book.getChapterCount() * 100.0;
                 }
 
-                // 완료 여부 확인 (currentReadChapterNumber >= chapterCount)
-                isCompleted = currentReadChapterNumber >= book.getChapterCount();
-
-                // Progress 엔티티의 isCompleted 필드 업데이트 (필요시)
-                if (progress.getIsCompleted() != isCompleted) {
-                    progress.setIsCompleted(isCompleted);
-                    bookProgressRepository.save(progress);
-                }
+                // DB에 저장된 완료 여부 사용
+                isCompleted = progress.getIsCompleted() != null ? progress.getIsCompleted() : false;
             }
         }
         return BookResponse.builder()

--- a/src/main/java/com/linglevel/api/content/book/service/ChapterService.java
+++ b/src/main/java/com/linglevel/api/content/book/service/ChapterService.java
@@ -124,22 +124,26 @@ public class ChapterService {
                 .orElse(null);
 
             if (bookProgress != null) {
-                int userCurrentChapterNumber = bookProgress.getCurrentReadChapterNumber() != null
-                    ? bookProgress.getCurrentReadChapterNumber() : 0;
-                int userCurrentChunkNumber = bookProgress.getCurrentReadChunkNumber() != null
-                    ? bookProgress.getCurrentReadChunkNumber() : 0;
+                Integer maxChapterNumber = bookProgress.getMaxReadChapterNumber() != null
+                    ? bookProgress.getMaxReadChapterNumber() : 0;
+                Integer maxChunkNumber = bookProgress.getMaxReadChunkNumber() != null
+                    ? bookProgress.getMaxReadChunkNumber() : 0;
 
-                if (chapter.getChapterNumber() < userCurrentChapterNumber) {
+                if (chapter.getChapterNumber() < maxChapterNumber) {
+                    // 이미 지나간 챕터 → 완료
                     currentReadChunkNumber = chapter.getChunkCount();
                     progressPercentage = 100.0;
                     isCompleted = true;
-                } else if (chapter.getChapterNumber().equals(userCurrentChapterNumber)) {
-                    currentReadChunkNumber = userCurrentChunkNumber;
+                } else if (chapter.getChapterNumber().equals(maxChapterNumber)) {
+                    // 현재 읽고 있는 max 챕터
+                    currentReadChunkNumber = maxChunkNumber;
                     if (chapter.getChunkCount() != null && chapter.getChunkCount() > 0) {
-                        progressPercentage = (double) userCurrentChunkNumber / chapter.getChunkCount() * 100.0;
+                        progressPercentage = (double) maxChunkNumber / chapter.getChunkCount() * 100.0;
                     }
-                    isCompleted = currentReadChunkNumber >= chapter.getChunkCount();
+                    // max 청크가 해당 챕터의 마지막 청크인 경우 완료
+                    isCompleted = maxChunkNumber >= chapter.getChunkCount();
                 } else {
+                    // 아직 안 읽은 챕터 → 미완료
                     currentReadChunkNumber = 0;
                     progressPercentage = 0.0;
                     isCompleted = false;

--- a/src/main/java/com/linglevel/api/content/book/service/ProgressService.java
+++ b/src/main/java/com/linglevel/api/content/book/service/ProgressService.java
@@ -56,12 +56,27 @@ public class ProgressService {
         BookProgress bookProgress = bookProgressRepository.findByUserIdAndBookId(userId, bookId)
                 .orElse(new BookProgress());
 
+        // Null 체크
+        if (chapter.getChapterNumber() == null || chunk.getChunkNumber() == null) {
+            throw new BooksException(BooksErrorCode.INVALID_CHUNK_NUMBER);
+        }
+
         bookProgress.setUserId(userId);
         bookProgress.setBookId(bookId);
         bookProgress.setChapterId(chapter.getId()); // 역추산된 chapter ID
         bookProgress.setChunkId(request.getChunkId());
         bookProgress.setCurrentReadChapterNumber(chapter.getChapterNumber());
         bookProgress.setCurrentReadChunkNumber(chunk.getChunkNumber());
+
+        // max 진도 업데이트 (current가 max보다 크면 max도 업데이트)
+        if (bookProgress.getMaxReadChapterNumber() == null ||
+            chapter.getChapterNumber() > bookProgress.getMaxReadChapterNumber()) {
+            bookProgress.setMaxReadChapterNumber(chapter.getChapterNumber());
+        }
+        if (bookProgress.getMaxReadChunkNumber() == null ||
+            chunk.getChunkNumber() > bookProgress.getMaxReadChunkNumber()) {
+            bookProgress.setMaxReadChunkNumber(chunk.getChunkNumber());
+        }
 
         // 완료 조건 자동 체크 (currentReadChapterNumber >= chapterCount)
         if (bookService.existsById(bookId)) {
@@ -104,8 +119,52 @@ public class ProgressService {
         newProgress.setChunkId(firstChunk.getId());
         newProgress.setCurrentReadChapterNumber(firstChapter.getChapterNumber());
         newProgress.setCurrentReadChunkNumber(firstChunk.getChunkNumber());
+        newProgress.setMaxReadChapterNumber(firstChapter.getChapterNumber());
+        newProgress.setMaxReadChunkNumber(firstChunk.getChunkNumber());
 
         return bookProgressRepository.save(newProgress);
+    }
+
+    @Transactional
+    public ProgressResponse resetProgress(String bookId, String username) {
+        if (!bookService.existsById(bookId)) {
+            throw new BooksException(BooksErrorCode.BOOK_NOT_FOUND);
+        }
+
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsersException(UsersErrorCode.USER_NOT_FOUND));
+
+        BookProgress bookProgress = bookProgressRepository.findByUserIdAndBookId(user.getId(), bookId)
+                .orElseThrow(() -> new BooksException(BooksErrorCode.PROGRESS_NOT_FOUND));
+
+        // 첫 번째 챕터/청크로 초기화 (max는 유지)
+        Chapter firstChapter = chapterService.findFirstByBookId(bookId);
+        Chunk firstChunk = chunkService.findFirstByChapterId(firstChapter.getId());
+
+        bookProgress.setChapterId(firstChapter.getId());
+        bookProgress.setChunkId(firstChunk.getId());
+        bookProgress.setCurrentReadChapterNumber(firstChapter.getChapterNumber());
+        bookProgress.setCurrentReadChunkNumber(firstChunk.getChunkNumber());
+        bookProgress.setIsCompleted(false);
+
+        bookProgressRepository.save(bookProgress);
+
+        return convertToProgressResponse(bookProgress);
+    }
+
+    @Transactional
+    public void deleteProgress(String bookId, String username) {
+        if (!bookService.existsById(bookId)) {
+            throw new BooksException(BooksErrorCode.BOOK_NOT_FOUND);
+        }
+
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsersException(UsersErrorCode.USER_NOT_FOUND));
+
+        BookProgress bookProgress = bookProgressRepository.findByUserIdAndBookId(user.getId(), bookId)
+                .orElseThrow(() -> new BooksException(BooksErrorCode.PROGRESS_NOT_FOUND));
+
+        bookProgressRepository.delete(bookProgress);
     }
 
     private ProgressResponse convertToProgressResponse(BookProgress progress) {
@@ -117,6 +176,8 @@ public class ProgressService {
                 .chunkId(progress.getChunkId())
                 .currentReadChapterNumber(progress.getCurrentReadChapterNumber())
                 .currentReadChunkNumber(progress.getCurrentReadChunkNumber())
+                .maxReadChapterNumber(progress.getMaxReadChapterNumber())
+                .maxReadChunkNumber(progress.getMaxReadChunkNumber())
                 .isCompleted(progress.getIsCompleted())
                 .updatedAt(progress.getUpdatedAt())
                 .build();

--- a/src/main/java/com/linglevel/api/content/book/service/ProgressService.java
+++ b/src/main/java/com/linglevel/api/content/book/service/ProgressService.java
@@ -69,12 +69,8 @@ public class ProgressService {
         bookProgress.setCurrentReadChunkNumber(chunk.getChunkNumber());
 
         // max 진도 업데이트 (current가 max보다 크면 max도 업데이트)
-        if (bookProgress.getMaxReadChapterNumber() == null ||
-            chapter.getChapterNumber() > bookProgress.getMaxReadChapterNumber()) {
+        if (shouldUpdateMaxProgress(bookProgress, chapter.getChapterNumber(), chunk.getChunkNumber())) {
             bookProgress.setMaxReadChapterNumber(chapter.getChapterNumber());
-        }
-        if (bookProgress.getMaxReadChunkNumber() == null ||
-            chunk.getChunkNumber() > bookProgress.getMaxReadChunkNumber()) {
             bookProgress.setMaxReadChunkNumber(chunk.getChunkNumber());
         }
 
@@ -138,6 +134,14 @@ public class ProgressService {
                 .orElseThrow(() -> new BooksException(BooksErrorCode.PROGRESS_NOT_FOUND));
 
         bookProgressRepository.delete(bookProgress);
+    }
+
+    private boolean shouldUpdateMaxProgress(BookProgress progress, Integer chapterNum, Integer chunkNum) {
+        Integer maxChapter = progress.getMaxReadChapterNumber();
+        Integer maxChunk = progress.getMaxReadChunkNumber();
+
+        return maxChapter == null || chapterNum > maxChapter
+            || (chapterNum.equals(maxChapter) && chunkNum > maxChunk);
     }
 
     private ProgressResponse convertToProgressResponse(BookProgress progress) {

--- a/src/main/java/com/linglevel/api/content/book/service/ProgressService.java
+++ b/src/main/java/com/linglevel/api/content/book/service/ProgressService.java
@@ -78,11 +78,11 @@ public class ProgressService {
             bookProgress.setMaxReadChunkNumber(chunk.getChunkNumber());
         }
 
-        // 완료 조건 자동 체크 (currentReadChapterNumber >= chapterCount)
+        // 완료 조건 자동 체크 (한번 true가 되면 계속 유지)
         if (bookService.existsById(bookId)) {
             var book = bookService.findById(bookId);
             boolean isCompleted = chapter.getChapterNumber() >= book.getChapterCount();
-            bookProgress.setIsCompleted(isCompleted);
+            bookProgress.setIsCompleted(bookProgress.getIsCompleted() != null && bookProgress.getIsCompleted() || isCompleted);
         }
 
         bookProgressRepository.save(bookProgress);

--- a/src/main/java/com/linglevel/api/content/book/service/ProgressService.java
+++ b/src/main/java/com/linglevel/api/content/book/service/ProgressService.java
@@ -126,33 +126,6 @@ public class ProgressService {
     }
 
     @Transactional
-    public ProgressResponse resetProgress(String bookId, String username) {
-        if (!bookService.existsById(bookId)) {
-            throw new BooksException(BooksErrorCode.BOOK_NOT_FOUND);
-        }
-
-        User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new UsersException(UsersErrorCode.USER_NOT_FOUND));
-
-        BookProgress bookProgress = bookProgressRepository.findByUserIdAndBookId(user.getId(), bookId)
-                .orElseThrow(() -> new BooksException(BooksErrorCode.PROGRESS_NOT_FOUND));
-
-        // 첫 번째 챕터/청크로 초기화 (max는 유지)
-        Chapter firstChapter = chapterService.findFirstByBookId(bookId);
-        Chunk firstChunk = chunkService.findFirstByChapterId(firstChapter.getId());
-
-        bookProgress.setChapterId(firstChapter.getId());
-        bookProgress.setChunkId(firstChunk.getId());
-        bookProgress.setCurrentReadChapterNumber(firstChapter.getChapterNumber());
-        bookProgress.setCurrentReadChunkNumber(firstChunk.getChunkNumber());
-        bookProgress.setIsCompleted(false);
-
-        bookProgressRepository.save(bookProgress);
-
-        return convertToProgressResponse(bookProgress);
-    }
-
-    @Transactional
     public void deleteProgress(String bookId, String username) {
         if (!bookService.existsById(bookId)) {
             throw new BooksException(BooksErrorCode.BOOK_NOT_FOUND);

--- a/src/main/java/com/linglevel/api/content/custom/controller/CustomContentProgressController.java
+++ b/src/main/java/com/linglevel/api/content/custom/controller/CustomContentProgressController.java
@@ -63,22 +63,6 @@ public class CustomContentProgressController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "커스텀 콘텐츠 읽기 진도 초기화", description = "사용자의 현재 읽기 진도를 0으로 초기화합니다. 최대 진도 기록은 유지됩니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "초기화 성공", useReturnTypeSchema = true),
-            @ApiResponse(responseCode = "404", description = "커스텀 콘텐츠 또는 진도 기록을 찾을 수 없음",
-                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
-    })
-    @PostMapping("/{customId}/progress/reset")
-    public ResponseEntity<CustomContentReadingProgressResponse> resetProgress(
-            @Parameter(description = "커스텀 콘텐츠 ID", example = "60d0fe4f5311236168a109ca")
-            @PathVariable String customId,
-            Authentication authentication) {
-        String username = authentication.getName();
-        CustomContentReadingProgressResponse response = customContentReadingProgressService.resetProgress(customId, username);
-        return ResponseEntity.ok(response);
-    }
-
     @Operation(summary = "커스텀 콘텐츠 읽기 진도 삭제", description = "사용자의 읽기 진도 기록을 완전히 삭제합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "삭제 성공"),

--- a/src/main/java/com/linglevel/api/content/custom/controller/CustomContentProgressController.java
+++ b/src/main/java/com/linglevel/api/content/custom/controller/CustomContentProgressController.java
@@ -63,6 +63,38 @@ public class CustomContentProgressController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "커스텀 콘텐츠 읽기 진도 초기화", description = "사용자의 현재 읽기 진도를 0으로 초기화합니다. 최대 진도 기록은 유지됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "초기화 성공", useReturnTypeSchema = true),
+            @ApiResponse(responseCode = "404", description = "커스텀 콘텐츠 또는 진도 기록을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @PostMapping("/{customId}/progress/reset")
+    public ResponseEntity<CustomContentReadingProgressResponse> resetProgress(
+            @Parameter(description = "커스텀 콘텐츠 ID", example = "60d0fe4f5311236168a109ca")
+            @PathVariable String customId,
+            Authentication authentication) {
+        String username = authentication.getName();
+        CustomContentReadingProgressResponse response = customContentReadingProgressService.resetProgress(customId, username);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "커스텀 콘텐츠 읽기 진도 삭제", description = "사용자의 읽기 진도 기록을 완전히 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "커스텀 콘텐츠 또는 진도 기록을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+    })
+    @DeleteMapping("/{customId}/progress")
+    public ResponseEntity<Void> deleteProgress(
+            @Parameter(description = "커스텀 콘텐츠 ID", example = "60d0fe4f5311236168a109ca")
+            @PathVariable String customId,
+            Authentication authentication) {
+        String username = authentication.getName();
+        customContentReadingProgressService.deleteProgress(customId, username);
+        return ResponseEntity.noContent().build();
+    }
+
     @ExceptionHandler(CustomContentException.class)
     public ResponseEntity<ExceptionResponse> handleCustomContentException(CustomContentException e) {
         log.info("Custom Content Progress Exception: {}", e.getMessage());

--- a/src/main/java/com/linglevel/api/content/custom/dto/CustomContentReadingProgressResponse.java
+++ b/src/main/java/com/linglevel/api/content/custom/dto/CustomContentReadingProgressResponse.java
@@ -29,6 +29,9 @@ public class CustomContentReadingProgressResponse {
     @Schema(description = "현재 읽은 청크 번호", example = "3")
     private Integer currentReadChunkNumber;
 
+    @Schema(description = "최대 읽은 청크 번호", example = "5")
+    private Integer maxReadChunkNumber;
+
     @Schema(description = "완료 여부", example = "false")
     private Boolean isCompleted;
 

--- a/src/main/java/com/linglevel/api/content/custom/entity/CustomContentProgress.java
+++ b/src/main/java/com/linglevel/api/content/custom/entity/CustomContentProgress.java
@@ -29,6 +29,8 @@ public class CustomContentProgress {
 
     private Integer currentReadChunkNumber;
 
+    private Integer maxReadChunkNumber;
+
     private Boolean isCompleted = false;
 
     @LastModifiedDate

--- a/src/main/java/com/linglevel/api/content/custom/exception/CustomContentErrorCode.java
+++ b/src/main/java/com/linglevel/api/content/custom/exception/CustomContentErrorCode.java
@@ -23,6 +23,7 @@ public enum CustomContentErrorCode {
     CUSTOM_CONTENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 커스텀 콘텐츠에 대한 접근 권한이 없습니다."),
     CUSTOM_CONTENT_CHUNK_NOT_FOUND(HttpStatus.NOT_FOUND, "커스텀 콘텐츠 청크를 찾을 수 없습니다."),
     CHUNK_NOT_FOUND_IN_CUSTOM_CONTENT(HttpStatus.NOT_FOUND, "Chunk not found in this custom content."),
+    PROGRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "진도 기록을 찾을 수 없습니다."),
     
     // 인증/인가 관련 (4xx)
     USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "인증된 사용자 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/linglevel/api/content/custom/service/CustomContentReadingProgressService.java
+++ b/src/main/java/com/linglevel/api/content/custom/service/CustomContentReadingProgressService.java
@@ -53,10 +53,21 @@ public class CustomContentReadingProgressService {
         CustomContentProgress customProgress = customContentProgressRepository.findByUserIdAndCustomId(userId, customId)
                 .orElse(new CustomContentProgress());
 
+        // Null 체크
+        if (chunk.getChunkNum() == null) {
+            throw new CustomContentException(CustomContentErrorCode.CUSTOM_CONTENT_CHUNK_NOT_FOUND);
+        }
+
         customProgress.setUserId(userId);
         customProgress.setCustomId(customId);
         customProgress.setChunkId(request.getChunkId());
         customProgress.setCurrentReadChunkNumber(chunk.getChunkNum()); // CustomContentChunk는 chunkNum 필드 사용
+
+        // max 진도 업데이트 (current가 max보다 크면 max도 업데이트)
+        if (customProgress.getMaxReadChunkNumber() == null ||
+            chunk.getChunkNum() > customProgress.getMaxReadChunkNumber()) {
+            customProgress.setMaxReadChunkNumber(chunk.getChunkNum());
+        }
 
         // 완료 조건 자동 체크
         CustomContent customContent = customContentRepository.findById(customId)
@@ -99,9 +110,49 @@ public class CustomContentReadingProgressService {
         newProgress.setCustomId(customId);
         newProgress.setChunkId(firstChunk.getId());
         newProgress.setCurrentReadChunkNumber(firstChunk.getChunkNum());
+        newProgress.setMaxReadChunkNumber(firstChunk.getChunkNum());
         // updatedAt은 @LastModifiedDate에 의해 자동 설정됨
 
         return customContentProgressRepository.save(newProgress);
+    }
+
+    @Transactional
+    public CustomContentReadingProgressResponse resetProgress(String customId, String username) {
+        if (!customContentService.existsById(customId)) {
+            throw new CustomContentException(CustomContentErrorCode.CUSTOM_CONTENT_NOT_FOUND);
+        }
+
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsersException(UsersErrorCode.USER_NOT_FOUND));
+
+        CustomContentProgress customProgress = customContentProgressRepository.findByUserIdAndCustomId(user.getId(), customId)
+                .orElseThrow(() -> new CustomContentException(CustomContentErrorCode.PROGRESS_NOT_FOUND));
+
+        // 첫 번째 청크로 초기화 (max는 유지)
+        CustomContentChunk firstChunk = customContentChunkService.findFirstByCustomContentId(customId);
+
+        customProgress.setChunkId(firstChunk.getId());
+        customProgress.setCurrentReadChunkNumber(firstChunk.getChunkNum());
+        customProgress.setIsCompleted(false);
+
+        customContentProgressRepository.save(customProgress);
+
+        return convertToCustomContentReadingProgressResponse(customProgress);
+    }
+
+    @Transactional
+    public void deleteProgress(String customId, String username) {
+        if (!customContentService.existsById(customId)) {
+            throw new CustomContentException(CustomContentErrorCode.CUSTOM_CONTENT_NOT_FOUND);
+        }
+
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsersException(UsersErrorCode.USER_NOT_FOUND));
+
+        CustomContentProgress customProgress = customContentProgressRepository.findByUserIdAndCustomId(user.getId(), customId)
+                .orElseThrow(() -> new CustomContentException(CustomContentErrorCode.PROGRESS_NOT_FOUND));
+
+        customContentProgressRepository.delete(customProgress);
     }
 
     private CustomContentReadingProgressResponse convertToCustomContentReadingProgressResponse(CustomContentProgress progress) {
@@ -111,6 +162,7 @@ public class CustomContentReadingProgressService {
                 .customId(progress.getCustomId())
                 .chunkId(progress.getChunkId())
                 .currentReadChunkNumber(progress.getCurrentReadChunkNumber())
+                .maxReadChunkNumber(progress.getMaxReadChunkNumber())
                 .isCompleted(progress.getIsCompleted())
                 .updatedAt(progress.getUpdatedAt())
                 .build();

--- a/src/main/java/com/linglevel/api/content/custom/service/CustomContentReadingProgressService.java
+++ b/src/main/java/com/linglevel/api/content/custom/service/CustomContentReadingProgressService.java
@@ -117,30 +117,6 @@ public class CustomContentReadingProgressService {
     }
 
     @Transactional
-    public CustomContentReadingProgressResponse resetProgress(String customId, String username) {
-        if (!customContentService.existsById(customId)) {
-            throw new CustomContentException(CustomContentErrorCode.CUSTOM_CONTENT_NOT_FOUND);
-        }
-
-        User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new UsersException(UsersErrorCode.USER_NOT_FOUND));
-
-        CustomContentProgress customProgress = customContentProgressRepository.findByUserIdAndCustomId(user.getId(), customId)
-                .orElseThrow(() -> new CustomContentException(CustomContentErrorCode.PROGRESS_NOT_FOUND));
-
-        // 첫 번째 청크로 초기화 (max는 유지)
-        CustomContentChunk firstChunk = customContentChunkService.findFirstByCustomContentId(customId);
-
-        customProgress.setChunkId(firstChunk.getId());
-        customProgress.setCurrentReadChunkNumber(firstChunk.getChunkNum());
-        customProgress.setIsCompleted(false);
-
-        customContentProgressRepository.save(customProgress);
-
-        return convertToCustomContentReadingProgressResponse(customProgress);
-    }
-
-    @Transactional
     public void deleteProgress(String customId, String username) {
         if (!customContentService.existsById(customId)) {
             throw new CustomContentException(CustomContentErrorCode.CUSTOM_CONTENT_NOT_FOUND);

--- a/src/main/java/com/linglevel/api/content/custom/service/CustomContentReadingProgressService.java
+++ b/src/main/java/com/linglevel/api/content/custom/service/CustomContentReadingProgressService.java
@@ -69,11 +69,11 @@ public class CustomContentReadingProgressService {
             customProgress.setMaxReadChunkNumber(chunk.getChunkNum());
         }
 
-        // 완료 조건 자동 체크
+        // 완료 조건 자동 체크 (한번 true가 되면 계속 유지)
         CustomContent customContent = customContentRepository.findById(customId)
                 .orElseThrow(() -> new CustomContentException(CustomContentErrorCode.CUSTOM_CONTENT_NOT_FOUND));
         boolean isCompleted = chunk.getChunkNum() >= customContent.getChunkCount();
-        customProgress.setIsCompleted(isCompleted);
+        customProgress.setIsCompleted(customProgress.getIsCompleted() != null && customProgress.getIsCompleted() || isCompleted);
 
         // updatedAt은 @LastModifiedDate에 의해 자동 설정됨
 


### PR DESCRIPTION
## Summary
사용자의 콘텐츠 읽기 진도를 추적하는 max progress 필드 추가 및 진도 관리 API 개선

## Problem
  1. 사용자가 이전에 읽었던 최대 진도(max progress)를 추적할 수 없어, 이전 위치로 되돌아가는 경우 진도율 계산이 부정확함
  2. Book의 경우 Chapter > Chunk 계층 구조에서 Chunk 번호만 비교하여 max progress를 업데이트하면, 다른 챕터로 이동 시 잘못된 비교가 발생
  3. 진도 초기화 API가 없어 사용자가 처음부터 다시 읽기를 원할 때 대응 불가

## Solution
  1. **Max Progress 필드 추가**
     - `maxReadChapterNumber`, `maxReadChunkNumber` 필드를 Book, Article, CustomContent 진도 엔티티에 추가
     - 진도 업데이트 시 현재 진도가 최대 진도보다 크면 자동으로 max 값 갱신

  2. **계층적 비교 로직 구현**
     - Book의 경우 Chapter와 Chunk를 함께 비교하는 `shouldUpdateMaxProgress()` 메서드 구현
     - `(chapter > maxChapter) OR (chapter == maxChapter AND chunk > maxChunk)` 조건으로 정확한 비교

  3. **진도 삭제 API 추가**
     - Reset API 대신 DELETE 방식으로 진도 데이터 완전 삭제
     - 다음 조회 시 자동으로 초기 진도 생성

## Related Issues
closes #167 