### PR TITLE
Fix: apply progress filter before pagination in contents

### DIFF
--- a/src/main/java/com/linglevel/api/content/article/repository/ArticleRepository.java
+++ b/src/main/java/com/linglevel/api/content/article/repository/ArticleRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.mongodb.repository.Query;
 
 import java.util.List;
 
-public interface ArticleRepository extends MongoRepository<Article, String> {
+public interface ArticleRepository extends MongoRepository<Article, String>, ArticleRepositoryCustom {
     
     // 제목 또는 작가로 키워드 검색
     @Query("{'$or': [{'title': {'$regex': ?0, '$options': 'i'}}, {'author': {'$regex': ?0, '$options': 'i'}}]}")

--- a/src/main/java/com/linglevel/api/content/article/repository/ArticleRepositoryCustom.java
+++ b/src/main/java/com/linglevel/api/content/article/repository/ArticleRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.linglevel.api.content.article.repository;
+
+import com.linglevel.api.content.article.dto.GetArticlesRequest;
+import com.linglevel.api.content.article.entity.Article;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ArticleRepositoryCustom {
+    Page<Article> findArticlesWithFilters(GetArticlesRequest request, String userId, Pageable pageable);
+}

--- a/src/main/java/com/linglevel/api/content/article/repository/ArticleRepositoryImpl.java
+++ b/src/main/java/com/linglevel/api/content/article/repository/ArticleRepositoryImpl.java
@@ -1,0 +1,168 @@
+package com.linglevel.api.content.article.repository;
+
+import com.linglevel.api.content.article.dto.GetArticlesRequest;
+import com.linglevel.api.content.article.entity.Article;
+import com.linglevel.api.content.common.ProgressStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
+
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public Page<Article> findArticlesWithFilters(GetArticlesRequest request, String userId, Pageable pageable) {
+        Query query = buildQuery(request, userId);
+
+        // 총 개수 조회 (필터링 적용 후)
+        long total = mongoTemplate.count(query, Article.class);
+
+        // 페이지네이션 적용
+        query.with(pageable);
+
+        // 데이터 조회
+        List<Article> articles = mongoTemplate.find(query, Article.class);
+
+        return new PageImpl<>(articles, pageable, total);
+    }
+
+    /**
+     * 동적 쿼리 빌드
+     */
+    private Query buildQuery(GetArticlesRequest request, String userId) {
+        Query query = new Query();
+
+        // 각 필터를 독립적인 메서드로 분리
+        applyTagsFilter(query, request.getTags());
+        applyKeywordFilter(query, request.getKeyword());
+        applyProgressFilter(query, request.getProgress(), userId);
+
+        return query;
+    }
+
+    /**
+     * 태그 필터 적용
+     */
+    private void applyTagsFilter(Query query, String tags) {
+        if (!StringUtils.hasText(tags)) {
+            return;
+        }
+
+        List<String> tagList = Arrays.asList(tags.split(","));
+        query.addCriteria(Criteria.where("tags").in(tagList));
+    }
+
+    /**
+     * 키워드 필터 적용 (제목 또는 작가)
+     */
+    private void applyKeywordFilter(Query query, String keyword) {
+        if (!StringUtils.hasText(keyword)) {
+            return;
+        }
+
+        Criteria keywordCriteria = new Criteria().orOperator(
+            Criteria.where("title").regex(keyword, "i"),
+            Criteria.where("author").regex(keyword, "i")
+        );
+        query.addCriteria(keywordCriteria);
+    }
+
+    /**
+     * 진도 필터 적용
+     */
+    private void applyProgressFilter(Query query, ProgressStatus progress, String userId) {
+        if (progress == null || userId == null) {
+            return;
+        }
+
+        List<String> articleIds = getArticleIdsByProgress(userId, progress);
+        if (!articleIds.isEmpty()) {
+            query.addCriteria(Criteria.where("id").in(articleIds));
+        } else {
+            // 조건에 맞는 아티클이 없으면 빈 결과 반환
+            query.addCriteria(Criteria.where("_id").is(null));
+        }
+    }
+
+    /**
+     * 진도 상태별 아티클 ID 목록 조회
+     */
+    private List<String> getArticleIdsByProgress(String userId, ProgressStatus progressStatus) {
+        return switch (progressStatus) {
+            case NOT_STARTED -> getNotStartedArticleIds(userId);
+            case IN_PROGRESS -> getInProgressArticleIds(userId);
+            case COMPLETED -> getCompletedArticleIds(userId);
+        };
+    }
+
+    /**
+     * 시작하지 않은 아티클 ID 목록 조회
+     */
+    private List<String> getNotStartedArticleIds(String userId) {
+        // 모든 아티클 ID 조회
+        List<String> allArticleIds = mongoTemplate.findAll(Article.class).stream()
+                .map(Article::getId)
+                .toList();
+
+        // 진도가 있는 아티클 ID 조회
+        List<String> progressArticleIds = findProgressArticleIds(userId);
+
+        // 진도가 없는 아티클만 반환
+        return allArticleIds.stream()
+                .filter(articleId -> !progressArticleIds.contains(articleId))
+                .toList();
+    }
+
+    /**
+     * 진행 중인 아티클 ID 목록 조회
+     */
+    private List<String> getInProgressArticleIds(String userId) {
+        Query query = new Query();
+        query.addCriteria(Criteria.where("userId").is(userId));
+        query.addCriteria(Criteria.where("isCompleted").is(false));
+        query.addCriteria(Criteria.where("currentReadChunkNumber").gt(0));
+
+        return findArticleIdsFromProgress(query);
+    }
+
+    /**
+     * 완료한 아티클 ID 목록 조회
+     */
+    private List<String> getCompletedArticleIds(String userId) {
+        Query query = new Query();
+        query.addCriteria(Criteria.where("userId").is(userId));
+        query.addCriteria(Criteria.where("isCompleted").is(true));
+
+        return findArticleIdsFromProgress(query);
+    }
+
+    /**
+     * 특정 사용자의 모든 진도 아티클 ID 조회
+     */
+    private List<String> findProgressArticleIds(String userId) {
+        Query query = new Query();
+        query.addCriteria(Criteria.where("userId").is(userId));
+
+        return findArticleIdsFromProgress(query);
+    }
+
+    /**
+     * ArticleProgress 컬렉션에서 articleId 추출
+     */
+    private List<String> findArticleIdsFromProgress(Query query) {
+        return mongoTemplate.find(query, org.bson.Document.class, "articleProgress")
+                .stream()
+                .map(doc -> doc.getString("articleId"))
+                .toList();
+    }
+}

--- a/src/main/java/com/linglevel/api/content/book/repository/BookRepository.java
+++ b/src/main/java/com/linglevel/api/content/book/repository/BookRepository.java
@@ -3,6 +3,5 @@ package com.linglevel.api.content.book.repository;
 import com.linglevel.api.content.book.entity.Book;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface
-BookRepository extends MongoRepository<Book, String> {
+public interface BookRepository extends MongoRepository<Book, String>, BookRepositoryCustom {
 }

--- a/src/main/java/com/linglevel/api/content/book/repository/BookRepositoryCustom.java
+++ b/src/main/java/com/linglevel/api/content/book/repository/BookRepositoryCustom.java
@@ -1,0 +1,18 @@
+package com.linglevel.api.content.book.repository;
+
+import com.linglevel.api.content.book.dto.GetBooksRequest;
+import com.linglevel.api.content.book.entity.Book;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface BookRepositoryCustom {
+    /**
+     * 동적 필터링이 적용된 책 목록 조회
+     *
+     * @param request 필터링 조건 (tags, keyword, progress 등)
+     * @param userId 사용자 ID (진도 필터링에 사용)
+     * @param pageable 페이지네이션 정보
+     * @return 필터링된 책 페이지
+     */
+    Page<Book> findBooksWithFilters(GetBooksRequest request, String userId, Pageable pageable);
+}

--- a/src/main/java/com/linglevel/api/content/book/repository/BookRepositoryImpl.java
+++ b/src/main/java/com/linglevel/api/content/book/repository/BookRepositoryImpl.java
@@ -1,0 +1,169 @@
+package com.linglevel.api.content.book.repository;
+
+import com.linglevel.api.content.book.dto.GetBooksRequest;
+import com.linglevel.api.content.book.entity.Book;
+import com.linglevel.api.content.common.ProgressStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Book Repository 커스텀 구현체
+ * MongoTemplate + Criteria를 BooleanExpression 스타일로 사용
+ */
+@RequiredArgsConstructor
+public class BookRepositoryImpl implements BookRepositoryCustom {
+
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public Page<Book> findBooksWithFilters(GetBooksRequest request, String userId, Pageable pageable) {
+        Query query = buildQuery(request, userId);
+
+        // 총 개수 조회 (필터링 적용 후)
+        long total = mongoTemplate.count(query, Book.class);
+
+        // 페이지네이션 적용
+        query.with(pageable);
+
+        // 데이터 조회
+        List<Book> books = mongoTemplate.find(query, Book.class);
+
+        return new PageImpl<>(books, pageable, total);
+    }
+
+    /**
+     * 동적 쿼리 빌드 (BooleanExpression 스타일)
+     */
+    private Query buildQuery(GetBooksRequest request, String userId) {
+        Query query = new Query();
+
+        // 각 필터를 독립적인 메서드로 분리
+        applyTagsFilter(query, request.getTags());
+        applyKeywordFilter(query, request.getKeyword());
+        applyProgressFilter(query, request.getProgress(), userId);
+
+        return query;
+    }
+
+    /**
+     * 태그 필터 적용
+     */
+    private void applyTagsFilter(Query query, String tags) {
+        if (!StringUtils.hasText(tags)) {
+            return;
+        }
+
+        List<String> tagList = Arrays.asList(tags.split(","));
+        query.addCriteria(Criteria.where("tags").in(tagList));
+    }
+
+    /**
+     * 키워드 필터 적용 (제목 또는 작가)
+     */
+    private void applyKeywordFilter(Query query, String keyword) {
+        if (!StringUtils.hasText(keyword)) {
+            return;
+        }
+
+        Criteria keywordCriteria = new Criteria().orOperator(
+            Criteria.where("title").regex(keyword, "i"),
+            Criteria.where("author").regex(keyword, "i")
+        );
+        query.addCriteria(keywordCriteria);
+    }
+
+    /**
+     * 진도 필터 적용
+     */
+    private void applyProgressFilter(Query query, ProgressStatus progress, String userId) {
+        if (progress == null || userId == null) {
+            return;
+        }
+
+        List<String> bookIds = getBookIdsByProgress(userId, progress);
+        if (!bookIds.isEmpty()) {
+            query.addCriteria(Criteria.where("id").in(bookIds));
+        }
+    }
+
+    /**
+     * 진도 상태별 책 ID 목록 조회
+     */
+    private List<String> getBookIdsByProgress(String userId, ProgressStatus progressStatus) {
+        return switch (progressStatus) {
+            case NOT_STARTED -> getNotStartedBookIds(userId);
+            case IN_PROGRESS -> getInProgressBookIds(userId);
+            case COMPLETED -> getCompletedBookIds(userId);
+        };
+    }
+
+    /**
+     * 시작하지 않은 책 ID 목록 조회
+     */
+    private List<String> getNotStartedBookIds(String userId) {
+        // 모든 책 ID 조회
+        List<String> allBookIds = mongoTemplate.findAll(Book.class).stream()
+                .map(Book::getId)
+                .toList();
+
+        // 진도가 있는 책 ID 조회
+        List<String> progressBookIds = findProgressBookIds(userId);
+
+        // 진도가 없는 책만 반환
+        return allBookIds.stream()
+                .filter(bookId -> !progressBookIds.contains(bookId))
+                .toList();
+    }
+
+    /**
+     * 진행 중인 책 ID 목록 조회
+     */
+    private List<String> getInProgressBookIds(String userId) {
+        Query query = new Query();
+        query.addCriteria(Criteria.where("userId").is(userId));
+        query.addCriteria(Criteria.where("isCompleted").is(false));
+        query.addCriteria(Criteria.where("maxReadChunkNumber").gt(0));
+
+        return findBookIdsFromProgress(query);
+    }
+
+    /**
+     * 완료한 책 ID 목록 조회
+     */
+    private List<String> getCompletedBookIds(String userId) {
+        Query query = new Query();
+        query.addCriteria(Criteria.where("userId").is(userId));
+        query.addCriteria(Criteria.where("isCompleted").is(true));
+
+        return findBookIdsFromProgress(query);
+    }
+
+    /**
+     * 특정 사용자의 모든 진도 책 ID 조회
+     */
+    private List<String> findProgressBookIds(String userId) {
+        Query query = new Query();
+        query.addCriteria(Criteria.where("userId").is(userId));
+
+        return findBookIdsFromProgress(query);
+    }
+
+    /**
+     * Progress 컬렉션에서 bookId 추출
+     */
+    private List<String> findBookIdsFromProgress(Query query) {
+        return mongoTemplate.find(query, org.bson.Document.class, "bookProgress")
+                .stream()
+                .map(doc -> doc.getString("bookId"))
+                .toList();
+    }
+}

--- a/src/main/java/com/linglevel/api/content/book/repository/ChapterRepository.java
+++ b/src/main/java/com/linglevel/api/content/book/repository/ChapterRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface ChapterRepository extends MongoRepository<Chapter, String> {
+public interface ChapterRepository extends MongoRepository<Chapter, String>, ChapterRepositoryCustom {
     Page<Chapter> findByBookId(String chapterId, Pageable pageable);
     
     List<Chapter> findByBookIdOrderByChapterNumber(String bookId);

--- a/src/main/java/com/linglevel/api/content/book/repository/ChapterRepositoryCustom.java
+++ b/src/main/java/com/linglevel/api/content/book/repository/ChapterRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.linglevel.api.content.book.repository;
+
+import com.linglevel.api.content.book.dto.GetChaptersRequest;
+import com.linglevel.api.content.book.entity.Chapter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ChapterRepositoryCustom {
+    Page<Chapter> findChaptersWithFilters(String bookId, GetChaptersRequest request, String userId, Pageable pageable);
+}

--- a/src/main/java/com/linglevel/api/content/book/repository/ChapterRepositoryImpl.java
+++ b/src/main/java/com/linglevel/api/content/book/repository/ChapterRepositoryImpl.java
@@ -1,0 +1,113 @@
+package com.linglevel.api.content.book.repository;
+
+import com.linglevel.api.content.book.dto.GetChaptersRequest;
+import com.linglevel.api.content.book.entity.BookProgress;
+import com.linglevel.api.content.book.entity.Chapter;
+import com.linglevel.api.content.common.ProgressStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class ChapterRepositoryImpl implements ChapterRepositoryCustom {
+
+    private final MongoTemplate mongoTemplate;
+    private final BookProgressRepository bookProgressRepository;
+
+    @Override
+    public Page<Chapter> findChaptersWithFilters(String bookId, GetChaptersRequest request, String userId, Pageable pageable) {
+        Query query = buildQuery(bookId, request, userId);
+
+        // 총 개수 조회 (필터링 적용 후)
+        long total = mongoTemplate.count(query, Chapter.class);
+
+        // 페이지네이션 적용
+        query.with(pageable);
+
+        // 데이터 조회
+        List<Chapter> chapters = mongoTemplate.find(query, Chapter.class);
+
+        return new PageImpl<>(chapters, pageable, total);
+    }
+
+    /**
+     * 동적 쿼리 빌드
+     */
+    private Query buildQuery(String bookId, GetChaptersRequest request, String userId) {
+        Query query = new Query();
+
+        // bookId 필터는 항상 적용
+        query.addCriteria(Criteria.where("bookId").is(bookId));
+
+        // 진도 필터 적용
+        applyProgressFilter(query, request.getProgress(), bookId, userId);
+
+        return query;
+    }
+
+    /**
+     * 진도 필터 적용
+     */
+    private void applyProgressFilter(Query query, ProgressStatus progress, String bookId, String userId) {
+        if (progress == null || userId == null) {
+            return;
+        }
+
+        BookProgress bookProgress = bookProgressRepository.findByUserIdAndBookId(userId, bookId)
+            .orElse(null);
+
+        List<Integer> chapterNumbers = getChapterNumbersByProgress(bookProgress, progress);
+
+        if (chapterNumbers == null) {
+            // null이면 필터링하지 않음 (모든 챕터 반환)
+            return;
+        }
+
+        if (!chapterNumbers.isEmpty()) {
+            query.addCriteria(Criteria.where("chapterNumber").in(chapterNumbers));
+        } else {
+            // 조건에 맞는 챕터가 없으면 빈 결과 반환
+            query.addCriteria(Criteria.where("_id").is(null));
+        }
+    }
+
+    /**
+     * 진도 상태별 챕터 번호 목록 조회
+     */
+    private List<Integer> getChapterNumbersByProgress(BookProgress bookProgress, ProgressStatus progressStatus) {
+        if (bookProgress == null) {
+            // 진도 정보가 없으면 모든 챕터가 NOT_STARTED
+            if (progressStatus == ProgressStatus.NOT_STARTED) {
+                return null; // null이면 필터링하지 않음 (모든 챕터 반환)
+            } else {
+                return List.of(); // 빈 리스트 반환 (결과 없음)
+            }
+        }
+
+        Integer currentChapterNumber = bookProgress.getCurrentReadChapterNumber() != null
+            ? bookProgress.getCurrentReadChapterNumber() : 0;
+
+        // 모든 챕터 번호 조회
+        List<Chapter> allChapters = mongoTemplate.find(
+            Query.query(Criteria.where("bookId").is(bookProgress.getBookId())),
+            Chapter.class
+        );
+
+        return allChapters.stream()
+            .map(Chapter::getChapterNumber)
+            .filter(chapterNumber -> {
+                return switch (progressStatus) {
+                    case NOT_STARTED -> chapterNumber > currentChapterNumber;
+                    case IN_PROGRESS -> chapterNumber.equals(currentChapterNumber) && currentChapterNumber > 0;
+                    case COMPLETED -> chapterNumber < currentChapterNumber;
+                };
+            })
+            .toList();
+    }
+}

--- a/src/main/java/com/linglevel/api/content/book/service/BookService.java
+++ b/src/main/java/com/linglevel/api/content/book/service/BookService.java
@@ -123,19 +123,15 @@ public class BookService {
             sort
         );
 
-        Page<Book> bookPage = bookRepository.findAll(pageable);
-
         // 사용자 ID 조회
         final String userId = getUserId(username);
+
+        // QueryDSL Custom Repository를 사용하여 필터링 + 페이지네이션 통합 처리
+        Page<Book> bookPage = bookRepository.findBooksWithFilters(request, userId, pageable);
 
         List<BookResponse> bookResponses = bookPage.getContent().stream()
             .map(book -> convertToBookResponse(book, userId))
             .collect(Collectors.toList());
-
-        // 진도별 필터링 적용
-        if (request.getProgress() != null && userId != null) {
-            bookResponses = filterByProgress(bookResponses, request.getProgress());
-        }
 
         return new PageResponse<>(bookResponses, bookPage);
     }

--- a/src/main/java/com/linglevel/api/content/custom/repository/CustomContentRepository.java
+++ b/src/main/java/com/linglevel/api/content/custom/repository/CustomContentRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface CustomContentRepository extends MongoRepository<CustomContent, String> {
+public interface CustomContentRepository extends MongoRepository<CustomContent, String>, CustomContentRepositoryCustom {
     
     Page<CustomContent> findByUserIdAndIsDeletedFalse(String userId, Pageable pageable);
     

--- a/src/main/java/com/linglevel/api/content/custom/repository/CustomContentRepositoryCustom.java
+++ b/src/main/java/com/linglevel/api/content/custom/repository/CustomContentRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.linglevel.api.content.custom.repository;
+
+import com.linglevel.api.content.custom.dto.GetCustomContentsRequest;
+import com.linglevel.api.content.custom.entity.CustomContent;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomContentRepositoryCustom {
+    Page<CustomContent> findCustomContentsWithFilters(String userId, GetCustomContentsRequest request, Pageable pageable);
+}

--- a/src/main/java/com/linglevel/api/content/custom/repository/CustomContentRepositoryImpl.java
+++ b/src/main/java/com/linglevel/api/content/custom/repository/CustomContentRepositoryImpl.java
@@ -1,0 +1,175 @@
+package com.linglevel.api.content.custom.repository;
+
+import com.linglevel.api.content.common.ProgressStatus;
+import com.linglevel.api.content.custom.dto.GetCustomContentsRequest;
+import com.linglevel.api.content.custom.entity.CustomContent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomContentRepositoryImpl implements CustomContentRepositoryCustom {
+
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public Page<CustomContent> findCustomContentsWithFilters(String userId, GetCustomContentsRequest request, Pageable pageable) {
+        Query query = buildQuery(userId, request);
+
+        // 총 개수 조회 (필터링 적용 후)
+        long total = mongoTemplate.count(query, CustomContent.class);
+
+        // 페이지네이션 적용
+        query.with(pageable);
+
+        // 데이터 조회
+        List<CustomContent> contents = mongoTemplate.find(query, CustomContent.class);
+
+        return new PageImpl<>(contents, pageable, total);
+    }
+
+    /**
+     * 동적 쿼리 빌드
+     */
+    private Query buildQuery(String userId, GetCustomContentsRequest request) {
+        Query query = new Query();
+
+        // 기본 필터 (userId, isDeleted)
+        query.addCriteria(Criteria.where("userId").is(userId));
+        query.addCriteria(Criteria.where("isDeleted").is(false));
+
+        // 각 필터를 독립적인 메서드로 분리
+        applyKeywordFilter(query, request.getKeyword());
+        applyTagsFilter(query, request.getTags());
+        applyProgressFilter(query, request.getProgress(), userId);
+
+        return query;
+    }
+
+    /**
+     * 키워드 필터 적용 (제목 또는 작가)
+     */
+    private void applyKeywordFilter(Query query, String keyword) {
+        if (!StringUtils.hasText(keyword)) {
+            return;
+        }
+
+        Criteria keywordCriteria = new Criteria().orOperator(
+            Criteria.where("title").regex(keyword, "i"),
+            Criteria.where("author").regex(keyword, "i")
+        );
+        query.addCriteria(keywordCriteria);
+    }
+
+    /**
+     * 태그 필터 적용
+     */
+    private void applyTagsFilter(Query query, String tags) {
+        if (!StringUtils.hasText(tags)) {
+            return;
+        }
+
+        String[] tagArray = tags.split(",");
+        query.addCriteria(Criteria.where("tags").all((Object[]) tagArray));
+    }
+
+    /**
+     * 진도 필터 적용
+     */
+    private void applyProgressFilter(Query query, ProgressStatus progress, String userId) {
+        if (progress == null || userId == null) {
+            return;
+        }
+
+        List<String> contentIds = getContentIdsByProgress(userId, progress);
+        if (!contentIds.isEmpty()) {
+            query.addCriteria(Criteria.where("id").in(contentIds));
+        } else {
+            // 조건에 맞는 콘텐츠가 없으면 빈 결과 반환
+            query.addCriteria(Criteria.where("_id").is(null));
+        }
+    }
+
+    /**
+     * 진도 상태별 콘텐츠 ID 목록 조회
+     */
+    private List<String> getContentIdsByProgress(String userId, ProgressStatus progressStatus) {
+        return switch (progressStatus) {
+            case NOT_STARTED -> getNotStartedContentIds(userId);
+            case IN_PROGRESS -> getInProgressContentIds(userId);
+            case COMPLETED -> getCompletedContentIds(userId);
+        };
+    }
+
+    /**
+     * 시작하지 않은 콘텐츠 ID 목록 조회
+     */
+    private List<String> getNotStartedContentIds(String userId) {
+        // 해당 사용자의 모든 콘텐츠 ID 조회
+        Query userContentQuery = new Query();
+        userContentQuery.addCriteria(Criteria.where("userId").is(userId));
+        userContentQuery.addCriteria(Criteria.where("isDeleted").is(false));
+
+        List<String> allContentIds = mongoTemplate.find(userContentQuery, CustomContent.class).stream()
+                .map(CustomContent::getId)
+                .toList();
+
+        // 진도가 있는 콘텐츠 ID 조회
+        List<String> progressContentIds = findProgressContentIds(userId);
+
+        // 진도가 없는 콘텐츠만 반환
+        return allContentIds.stream()
+                .filter(contentId -> !progressContentIds.contains(contentId))
+                .toList();
+    }
+
+    /**
+     * 진행 중인 콘텐츠 ID 목록 조회
+     */
+    private List<String> getInProgressContentIds(String userId) {
+        Query query = new Query();
+        query.addCriteria(Criteria.where("userId").is(userId));
+        query.addCriteria(Criteria.where("isCompleted").is(false));
+        query.addCriteria(Criteria.where("currentReadChunkNumber").gt(0));
+
+        return findContentIdsFromProgress(query);
+    }
+
+    /**
+     * 완료한 콘텐츠 ID 목록 조회
+     */
+    private List<String> getCompletedContentIds(String userId) {
+        Query query = new Query();
+        query.addCriteria(Criteria.where("userId").is(userId));
+        query.addCriteria(Criteria.where("isCompleted").is(true));
+
+        return findContentIdsFromProgress(query);
+    }
+
+    /**
+     * 특정 사용자의 모든 진도 콘텐츠 ID 조회
+     */
+    private List<String> findProgressContentIds(String userId) {
+        Query query = new Query();
+        query.addCriteria(Criteria.where("userId").is(userId));
+
+        return findContentIdsFromProgress(query);
+    }
+
+    /**
+     * CustomContentProgress 컬렉션에서 customId 추출
+     */
+    private List<String> findContentIdsFromProgress(Query query) {
+        return mongoTemplate.find(query, org.bson.Document.class, "customContentProgress")
+                .stream()
+                .map(doc -> doc.getString("customId"))
+                .toList();
+    }
+}

--- a/src/test/java/com/linglevel/api/content/article/service/ArticleServiceTest.java
+++ b/src/test/java/com/linglevel/api/content/article/service/ArticleServiceTest.java
@@ -1,0 +1,229 @@
+package com.linglevel.api.content.article.service;
+
+import com.linglevel.api.common.AbstractDatabaseTest;
+import com.linglevel.api.common.dto.PageResponse;
+import com.linglevel.api.content.article.dto.ArticleResponse;
+import com.linglevel.api.content.article.dto.GetArticlesRequest;
+import com.linglevel.api.content.article.entity.Article;
+import com.linglevel.api.content.article.entity.ArticleProgress;
+import com.linglevel.api.content.article.repository.ArticleProgressRepository;
+import com.linglevel.api.content.article.repository.ArticleRepository;
+import com.linglevel.api.content.common.DifficultyLevel;
+import com.linglevel.api.content.common.ProgressStatus;
+import com.linglevel.api.user.entity.User;
+import com.linglevel.api.user.entity.UserRole;
+import com.linglevel.api.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class ArticleServiceTest extends AbstractDatabaseTest {
+
+    @Autowired
+    private ArticleService articleService;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private ArticleProgressRepository articleProgressRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        // 데이터 초기화
+        articleProgressRepository.deleteAll();
+        articleRepository.deleteAll();
+        userRepository.deleteAll();
+
+        // 테스트 유저 생성
+        testUser = new User();
+        testUser.setUsername("testuser");
+        testUser.setEmail("test@example.com");
+        testUser.setRole(UserRole.USER);
+        testUser.setDeleted(false);
+        testUser.setCreatedAt(LocalDateTime.now());
+        testUser = userRepository.save(testUser);
+    }
+
+    @Test
+    @DisplayName("진도 필터링과 페이지네이션 - IN_PROGRESS")
+    void testProgressFilterWithPagination_InProgress() {
+        // Given: 30개 아티클 생성
+        for (int i = 1; i <= 30; i++) {
+            Article article = createArticle("Article " + i, "Author " + i, Arrays.asList("tag1"));
+            articleRepository.save(article);
+
+            // 10개는 진행중, 10개는 완료, 10개는 시작안함
+            if (i <= 10) {
+                createArticleProgress(testUser.getId(), article.getId(), false);
+            } else if (i <= 20) {
+                createArticleProgress(testUser.getId(), article.getId(), true);
+            }
+        }
+
+        // When: IN_PROGRESS 필터로 1페이지(limit=5) 요청
+        GetArticlesRequest request = new GetArticlesRequest();
+        request.setProgress(ProgressStatus.IN_PROGRESS);
+        request.setPage(1);
+        request.setLimit(5);
+
+        PageResponse<ArticleResponse> response = articleService.getArticles(request, testUser.getUsername());
+
+        // Then: 정확히 5개 반환, 총 10개
+        assertThat(response.getData()).hasSize(5);
+        assertThat(response.getTotalCount()).isEqualTo(10);
+        assertThat(response.getTotalPages()).isEqualTo(2);
+
+        // 모든 항목이 진행중이어야 함
+        response.getData().forEach(article -> {
+            assertThat(article.getProgressPercentage()).isGreaterThan(0.0);
+            assertThat(article.getIsCompleted()).isFalse();
+        });
+    }
+
+    @Test
+    @DisplayName("태그 필터링과 페이지네이션")
+    void testTagsFilterWithPagination() {
+        // Given: technology 태그 15개, business 태그 15개
+        for (int i = 1; i <= 15; i++) {
+            Article article = createArticle("Tech Article " + i, "Author " + i, Arrays.asList("technology"));
+            articleRepository.save(article);
+        }
+        for (int i = 1; i <= 15; i++) {
+            Article article = createArticle("Business Article " + i, "Author " + i, Arrays.asList("business"));
+            articleRepository.save(article);
+        }
+
+        // When: technology 태그로 필터링, 1페이지(limit=10)
+        GetArticlesRequest request = new GetArticlesRequest();
+        request.setTags("technology");
+        request.setPage(1);
+        request.setLimit(10);
+
+        PageResponse<ArticleResponse> response = articleService.getArticles(request, testUser.getUsername());
+
+        // Then: 정확히 10개 반환, 총 15개
+        assertThat(response.getData()).hasSize(10);
+        assertThat(response.getTotalCount()).isEqualTo(15);
+        assertThat(response.getTotalPages()).isEqualTo(2);
+
+        // 모든 아티클이 technology 태그를 가져야 함
+        response.getData().forEach(article -> {
+            assertThat(article.getTags()).contains("technology");
+        });
+    }
+
+    @Test
+    @DisplayName("키워드 검색과 페이지네이션")
+    void testKeywordSearchWithPagination() {
+        // Given: 제목에 "viking" 포함된 아티클 12개, 다른 아티클 18개
+        for (int i = 1; i <= 12; i++) {
+            Article article = createArticle("The Viking Story " + i, "Author " + i, Arrays.asList("tag1"));
+            articleRepository.save(article);
+        }
+        for (int i = 1; i <= 18; i++) {
+            Article article = createArticle("Other Article " + i, "Author " + i, Arrays.asList("tag1"));
+            articleRepository.save(article);
+        }
+
+        // When: "viking" 키워드로 검색, 1페이지(limit=10)
+        GetArticlesRequest request = new GetArticlesRequest();
+        request.setKeyword("viking");
+        request.setPage(1);
+        request.setLimit(10);
+
+        PageResponse<ArticleResponse> response = articleService.getArticles(request, testUser.getUsername());
+
+        // Then: 정확히 10개 반환, 총 12개
+        assertThat(response.getData()).hasSize(10);
+        assertThat(response.getTotalCount()).isEqualTo(12);
+        assertThat(response.getTotalPages()).isEqualTo(2);
+
+        // 모든 아티클의 제목에 "viking"이 포함되어야 함
+        response.getData().forEach(article -> {
+            assertThat(article.getTitle().toLowerCase()).contains("viking");
+        });
+    }
+
+    @Test
+    @DisplayName("복합 필터링 - 태그 + 진도 + 페이지네이션")
+    void testCombinedFiltersWithPagination() {
+        // Given: technology 태그를 가진 아티클 20개 생성
+        for (int i = 1; i <= 20; i++) {
+            Article article = createArticle("Tech Article " + i, "Author " + i, Arrays.asList("technology"));
+            articleRepository.save(article);
+
+            // 절반만 진행중으로 설정
+            if (i <= 10) {
+                createArticleProgress(testUser.getId(), article.getId(), false);
+            }
+        }
+
+        // business 태그를 가진 아티클 10개 생성 (진행중)
+        for (int i = 1; i <= 10; i++) {
+            Article article = createArticle("Business Article " + i, "Author " + i, Arrays.asList("business"));
+            articleRepository.save(article);
+            createArticleProgress(testUser.getId(), article.getId(), false);
+        }
+
+        // When: technology 태그 + IN_PROGRESS 필터, 1페이지(limit=5)
+        GetArticlesRequest request = new GetArticlesRequest();
+        request.setTags("technology");
+        request.setProgress(ProgressStatus.IN_PROGRESS);
+        request.setPage(1);
+        request.setLimit(5);
+
+        PageResponse<ArticleResponse> response = articleService.getArticles(request, testUser.getUsername());
+
+        // Then: technology 태그 + 진행중인 아티클만 반환
+        assertThat(response.getData()).hasSize(5);
+        assertThat(response.getTotalCount()).isEqualTo(10); // technology + 진행중 = 10개
+        assertThat(response.getTotalPages()).isEqualTo(2);
+
+        response.getData().forEach(article -> {
+            assertThat(article.getTags()).contains("technology");
+            assertThat(article.getProgressPercentage()).isGreaterThan(0.0);
+            assertThat(article.getIsCompleted()).isFalse();
+        });
+    }
+
+    private Article createArticle(String title, String author, List<String> tags) {
+        Article article = new Article();
+        article.setTitle(title);
+        article.setAuthor(author);
+        article.setTags(tags);
+        article.setDifficultyLevel(DifficultyLevel.A1);
+        article.setChunkCount(100);
+        article.setReadingTime(60);
+        article.setAverageRating(4.5);
+        article.setReviewCount(100);
+        article.setViewCount(1000);
+        article.setCreatedAt(LocalDateTime.now());
+        return article;
+    }
+
+    private void createArticleProgress(String userId, String articleId, boolean isCompleted) {
+        ArticleProgress progress = new ArticleProgress();
+        progress.setUserId(userId);
+        progress.setArticleId(articleId);
+        progress.setCurrentReadChunkNumber(isCompleted ? 100 : 50);
+        progress.setMaxReadChunkNumber(isCompleted ? 100 : 50);
+        progress.setIsCompleted(isCompleted);
+        progress.setUpdatedAt(LocalDateTime.now());
+        articleProgressRepository.save(progress);
+    }
+}

--- a/src/test/java/com/linglevel/api/content/book/service/BookServiceTest.java
+++ b/src/test/java/com/linglevel/api/content/book/service/BookServiceTest.java
@@ -1,0 +1,308 @@
+package com.linglevel.api.content.book.service;
+
+import com.linglevel.api.common.AbstractDatabaseTest;
+import com.linglevel.api.common.dto.PageResponse;
+import com.linglevel.api.content.book.dto.BookResponse;
+import com.linglevel.api.content.book.dto.GetBooksRequest;
+import com.linglevel.api.content.book.entity.Book;
+import com.linglevel.api.content.book.entity.BookProgress;
+import com.linglevel.api.content.book.repository.BookProgressRepository;
+import com.linglevel.api.content.book.repository.BookRepository;
+import com.linglevel.api.content.common.DifficultyLevel;
+import com.linglevel.api.content.common.ProgressStatus;
+import com.linglevel.api.user.entity.User;
+import com.linglevel.api.user.entity.UserRole;
+import com.linglevel.api.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class BookServiceTest extends AbstractDatabaseTest {
+
+    @Autowired
+    private BookService bookService;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private BookProgressRepository bookProgressRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        // 데이터 초기화
+        bookProgressRepository.deleteAll();
+        bookRepository.deleteAll();
+        userRepository.deleteAll();
+
+        // 테스트 유저 생성
+        testUser = new User();
+        testUser.setUsername("testuser");
+        testUser.setEmail("test@example.com");
+        testUser.setRole(UserRole.USER);
+        testUser.setDeleted(false);
+        testUser.setCreatedAt(LocalDateTime.now());
+        testUser = userRepository.save(testUser);
+    }
+
+    @Test
+    @DisplayName("진도 필터링과 페이지네이션이 함께 동작할 때 - IN_PROGRESS 필터")
+    void testProgressFilterWithPagination_InProgress() {
+        // Given: 30개의 책 생성
+        for (int i = 1; i <= 30; i++) {
+            Book book = createBook("Book " + i, "Author " + i, Arrays.asList("tag1"));
+            bookRepository.save(book);
+
+            // 10개는 진행중, 10개는 완료, 10개는 시작안함
+            if (i <= 10) {
+                // 진행중
+                createBookProgress(testUser.getId(), book.getId(), false);
+            } else if (i <= 20) {
+                // 완료
+                createBookProgress(testUser.getId(), book.getId(), true);
+            }
+            // 21~30은 진행 정보 없음 (NOT_STARTED)
+        }
+
+        // When: IN_PROGRESS 필터로 1페이지(limit=5) 요청
+        GetBooksRequest request = GetBooksRequest.builder()
+                .progress(ProgressStatus.IN_PROGRESS)
+                .page(1)
+                .limit(5)
+                .build();
+
+        PageResponse<BookResponse> response = bookService.getBooks(request, testUser.getUsername());
+
+        // Then: 정확히 5개가 반환되어야 함 (진행중 10개 중 첫 5개)
+        assertThat(response.getData()).hasSize(5);
+        assertThat(response.getTotalCount()).isEqualTo(10); // 진행중 총 10개
+        assertThat(response.getTotalPages()).isEqualTo(2); // 10개 / 5 = 2페이지
+
+        // 모든 항목이 진행중이어야 함
+        response.getData().forEach(book -> {
+            assertThat(book.getProgressPercentage()).isGreaterThan(0.0);
+            assertThat(book.getIsCompleted()).isFalse();
+        });
+    }
+
+    @Test
+    @DisplayName("진도 필터링과 페이지네이션이 함께 동작할 때 - COMPLETED 필터")
+    void testProgressFilterWithPagination_Completed() {
+        // Given: 30개의 책 생성
+        for (int i = 1; i <= 30; i++) {
+            Book book = createBook("Book " + i, "Author " + i, Arrays.asList("tag1"));
+            bookRepository.save(book);
+
+            if (i <= 10) {
+                createBookProgress(testUser.getId(), book.getId(), false);
+            } else if (i <= 20) {
+                createBookProgress(testUser.getId(), book.getId(), true);
+            }
+        }
+
+        // When: COMPLETED 필터로 1페이지(limit=5) 요청
+        GetBooksRequest request = GetBooksRequest.builder()
+                .progress(ProgressStatus.COMPLETED)
+                .page(1)
+                .limit(5)
+                .build();
+
+        PageResponse<BookResponse> response = bookService.getBooks(request, testUser.getUsername());
+
+        // Then: 정확히 5개가 반환되어야 함 (완료 10개 중 첫 5개)
+        assertThat(response.getData()).hasSize(5);
+        assertThat(response.getTotalCount()).isEqualTo(10); // 완료 총 10개
+        assertThat(response.getTotalPages()).isEqualTo(2);
+
+        // 모든 항목이 완료되어야 함
+        response.getData().forEach(book -> {
+            assertThat(book.getIsCompleted()).isTrue();
+        });
+    }
+
+    @Test
+    @DisplayName("진도 필터링과 페이지네이션이 함께 동작할 때 - NOT_STARTED 필터")
+    void testProgressFilterWithPagination_NotStarted() {
+        // Given: 30개의 책 생성
+        for (int i = 1; i <= 30; i++) {
+            Book book = createBook("Book " + i, "Author " + i, Arrays.asList("tag1"));
+            bookRepository.save(book);
+
+            if (i <= 10) {
+                createBookProgress(testUser.getId(), book.getId(), false);
+            } else if (i <= 20) {
+                createBookProgress(testUser.getId(), book.getId(), true);
+            }
+        }
+
+        // When: NOT_STARTED 필터로 1페이지(limit=5) 요청
+        GetBooksRequest request = GetBooksRequest.builder()
+                .progress(ProgressStatus.NOT_STARTED)
+                .page(1)
+                .limit(5)
+                .build();
+
+        PageResponse<BookResponse> response = bookService.getBooks(request, testUser.getUsername());
+
+        // Then: 정확히 5개가 반환되어야 함 (시작안함 10개 중 첫 5개)
+        assertThat(response.getData()).hasSize(5);
+        assertThat(response.getTotalCount()).isEqualTo(10); // 시작안함 총 10개
+        assertThat(response.getTotalPages()).isEqualTo(2);
+
+        // 모든 항목이 시작하지 않았어야 함
+        response.getData().forEach(book -> {
+            assertThat(book.getProgressPercentage()).isEqualTo(0.0);
+        });
+    }
+
+    @Test
+    @DisplayName("태그 필터링과 페이지네이션")
+    void testTagsFilterWithPagination() {
+        // Given: philosophy 태그를 가진 책 15개, children 태그를 가진 책 15개
+        for (int i = 1; i <= 15; i++) {
+            Book book = createBook("Philosophy Book " + i, "Author " + i, Arrays.asList("philosophy"));
+            bookRepository.save(book);
+        }
+        for (int i = 1; i <= 15; i++) {
+            Book book = createBook("Children Book " + i, "Author " + i, Arrays.asList("children"));
+            bookRepository.save(book);
+        }
+
+        // When: philosophy 태그로 필터링, 1페이지(limit=10)
+        GetBooksRequest request = GetBooksRequest.builder()
+                .tags("philosophy")
+                .page(1)
+                .limit(10)
+                .build();
+
+        PageResponse<BookResponse> response = bookService.getBooks(request, testUser.getUsername());
+
+        // Then: 정확히 10개 반환, 총 15개
+        assertThat(response.getData()).hasSize(10);
+        assertThat(response.getTotalCount()).isEqualTo(15);
+        assertThat(response.getTotalPages()).isEqualTo(2);
+
+        // 모든 책이 philosophy 태그를 가져야 함
+        response.getData().forEach(book -> {
+            assertThat(book.getTags()).contains("philosophy");
+        });
+    }
+
+    @Test
+    @DisplayName("키워드 검색과 페이지네이션")
+    void testKeywordSearchWithPagination() {
+        // Given: 제목에 "prince"가 포함된 책 12개, 다른 책 18개
+        for (int i = 1; i <= 12; i++) {
+            Book book = createBook("The Little Prince " + i, "Author " + i, Arrays.asList("tag1"));
+            bookRepository.save(book);
+        }
+        for (int i = 1; i <= 18; i++) {
+            Book book = createBook("Other Book " + i, "Author " + i, Arrays.asList("tag1"));
+            bookRepository.save(book);
+        }
+
+        // When: "prince" 키워드로 검색, 1페이지(limit=10)
+        GetBooksRequest request = GetBooksRequest.builder()
+                .keyword("prince")
+                .page(1)
+                .limit(10)
+                .build();
+
+        PageResponse<BookResponse> response = bookService.getBooks(request, testUser.getUsername());
+
+        // Then: 정확히 10개 반환, 총 12개
+        assertThat(response.getData()).hasSize(10);
+        assertThat(response.getTotalCount()).isEqualTo(12);
+        assertThat(response.getTotalPages()).isEqualTo(2);
+
+        // 모든 책의 제목에 "prince"가 포함되어야 함
+        response.getData().forEach(book -> {
+            assertThat(book.getTitle().toLowerCase()).contains("prince");
+        });
+    }
+
+    @Test
+    @DisplayName("복합 필터링 - 태그 + 진도 + 페이지네이션")
+    void testCombinedFiltersWithPagination() {
+        // Given: philosophy 태그를 가진 책 20개 생성
+        for (int i = 1; i <= 20; i++) {
+            Book book = createBook("Philosophy Book " + i, "Author " + i, Arrays.asList("philosophy"));
+            bookRepository.save(book);
+
+            // 절반만 진행중으로 설정
+            if (i <= 10) {
+                createBookProgress(testUser.getId(), book.getId(), false);
+            }
+        }
+
+        // children 태그를 가진 책 10개 생성 (진행중)
+        for (int i = 1; i <= 10; i++) {
+            Book book = createBook("Children Book " + i, "Author " + i, Arrays.asList("children"));
+            bookRepository.save(book);
+            createBookProgress(testUser.getId(), book.getId(), false);
+        }
+
+        // When: philosophy 태그 + IN_PROGRESS 필터, 1페이지(limit=5)
+        GetBooksRequest request = GetBooksRequest.builder()
+                .tags("philosophy")
+                .progress(ProgressStatus.IN_PROGRESS)
+                .page(1)
+                .limit(5)
+                .build();
+
+        PageResponse<BookResponse> response = bookService.getBooks(request, testUser.getUsername());
+
+        // Then: philosophy 태그 + 진행중인 책만 반환
+        assertThat(response.getData()).hasSize(5);
+        assertThat(response.getTotalCount()).isEqualTo(10); // philosophy + 진행중 = 10개
+        assertThat(response.getTotalPages()).isEqualTo(2);
+
+        response.getData().forEach(book -> {
+            assertThat(book.getTags()).contains("philosophy");
+            assertThat(book.getProgressPercentage()).isGreaterThan(0.0);
+            assertThat(book.getIsCompleted()).isFalse();
+        });
+    }
+
+    private Book createBook(String title, String author, List<String> tags) {
+        Book book = new Book();
+        book.setTitle(title);
+        book.setAuthor(author);
+        book.setTags(tags);
+        book.setDifficultyLevel(DifficultyLevel.A1);
+        book.setChapterCount(10);
+        book.setReadingTime(60);
+        book.setAverageRating(4.5);
+        book.setReviewCount(100);
+        book.setViewCount(1000);
+        book.setCreatedAt(LocalDateTime.now());
+        return book;
+    }
+
+    private void createBookProgress(String userId, String bookId, boolean isCompleted) {
+        BookProgress progress = new BookProgress();
+        progress.setUserId(userId);
+        progress.setBookId(bookId);
+        progress.setCurrentReadChapterNumber(isCompleted ? 10 : 5);
+        progress.setCurrentReadChunkNumber(isCompleted ? 100 : 50);
+        progress.setMaxReadChapterNumber(isCompleted ? 10 : 5);
+        progress.setMaxReadChunkNumber(isCompleted ? 100 : 50);
+        progress.setIsCompleted(isCompleted);
+        progress.setUpdatedAt(LocalDateTime.now());
+        bookProgressRepository.save(progress);
+    }
+}

--- a/src/test/java/com/linglevel/api/content/book/service/ChapterServiceTest.java
+++ b/src/test/java/com/linglevel/api/content/book/service/ChapterServiceTest.java
@@ -1,0 +1,213 @@
+package com.linglevel.api.content.book.service;
+
+import com.linglevel.api.common.AbstractDatabaseTest;
+import com.linglevel.api.common.dto.PageResponse;
+import com.linglevel.api.content.book.dto.ChapterResponse;
+import com.linglevel.api.content.book.dto.GetChaptersRequest;
+import com.linglevel.api.content.book.entity.Book;
+import com.linglevel.api.content.book.entity.BookProgress;
+import com.linglevel.api.content.book.entity.Chapter;
+import com.linglevel.api.content.book.repository.BookProgressRepository;
+import com.linglevel.api.content.book.repository.BookRepository;
+import com.linglevel.api.content.book.repository.ChapterRepository;
+import com.linglevel.api.content.common.DifficultyLevel;
+import com.linglevel.api.content.common.ProgressStatus;
+import com.linglevel.api.user.entity.User;
+import com.linglevel.api.user.entity.UserRole;
+import com.linglevel.api.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class ChapterServiceTest extends AbstractDatabaseTest {
+
+    @Autowired
+    private ChapterService chapterService;
+
+    @Autowired
+    private ChapterRepository chapterRepository;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private BookProgressRepository bookProgressRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User testUser;
+    private Book testBook;
+
+    @BeforeEach
+    void setUp() {
+        // 데이터 초기화
+        bookProgressRepository.deleteAll();
+        chapterRepository.deleteAll();
+        bookRepository.deleteAll();
+        userRepository.deleteAll();
+
+        // 테스트 유저 생성
+        testUser = new User();
+        testUser.setUsername("testuser");
+        testUser.setEmail("test@example.com");
+        testUser.setRole(UserRole.USER);
+        testUser.setDeleted(false);
+        testUser.setCreatedAt(LocalDateTime.now());
+        testUser = userRepository.save(testUser);
+
+        // 테스트 책 생성
+        testBook = new Book();
+        testBook.setTitle("Test Book");
+        testBook.setAuthor("Test Author");
+        testBook.setDifficultyLevel(DifficultyLevel.A1);
+        testBook.setChapterCount(10);
+        testBook.setCreatedAt(LocalDateTime.now());
+        testBook = bookRepository.save(testBook);
+    }
+
+    @Test
+    @DisplayName("진도 필터링과 페이지네이션 - NOT_STARTED")
+    void testProgressFilterWithPagination_NotStarted() {
+        // Given: 10개 챕터 생성, 현재 5번 챕터까지 읽음
+        for (int i = 1; i <= 10; i++) {
+            Chapter chapter = createChapter(testBook.getId(), i, "Chapter " + i);
+            chapterRepository.save(chapter);
+        }
+
+        BookProgress progress = new BookProgress();
+        progress.setUserId(testUser.getId());
+        progress.setBookId(testBook.getId());
+        progress.setCurrentReadChapterNumber(5);
+        progress.setCurrentReadChunkNumber(50);
+        progress.setMaxReadChapterNumber(5);
+        progress.setMaxReadChunkNumber(50);
+        progress.setIsCompleted(false);
+        progress.setUpdatedAt(LocalDateTime.now());
+        bookProgressRepository.save(progress);
+
+        // When: NOT_STARTED 필터로 1페이지(limit=3) 요청
+        GetChaptersRequest request = GetChaptersRequest.builder()
+                .progress(ProgressStatus.NOT_STARTED)
+                .page(1)
+                .limit(3)
+                .build();
+
+        PageResponse<ChapterResponse> response = chapterService.getChapters(testBook.getId(), request, testUser.getUsername());
+
+        // Then: 6-10번 챕터 중 첫 3개 반환
+        assertThat(response.getData()).hasSize(3);
+        assertThat(response.getTotalCount()).isEqualTo(5); // 6-10번 = 5개
+        assertThat(response.getTotalPages()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("진도 필터링과 페이지네이션 - IN_PROGRESS")
+    void testProgressFilterWithPagination_InProgress() {
+        // Given: 10개 챕터 생성, 현재 5번 챕터 읽는 중
+        for (int i = 1; i <= 10; i++) {
+            Chapter chapter = createChapter(testBook.getId(), i, "Chapter " + i);
+            chapterRepository.save(chapter);
+        }
+
+        BookProgress progress = new BookProgress();
+        progress.setUserId(testUser.getId());
+        progress.setBookId(testBook.getId());
+        progress.setCurrentReadChapterNumber(5);
+        progress.setCurrentReadChunkNumber(50);
+        progress.setMaxReadChapterNumber(5);
+        progress.setMaxReadChunkNumber(50);
+        progress.setIsCompleted(false);
+        progress.setUpdatedAt(LocalDateTime.now());
+        bookProgressRepository.save(progress);
+
+        // When: IN_PROGRESS 필터로 요청
+        GetChaptersRequest request = GetChaptersRequest.builder()
+                .progress(ProgressStatus.IN_PROGRESS)
+                .page(1)
+                .limit(10)
+                .build();
+
+        PageResponse<ChapterResponse> response = chapterService.getChapters(testBook.getId(), request, testUser.getUsername());
+
+        // Then: 5번 챕터만 반환
+        assertThat(response.getData()).hasSize(1);
+        assertThat(response.getTotalCount()).isEqualTo(1);
+        assertThat(response.getData().get(0).getChapterNumber()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("진도 필터링과 페이지네이션 - COMPLETED")
+    void testProgressFilterWithPagination_Completed() {
+        // Given: 10개 챕터 생성, 현재 5번 챕터까지 읽음
+        for (int i = 1; i <= 10; i++) {
+            Chapter chapter = createChapter(testBook.getId(), i, "Chapter " + i);
+            chapterRepository.save(chapter);
+        }
+
+        BookProgress progress = new BookProgress();
+        progress.setUserId(testUser.getId());
+        progress.setBookId(testBook.getId());
+        progress.setCurrentReadChapterNumber(5);
+        progress.setCurrentReadChunkNumber(50);
+        progress.setMaxReadChapterNumber(5);
+        progress.setMaxReadChunkNumber(50);
+        progress.setIsCompleted(false);
+        progress.setUpdatedAt(LocalDateTime.now());
+        bookProgressRepository.save(progress);
+
+        // When: COMPLETED 필터로 1페이지(limit=2) 요청
+        GetChaptersRequest request = GetChaptersRequest.builder()
+                .progress(ProgressStatus.COMPLETED)
+                .page(1)
+                .limit(2)
+                .build();
+
+        PageResponse<ChapterResponse> response = chapterService.getChapters(testBook.getId(), request, testUser.getUsername());
+
+        // Then: 1-4번 챕터 중 첫 2개 반환
+        assertThat(response.getData()).hasSize(2);
+        assertThat(response.getTotalCount()).isEqualTo(4); // 1-4번 = 4개
+        assertThat(response.getTotalPages()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("진도 정보 없을 때 - NOT_STARTED는 모든 챕터 반환")
+    void testNoProgress_NotStarted() {
+        // Given: 10개 챕터 생성, 진도 정보 없음
+        for (int i = 1; i <= 10; i++) {
+            Chapter chapter = createChapter(testBook.getId(), i, "Chapter " + i);
+            chapterRepository.save(chapter);
+        }
+
+        // When: NOT_STARTED 필터로 요청
+        GetChaptersRequest request = GetChaptersRequest.builder()
+                .progress(ProgressStatus.NOT_STARTED)
+                .page(1)
+                .limit(5)
+                .build();
+
+        PageResponse<ChapterResponse> response = chapterService.getChapters(testBook.getId(), request, testUser.getUsername());
+
+        // Then: 모든 챕터가 NOT_STARTED이므로 첫 5개 반환
+        assertThat(response.getData()).hasSize(5);
+        assertThat(response.getTotalCount()).isEqualTo(10);
+    }
+
+    private Chapter createChapter(String bookId, Integer chapterNumber, String title) {
+        Chapter chapter = new Chapter();
+        chapter.setBookId(bookId);
+        chapter.setChapterNumber(chapterNumber);
+        chapter.setTitle(title);
+        chapter.setChunkCount(100);
+        chapter.setReadingTime(30);
+        return chapter;
+    }
+}


### PR DESCRIPTION
## Summary
페이지네이션 + 필터링 버그 수정: 필터를 페이지네이션 이전에 DB 레벨에서 적용하도록 개선

## Problem
  - 요청한 개수보다 적은 데이터 반환 (예: 10개 요청 시 2개만 반환)
  - 부정확한 totalCount 및 totalPages
  - 불필요한 메모리 처리로 인한 성능 저하

## Solution
MongoTemplate + Criteria를 사용한 Custom Repository 패턴으로 필터링을 DB 레벨에서 처리

## Related Issues
closes #165 