### PR TITLE
Feat: Improve invalid word caching with 3-retry system and auto-clean

### DIFF
--- a/src/main/java/com/linglevel/api/word/entity/InvalidWord.java
+++ b/src/main/java/com/linglevel/api/word/entity/InvalidWord.java
@@ -24,7 +24,4 @@ public class InvalidWord {
 
     @Builder.Default
     private Integer attemptCount = 1;
-
-    @Indexed(name = "ttl_expires_at", expireAfter = "0s")
-    private LocalDateTime expiresAt;
 }


### PR DESCRIPTION
## Summary
AI 단어 생성 실패 시 기록 및 캐싱

## Problem
- AI 단어 생성 실패 시 비용이 지속적으로 발생
- 실패한 단어를 모아보기 어려워 후속 조치 곤란

## Solution
- 3회 재시도 후 실패 시 캐싱하여 더 이상 생성하지 않도록 조치
- `Invalid Word` 콜렉션을 모니터링해 후속 조치 할 수 있도록 격리

## Related Issues
#206 