### PR TITLE
Fix: change get content category from string for ai service

### DIFF
--- a/src/main/java/com/linglevel/api/admin/dto/ArticleReleaseNotificationRequest.java
+++ b/src/main/java/com/linglevel/api/admin/dto/ArticleReleaseNotificationRequest.java
@@ -37,6 +37,6 @@ public class ArticleReleaseNotificationRequest {
 
         @Schema(description = "타겟 카테고리", example = "TECH", required = true)
         @NotNull(message = "Target category is required")
-        private ContentCategory targetCategory;
+        private String targetCategory;
     }
 }

--- a/src/main/java/com/linglevel/api/admin/service/NotificationService.java
+++ b/src/main/java/com/linglevel/api/admin/service/NotificationService.java
@@ -292,7 +292,7 @@ public class NotificationService {
 
                 MatchedArticle matchedArticle = new MatchedArticle(
                         articleInfo.getArticleId(),
-                        articleInfo.getTargetCategory(),
+                        ContentCategory.fromString(articleInfo.getTargetCategory()),
                         priority,
                         userLanguage
                 );


### PR DESCRIPTION
## Summary
AI 서비스가 String을 사용하기에 `ContentCategory` Enum 타입 사용에서 String으로 변경했습니다.