### PR TITLE
Feat: Optimize database indexing for improved chunk and word entity query performance

### DIFF
--- a/src/main/java/com/linglevel/api/content/article/entity/ArticleChunk.java
+++ b/src/main/java/com/linglevel/api/content/article/entity/ArticleChunk.java
@@ -4,6 +4,7 @@ import com.linglevel.api.content.common.ChunkType;
 import com.linglevel.api.content.common.DifficultyLevel;
 import lombok.*;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Getter
@@ -11,6 +12,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @NoArgsConstructor
 @AllArgsConstructor
 @Document(collection = "articleChunks")
+@CompoundIndex(name = "article_difficulty_chunk_idx", def = "{'articleId': 1, 'difficultyLevel': 1, 'chunkNumber': 1}")
 public class ArticleChunk {
     @Id
     private String id;

--- a/src/main/java/com/linglevel/api/content/book/entity/Chunk.java
+++ b/src/main/java/com/linglevel/api/content/book/entity/Chunk.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Getter
@@ -14,6 +15,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @NoArgsConstructor
 @AllArgsConstructor
 @Document(collection = "chunks")
+@CompoundIndex(name = "chapter_difficulty_chunk_idx", def = "{'chapterId': 1, 'difficultyLevel': 1, 'chunkNumber': 1}")
 public class Chunk {
     @Id
     private String id;

--- a/src/main/java/com/linglevel/api/content/custom/entity/CustomContentChunk.java
+++ b/src/main/java/com/linglevel/api/content/custom/entity/CustomContentChunk.java
@@ -18,6 +18,10 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Document(collection = "customContentChunks")
+@CompoundIndexes({
+    @CompoundIndex(name = "custom_content_difficulty_chapter_chunk_idx", def = "{'customContentId': 1, 'difficultyLevel': 1, 'chapterNum': 1, 'chunkNum': 1}"),
+    @CompoundIndex(name = "user_deleted_created_idx", def = "{'userId': 1, 'isDeleted': 1, 'createdAt': -1}")
+})
 public class CustomContentChunk {
     
     @Id

--- a/src/main/java/com/linglevel/api/word/entity/Word.java
+++ b/src/main/java/com/linglevel/api/word/entity/Word.java
@@ -23,11 +23,17 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Document(collection = "words")
-@CompoundIndex(
-    name = "word_language_pair_idx",
-    def = "{'word': 1, 'sourceLanguageCode': 1, 'targetLanguageCode': 1}",
-    unique = true
-)
+@CompoundIndexes({
+    @CompoundIndex(
+        name = "word_language_pair_idx",
+        def = "{'word': 1, 'sourceLanguageCode': 1, 'targetLanguageCode': 1}",
+        unique = true
+    ),
+    @CompoundIndex(
+        name = "word_target_language_idx",
+        def = "{'word': 1, 'targetLanguageCode': 1}"
+    )
+})
 public class Word {
     @Id
     private String id;


### PR DESCRIPTION
## Summary
- 콘텐츠의 `chunks` 목록을 불러올 때 부하가 큰 서비스에 맞춰 적절히 인덱싱을 추가했습니다.

## Related Issues
closes #235 