### PR TITLE
Fix: add unique constraint on fcm token

### DIFF
--- a/src/main/java/com/linglevel/api/fcm/entity/FcmToken.java
+++ b/src/main/java/com/linglevel/api/fcm/entity/FcmToken.java
@@ -30,6 +30,7 @@ public class FcmToken {
     private String deviceId;
     
     @NotNull
+    @Indexed(unique = true)
     private String fcmToken;
     
     @NotNull

--- a/src/main/java/com/linglevel/api/fcm/repository/FcmTokenRepository.java
+++ b/src/main/java/com/linglevel/api/fcm/repository/FcmTokenRepository.java
@@ -14,6 +14,8 @@ public interface FcmTokenRepository extends MongoRepository<FcmToken, String> {
 
     Optional<FcmToken> findByFcmToken(String fcmToken);
 
+    Optional<FcmToken> findFirstByFcmToken(String fcmToken);
+
     List<FcmToken> findByUserIdAndIsActive(String userId, Boolean isActive);
 
     List<FcmToken> findByIsActive(Boolean isActive);

--- a/src/main/java/com/linglevel/api/fcm/service/FcmMessagingService.java
+++ b/src/main/java/com/linglevel/api/fcm/service/FcmMessagingService.java
@@ -181,7 +181,11 @@ public class FcmMessagingService {
     private Map<String, String> getTokenToUserIdMap(List<String> fcmTokens) {
         List<FcmToken> tokens = fcmTokenRepository.findAllByFcmTokenIn(fcmTokens);
         return tokens.stream()
-                .collect(Collectors.toMap(FcmToken::getFcmToken, FcmToken::getUserId));
+                .collect(Collectors.toMap(
+                        FcmToken::getFcmToken,
+                        FcmToken::getUserId,
+                        (existing, replacement) -> existing
+                ));
     }
 
     /**
@@ -211,7 +215,7 @@ public class FcmMessagingService {
      * FCM 토큰으로 사용자 ID 조회
      */
     private String getUserIdFromToken(String fcmToken) {
-        Optional<FcmToken> tokenOpt = fcmTokenRepository.findByFcmToken(fcmToken);
+        Optional<FcmToken> tokenOpt = fcmTokenRepository.findFirstByFcmToken(fcmToken);
         return tokenOpt.map(FcmToken::getUserId).orElse(null);
     }
 


### PR DESCRIPTION
## Summary
FCM 토큰은 `기기` + `어플리케이션 인스턴스`에 대한 조합으로 유니크한 아이디를 가지는게 보장되므로 기기 별로 최신 로그인한 계정으로만 알림을 받도록 해야합니다.

## Related Issues
closes #256 