### PR TITLE
Fix: Store FCM messageId as unique campaignId to prevent duplicates

### DIFF
--- a/src/main/java/com/linglevel/api/admin/controller/PushCampaignController.java
+++ b/src/main/java/com/linglevel/api/admin/controller/PushCampaignController.java
@@ -25,8 +25,8 @@ public class PushCampaignController {
 
     @GetMapping
     @Operation(
-            summary = "캠페인 목록 조회",
-            description = "푸시 캠페인 목록을 조회합니다. 기간 필터링이 가능합니다."
+            summary = "캠페인 그룹 목록 조회",
+            description = "푸시 캠페인 그룹 목록을 조회합니다. 기간 필터링이 가능합니다."
     )
     public ResponseEntity<List<PushCampaignSummary>> getCampaigns(
             @RequestParam(required = false)
@@ -37,22 +37,22 @@ public class PushCampaignController {
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
             LocalDateTime endDate) {
 
-        log.debug("Get campaigns request - startDate: {}, endDate: {}", startDate, endDate);
+        log.debug("Get campaign groups request - startDate: {}, endDate: {}", startDate, endDate);
 
         List<PushCampaignSummary> summaries = pushCampaignService.getCampaignSummaries(startDate, endDate);
 
         return ResponseEntity.ok(summaries);
     }
 
-    @GetMapping("/{campaignId}/stats")
+    @GetMapping("/{campaignGroup}/stats")
     @Operation(
-            summary = "캠페인 상세 통계 조회",
-            description = "특정 캠페인의 상세 통계를 조회합니다."
+            summary = "캠페인 그룹 상세 통계 조회",
+            description = "특정 캠페인 그룹의 상세 통계를 조회합니다."
     )
-    public ResponseEntity<PushCampaignStats> getCampaignStats(@PathVariable String campaignId) {
-        log.debug("Get campaign stats request - campaignId: {}", campaignId);
+    public ResponseEntity<PushCampaignStats> getCampaignStats(@PathVariable String campaignGroup) {
+        log.debug("Get campaign group stats request - campaignGroup: {}", campaignGroup);
 
-        PushCampaignStats stats = pushCampaignService.getStats(campaignId);
+        PushCampaignStats stats = pushCampaignService.getStats(campaignGroup);
 
         return ResponseEntity.ok(stats);
     }

--- a/src/main/java/com/linglevel/api/fcm/entity/PushLog.java
+++ b/src/main/java/com/linglevel/api/fcm/entity/PushLog.java
@@ -20,8 +20,11 @@ public class PushLog {
     @Id
     private String id;
 
+    @Indexed(unique = true)
+    private String campaignId;  // 각 메시지의 고유 ID (messageId 역할)
+
     @Indexed
-    private String campaignId;
+    private String campaignGroup;  // 내부 그룹화용 (선택적)
 
     @Indexed
     private String userId;

--- a/src/main/java/com/linglevel/api/fcm/repository/PushLogRepository.java
+++ b/src/main/java/com/linglevel/api/fcm/repository/PushLogRepository.java
@@ -11,11 +11,11 @@ import java.util.Optional;
 @Repository
 public interface PushLogRepository extends MongoRepository<PushLog, String> {
 
-    List<PushLog> findByCampaignId(String campaignId);
+    Optional<PushLog> findByCampaignId(String campaignId);
+
+    List<PushLog> findByCampaignGroup(String campaignGroup);
 
     List<PushLog> findByUserId(String userId);
-
-    Optional<PushLog> findByCampaignIdAndUserId(String campaignId, String userId);
 
     List<PushLog> findBySentAtBetween(LocalDateTime startDate, LocalDateTime endDate);
 }


### PR DESCRIPTION
## Summary
- 알림 식별자를 유니크하지 않았던 `campainId + userId`에서 `campainId(UUID)` 로 개선했습니다.

## Related Issues
closes #274 