### PR TITLE
Fix: Replace deprecated sendAll() with sendEach() for batch FCM messaging

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -2,7 +2,7 @@ name: Dev Deployment
 
 on:
   push:
-    branches: [ develop, feat/streak ]
+    branches: [ develop, fix/fcm-multi-404 ]
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 		exclude group: 'io.swagger.core.v3', module: 'swagger-annotations'
 	}
 	implementation 'software.amazon.awssdk:s3:2.31.78'
-	implementation 'com.google.firebase:firebase-admin:8.1.0'
+	implementation 'com.google.firebase:firebase-admin:9.7.0'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	implementation 'com.sksamuel.scrimage:scrimage-core:4.3.5'
 	implementation 'com.sksamuel.scrimage:scrimage-webp:4.3.5'

--- a/src/main/java/com/linglevel/api/fcm/service/FcmMessagingService.java
+++ b/src/main/java/com/linglevel/api/fcm/service/FcmMessagingService.java
@@ -129,7 +129,7 @@ public class FcmMessagingService {
                 index++;
             }
 
-            BatchResponse response = firebaseMessaging.sendAll(messages);
+            BatchResponse response = firebaseMessaging.sendEach(messages);
             log.info("Batch messages sent to {} tokens - Success: {}, Failed: {} (Analytics: {})",
                      fcmTokens.size(), response.getSuccessCount(), response.getFailureCount(),
                      analyticsLabel != null ? analyticsLabel : "N/A");


### PR DESCRIPTION
closes #273 