### PR TITLE
Fix: change default custom content image description to empty string

### DIFF
--- a/src/main/java/com/linglevel/api/content/custom/service/CustomContentImportService.java
+++ b/src/main/java/com/linglevel/api/content/custom/service/CustomContentImportService.java
@@ -97,7 +97,7 @@ public class CustomContentImportService {
                             .chunkNum(chunkCounter++)
                             .type(ChunkType.IMAGE)
                             .chunkText(customContent.getCoverImageUrl())
-                            .description("Cover Image")
+                            .description("")
                             .build();
                     allChunks.add(coverImageChunk);
                     log.debug("Added cover image chunk for difficulty {} at chapter {}", difficulty, chapterCounter);


### PR DESCRIPTION
## Summary
커스텀 콘텐츠 기본 이미지 설명 빈 문자열로 변경

## Related Issues
closes #286 