### PR TITLE
Fix: Add fallback title for failed content notifications

### DIFF
--- a/src/main/java/com/linglevel/api/content/custom/service/CustomContentWebhookService.java
+++ b/src/main/java/com/linglevel/api/content/custom/service/CustomContentWebhookService.java
@@ -122,10 +122,14 @@ public class CustomContentWebhookService {
                 log.error("Failed to refund ticket for request: {}. Error: {}", request.getRequestId(), ticketE.getMessage());
             }
 
+            String titleForNotification = StringUtils.hasText(contentRequest.getTitle())
+                    ? contentRequest.getTitle()
+                    : "Untitled Content";
+
             notificationService.sendContentFailedNotification(
                     contentRequest.getUserId(),
                     request.getRequestId(),
-                    contentRequest.getTitle(),
+                    titleForNotification,
                     request.getErrorMessage()
             );
 


### PR DESCRIPTION
## Summary
Mock 제목으로 `Untitled Content`를 넣어 FCM Push 알림 발송에 실패하지 않도록 했습니다.

## Related Issues
closes #267