### PR TITLE
Fix: trigger dev deploy workflow from main

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -2,7 +2,7 @@ name: Dev Deployment
 
 on:
   push:
-    branches: [ develop, feat/migrate-on-premise ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
Update the deployment workflow trigger branch.

## Problem
The deployment workflow was still triggered by `develop` and an old temporary branch, even though deployment should be tied to the deployment branch.

## Solution
Change the push trigger in `.github/workflows/dev-deploy.yml` to run only on `main`.

## Changes
- remove `develop` from the deploy workflow trigger branches
- remove `feat/migrate-on-premise` from the deploy workflow trigger branches
- set the workflow to trigger only on `main`

## Example
A push to `main` will trigger the deployment workflow, while pushes to `develop` will no longer trigger it.

## Related Issues
N/A