### PR TITLE
feat(word): harden distributed single-flight with redisson and redis client unification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.redisson:redisson:3.51.0'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation('org.springframework.ai:spring-ai-bedrock-converse-spring-boot-starter') {
 		exclude group: 'io.swagger.core.v3', module: 'swagger-annotations'

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,10 @@ dependencies {
 	implementation 'org.springframework.session:spring-session-core'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation('org.springframework.boot:spring-boot-starter-data-redis') {
+		exclude group: 'io.lettuce', module: 'lettuce-core'
+	}
+	implementation 'redis.clients:jedis'
 	implementation 'org.redisson:redisson:3.51.0'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation('org.springframework.ai:spring-ai-bedrock-converse-spring-boot-starter') {
@@ -50,7 +53,7 @@ dependencies {
 	implementation 'com.sksamuel.scrimage:scrimage-webp:4.3.5'
 	implementation 'com.bucket4j:bucket4j_jdk17-core:8.15.0'
 	implementation 'com.bucket4j:bucket4j_jdk17-redis-common:8.15.0'
-	implementation 'com.bucket4j:bucket4j_jdk17-lettuce:8.15.0'
+	implementation 'com.bucket4j:bucket4j_jdk17-redisson:8.15.0'
 	implementation 'org.jsoup:jsoup:1.17.2'
 	implementation 'com.rometools:rome:2.1.0'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/linglevel/api/common/config/RedisConfig.java
+++ b/src/main/java/com/linglevel/api/common/config/RedisConfig.java
@@ -1,5 +1,8 @@
 package com.linglevel.api.common.config;
 
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -59,5 +62,14 @@ public class RedisConfig {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(redisConnectionFactory);
         return container;
+    }
+
+    @Bean(destroyMethod = "shutdown")
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        String scheme = ssl ? "rediss://" : "redis://";
+        config.useSingleServer()
+                .setAddress(scheme + host + ":" + port);
+        return Redisson.create(config);
     }
 }

--- a/src/main/java/com/linglevel/api/common/config/RedisConfig.java
+++ b/src/main/java/com/linglevel/api/common/config/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -51,5 +52,12 @@ public class RedisConfig {
 
         template.afterPropertiesSet();
         return template;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory redisConnectionFactory) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory);
+        return container;
     }
 }

--- a/src/main/java/com/linglevel/api/common/config/RedisConfig.java
+++ b/src/main/java/com/linglevel/api/common/config/RedisConfig.java
@@ -8,8 +8,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.connection.jedis.JedisClientConfiguration;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
@@ -31,16 +31,16 @@ public class RedisConfig {
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
 
-        LettuceClientConfiguration clientConfig;
+        JedisClientConfiguration clientConfig;
         if (ssl) {
-            clientConfig = LettuceClientConfiguration.builder()
+            clientConfig = JedisClientConfiguration.builder()
                     .useSsl()
                     .build();
         } else {
-            clientConfig = LettuceClientConfiguration.builder().build();
+            clientConfig = JedisClientConfiguration.builder().build();
         }
 
-        return new LettuceConnectionFactory(config, clientConfig);
+        return new JedisConnectionFactory(config, clientConfig);
     }
 
     @Bean

--- a/src/main/java/com/linglevel/api/common/ratelimit/bucket4j/Bucket4jConfig.java
+++ b/src/main/java/com/linglevel/api/common/ratelimit/bucket4j/Bucket4jConfig.java
@@ -1,18 +1,11 @@
 package com.linglevel.api.common.ratelimit.bucket4j;
 
 import io.github.bucket4j.distributed.proxy.ProxyManager;
-import io.github.bucket4j.redis.lettuce.cas.LettuceBasedProxyManager;
-import io.lettuce.core.RedisClient;
-import io.lettuce.core.RedisURI;
-import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.codec.ByteArrayCodec;
-import io.lettuce.core.codec.RedisCodec;
-import io.lettuce.core.codec.StringCodec;
-import org.springframework.beans.factory.annotation.Value;
+import io.github.bucket4j.redis.redisson.Bucket4jRedisson;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.time.Duration;
 
 /**
  * Bucket4j configuration for rate limiting with Redis backend.
@@ -20,32 +13,10 @@ import java.time.Duration;
 @Configuration
 public class Bucket4jConfig {
 
-    @Value("${spring.data.redis.host}")
-    private String host;
-
-    @Value("${spring.data.redis.port}")
-    private int port;
-
-    @Value("${spring.data.redis.ssl.enabled}")
-    private boolean ssl;
-
     @Bean
-    public ProxyManager<String> proxyManager() {
-        RedisURI.Builder uriBuilder = RedisURI.builder()
-                .withHost(host)
-                .withPort(port)
-                .withTimeout(Duration.ofSeconds(10));
-
-        if (ssl) {
-            uriBuilder.withSsl(true);
-        }
-
-        RedisClient redisClient = RedisClient.create(uriBuilder.build());
-        StatefulRedisConnection<String, byte[]> connection = redisClient.connect(
-                RedisCodec.of(StringCodec.UTF8, ByteArrayCodec.INSTANCE)
-        );
-
-        return LettuceBasedProxyManager.builderFor(connection)
+    public ProxyManager<String> proxyManager(RedissonClient redissonClient) {
+        Redisson redisson = (Redisson) redissonClient;
+        return Bucket4jRedisson.casBasedBuilder(redisson.getCommandExecutor())
                 .build();
     }
 }

--- a/src/main/java/com/linglevel/api/word/exception/WordsErrorCode.java
+++ b/src/main/java/com/linglevel/api/word/exception/WordsErrorCode.java
@@ -11,6 +11,7 @@ public enum WordsErrorCode {
     WORD_IS_MEANINGLESS(HttpStatus.BAD_REQUEST, "The word is meaningless."),
     WORD_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "Word already exists."),
     WORD_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "Word not found with id."),
+    WORD_ANALYSIS_TIMEOUT(HttpStatus.SERVICE_UNAVAILABLE, "Word analysis is temporarily delayed. Please try again."),
     INVALID_WORD_FORMAT(HttpStatus.BAD_REQUEST, "Word contains invalid characters (spaces, tabs, newlines, or special characters are not allowed)."),
     WORD_TOO_LONG(HttpStatus.BAD_REQUEST, "Word is too long (maximum 50 characters)."),
     SAME_SOURCE_TARGET_LANGUAGE(HttpStatus.BAD_REQUEST, "Source and target languages cannot be the same.");

--- a/src/main/java/com/linglevel/api/word/service/WordService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordService.java
@@ -50,14 +50,21 @@ public class WordService {
                 log.info("Word '{}' not found for targetLanguage {}, creating new one...",
                     wordVariant.getOriginalForm(), targetLanguage);
 
-                List<WordAnalysisResult> analysisResults = singleFlightCoordinator.execute(
-                        wordVariant.getOriginalForm(),
-                        targetLanguage,
-                        () -> wordAiService.analyzeWord(
-                                wordVariant.getOriginalForm(),
-                                targetLanguage.getCode()
-                        )
-                );
+                List<WordAnalysisResult> analysisResults;
+                try {
+                    analysisResults = singleFlightCoordinator.execute(
+                            wordVariant.getOriginalForm(),
+                            targetLanguage,
+                            () -> wordAiService.analyzeWord(
+                                    wordVariant.getOriginalForm(),
+                                    targetLanguage.getCode()
+                            )
+                    );
+                } catch (WordSingleFlightTimeoutException | WordSingleFlightLeaderFailureException e) {
+                    log.warn("Single-flight temporary failure for originalForm '{}'. Returning timeout error.",
+                            wordVariant.getOriginalForm(), e);
+                    throw new WordsException(WordsErrorCode.WORD_ANALYSIS_TIMEOUT);
+                }
 
                 // Word 생성 및 저장 (빈 결과는 WordAiService에서 예외 발생)
                 Word newWord = convertAnalysisResultToWord(analysisResults.get(0));
@@ -120,8 +127,8 @@ public class WordService {
                     word, invalidWord.getAttemptCount());
             });
 
-        } catch (WordSingleFlightTimeoutException e) {
-            log.warn("Single-flight wait timed out for word '{}'. Keeping invalid-word cache untouched.", word, e);
+        } catch (WordSingleFlightTimeoutException | WordSingleFlightLeaderFailureException e) {
+            log.warn("Single-flight temporary failure for word '{}'. Keeping invalid-word cache untouched.", word, e);
             throw new WordsException(WordsErrorCode.WORD_ANALYSIS_TIMEOUT);
         } catch (Exception e) {
             // AI 호출 실패 또는 무의미한 단어인 경우 InvalidWord로 캐싱

--- a/src/main/java/com/linglevel/api/word/service/WordService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordService.java
@@ -32,6 +32,7 @@ public class WordService {
     private final WordVariantRepository wordVariantRepository;
     private final InvalidWordRepository invalidWordRepository;
     private final WordAiService wordAiService;
+    private final WordSingleFlightRedisCoordinator singleFlightCoordinator;
 
     public WordSearchResponse getOrCreateWords(String userId, String word, LanguageCode targetLanguage) {
         List<WordVariant> wordVariants = getOrCreateWordEntities(word, targetLanguage);
@@ -49,9 +50,13 @@ public class WordService {
                 log.info("Word '{}' not found for targetLanguage {}, creating new one...",
                     wordVariant.getOriginalForm(), targetLanguage);
 
-                List<WordAnalysisResult> analysisResults = wordAiService.analyzeWord(
-                    wordVariant.getOriginalForm(),
-                    targetLanguage.getCode()
+                List<WordAnalysisResult> analysisResults = singleFlightCoordinator.execute(
+                        wordVariant.getOriginalForm(),
+                        targetLanguage,
+                        () -> wordAiService.analyzeWord(
+                                wordVariant.getOriginalForm(),
+                                targetLanguage.getCode()
+                        )
                 );
 
                 // Word 생성 및 저장 (빈 결과는 WordAiService에서 예외 발생)
@@ -102,7 +107,11 @@ public class WordService {
         log.info("Word '{}' not found in database. Calling AI to analyze...", word);
         List<WordAnalysisResult> analysisResults;
         try {
-            analysisResults = wordAiService.analyzeWord(word, targetLanguage.getCode());
+            analysisResults = singleFlightCoordinator.execute(
+                    word,
+                    targetLanguage,
+                    () -> wordAiService.analyzeWord(word, targetLanguage.getCode())
+            );
 
             // AI 호출 성공 시 InvalidWord 캐시에서 제거 (일시적 오류였던 경우 복구)
             cachedInvalidWord.ifPresent(invalidWord -> {

--- a/src/main/java/com/linglevel/api/word/service/WordService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordService.java
@@ -120,6 +120,9 @@ public class WordService {
                     word, invalidWord.getAttemptCount());
             });
 
+        } catch (WordSingleFlightTimeoutException e) {
+            log.warn("Single-flight wait timed out for word '{}'. Keeping invalid-word cache untouched.", word, e);
+            throw new WordsException(WordsErrorCode.WORD_ANALYSIS_TIMEOUT);
         } catch (Exception e) {
             // AI 호출 실패 또는 무의미한 단어인 경우 InvalidWord로 캐싱
             log.warn("AI call failed for word '{}'. Caching as invalid word to prevent retries.", word, e);

--- a/src/main/java/com/linglevel/api/word/service/WordSingleFlightLeaderFailureException.java
+++ b/src/main/java/com/linglevel/api/word/service/WordSingleFlightLeaderFailureException.java
@@ -1,0 +1,8 @@
+package com.linglevel.api.word.service;
+
+public class WordSingleFlightLeaderFailureException extends RuntimeException {
+
+    public WordSingleFlightLeaderFailureException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/linglevel/api/word/service/WordSingleFlightProperties.java
+++ b/src/main/java/com/linglevel/api/word/service/WordSingleFlightProperties.java
@@ -1,0 +1,27 @@
+package com.linglevel.api.word.service;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "word.single-flight")
+public class WordSingleFlightProperties {
+
+    private boolean enabled = true;
+
+    private long lockTtlMs = 20_000;
+
+    private long waitTimeoutMs = 5_000;
+
+    private long resultTtlMs = 60_000;
+
+    private String promptVersion = "v1";
+
+    private String model = "default";
+
+    private String schemaVersion = "v2";
+}

--- a/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
+++ b/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
@@ -135,7 +135,9 @@ public class WordSingleFlightRedisCoordinator {
             return unwrap(finalResult, keys.digest());
         }
 
-        throw new RuntimeException("Timed out waiting single-flight result for key digest=" + keys.digest());
+        throw new WordSingleFlightTimeoutException(
+                "Timed out waiting single-flight result for key digest=" + keys.digest()
+        );
     }
 
     private void publishDone(String channel) {

--- a/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
+++ b/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
@@ -7,10 +7,11 @@ import com.linglevel.api.word.dto.WordAnalysisResult;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.stereotype.Service;
@@ -22,7 +23,6 @@ import java.time.Duration;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Locale;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -40,13 +40,9 @@ public class WordSingleFlightRedisCoordinator {
     private static final String DONE_PREFIX = "sf:word:done";
     private static final String DONE_PATTERN = DONE_PREFIX + ":*";
 
-    private static final DefaultRedisScript<Long> UNLOCK_SCRIPT = new DefaultRedisScript<>(
-            "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
-            Long.class
-    );
-
     private final StringRedisTemplate stringRedisTemplate;
     private final RedisMessageListenerContainer redisMessageListenerContainer;
+    private final RedissonClient redissonClient;
     private final WordSingleFlightProperties properties;
     private final ObjectMapper objectMapper;
 
@@ -74,15 +70,10 @@ public class WordSingleFlightRedisCoordinator {
             return unwrap(cached, keys.digest());
         }
 
-        String lockToken = UUID.randomUUID().toString();
-        Boolean lockAcquired = stringRedisTemplate.opsForValue().setIfAbsent(
-                keys.lockKey(),
-                lockToken,
-                Duration.ofMillis(properties.getLockTtlMs())
-        );
-
-        if (Boolean.TRUE.equals(lockAcquired)) {
-            return executeAsLeader(keys, lockToken, leaderAction);
+        RLock lock = redissonClient.getLock(keys.lockKey());
+        boolean lockAcquired = tryAcquireLeaderLock(lock);
+        if (lockAcquired) {
+            return executeAsLeader(keys, lock, leaderAction);
         }
 
         return waitAsFollower(keys);
@@ -90,7 +81,7 @@ public class WordSingleFlightRedisCoordinator {
 
     private List<WordAnalysisResult> executeAsLeader(
             KeySet keys,
-            String lockToken,
+            RLock lock,
             Supplier<List<WordAnalysisResult>> leaderAction
     ) {
         try {
@@ -103,7 +94,16 @@ public class WordSingleFlightRedisCoordinator {
             publishDone(keys.channel());
             throw e;
         } finally {
-            releaseLock(keys.lockKey(), lockToken);
+            releaseLock(lock, keys.lockKey());
+        }
+    }
+
+    private boolean tryAcquireLeaderLock(RLock lock) {
+        try {
+            return lock.tryLock(0, properties.getLockTtlMs(), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while acquiring single-flight lock", e);
         }
     }
 
@@ -145,9 +145,11 @@ public class WordSingleFlightRedisCoordinator {
         stringRedisTemplate.convertAndSend(channel, "done");
     }
 
-    private void releaseLock(String lockKey, String lockToken) {
+    private void releaseLock(RLock lock, String lockKey) {
         try {
-            stringRedisTemplate.execute(UNLOCK_SCRIPT, List.of(lockKey), lockToken);
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
         } catch (Exception e) {
             log.warn("Failed to release single-flight lock key={}", lockKey, e);
         }

--- a/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
+++ b/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
@@ -1,0 +1,270 @@
+package com.linglevel.api.word.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linglevel.api.i18n.LanguageCode;
+import com.linglevel.api.word.dto.WordAnalysisResult;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WordSingleFlightRedisCoordinator {
+
+    private static final String LOCK_PREFIX = "sf:word:lock";
+    private static final String RESULT_PREFIX = "sf:word:result";
+    private static final String DONE_PREFIX = "sf:word:done";
+    private static final String DONE_PATTERN = DONE_PREFIX + ":*";
+
+    private static final DefaultRedisScript<Long> UNLOCK_SCRIPT = new DefaultRedisScript<>(
+            "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
+            Long.class
+    );
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final RedisMessageListenerContainer redisMessageListenerContainer;
+    private final WordSingleFlightProperties properties;
+    private final ObjectMapper objectMapper;
+
+    private final ConcurrentHashMap<String, CopyOnWriteArrayList<CompletableFuture<Void>>> channelWaiters = new ConcurrentHashMap<>();
+
+    private final MessageListener doneListener = this::onDoneMessage;
+
+    @PostConstruct
+    void subscribeDonePattern() {
+        redisMessageListenerContainer.addMessageListener(doneListener, new PatternTopic(DONE_PATTERN));
+    }
+
+    public List<WordAnalysisResult> execute(
+            String word,
+            LanguageCode targetLanguage,
+            Supplier<List<WordAnalysisResult>> leaderAction
+    ) {
+        if (!properties.isEnabled()) {
+            return leaderAction.get();
+        }
+
+        KeySet keys = buildKeySet(word, targetLanguage);
+        ResultEnvelope cached = readResult(keys.resultKey());
+        if (cached != null) {
+            return unwrap(cached, keys.digest());
+        }
+
+        String lockToken = UUID.randomUUID().toString();
+        Boolean lockAcquired = stringRedisTemplate.opsForValue().setIfAbsent(
+                keys.lockKey(),
+                lockToken,
+                Duration.ofMillis(properties.getLockTtlMs())
+        );
+
+        if (Boolean.TRUE.equals(lockAcquired)) {
+            return executeAsLeader(keys, lockToken, leaderAction);
+        }
+
+        return waitAsFollower(keys);
+    }
+
+    private List<WordAnalysisResult> executeAsLeader(
+            KeySet keys,
+            String lockToken,
+            Supplier<List<WordAnalysisResult>> leaderAction
+    ) {
+        try {
+            List<WordAnalysisResult> result = leaderAction.get();
+            writeResult(keys.resultKey(), ResultEnvelope.success(result));
+            publishDone(keys.channel());
+            return result;
+        } catch (RuntimeException e) {
+            writeResult(keys.resultKey(), ResultEnvelope.failed(e.getMessage()));
+            publishDone(keys.channel());
+            throw e;
+        } finally {
+            releaseLock(keys.lockKey(), lockToken);
+        }
+    }
+
+    private List<WordAnalysisResult> waitAsFollower(KeySet keys) {
+        ResultEnvelope current = readResult(keys.resultKey());
+        if (current != null) {
+            return unwrap(current, keys.digest());
+        }
+
+        CompletableFuture<Void> signal = new CompletableFuture<>();
+        registerWaiter(keys.channel(), signal);
+
+        try {
+            ResultEnvelope afterRegister = readResult(keys.resultKey());
+            if (afterRegister != null) {
+                return unwrap(afterRegister, keys.digest());
+            }
+
+            signal.get(properties.getWaitTimeoutMs(), TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            log.warn("Single-flight wait timed out for key digest={}", keys.digest());
+        } catch (Exception e) {
+            throw new RuntimeException("Single-flight wait interrupted for key digest=" + keys.digest(), e);
+        } finally {
+            unregisterWaiter(keys.channel(), signal);
+        }
+
+        ResultEnvelope finalResult = readResult(keys.resultKey());
+        if (finalResult != null) {
+            return unwrap(finalResult, keys.digest());
+        }
+
+        throw new RuntimeException("Timed out waiting single-flight result for key digest=" + keys.digest());
+    }
+
+    private void publishDone(String channel) {
+        stringRedisTemplate.convertAndSend(channel, "done");
+    }
+
+    private void releaseLock(String lockKey, String lockToken) {
+        try {
+            stringRedisTemplate.execute(UNLOCK_SCRIPT, List.of(lockKey), lockToken);
+        } catch (Exception e) {
+            log.warn("Failed to release single-flight lock key={}", lockKey, e);
+        }
+    }
+
+    private ResultEnvelope readResult(String resultKey) {
+        String raw = stringRedisTemplate.opsForValue().get(resultKey);
+        if (raw == null) {
+            return null;
+        }
+
+        try {
+            return objectMapper.readValue(raw, ResultEnvelope.class);
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to deserialize single-flight result key={}", resultKey, e);
+            return null;
+        }
+    }
+
+    private void writeResult(String resultKey, ResultEnvelope envelope) {
+        try {
+            String raw = objectMapper.writeValueAsString(envelope);
+            stringRedisTemplate.opsForValue().set(
+                    resultKey,
+                    raw,
+                    Duration.ofMillis(properties.getResultTtlMs())
+            );
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize single-flight result", e);
+        }
+    }
+
+    private List<WordAnalysisResult> unwrap(ResultEnvelope envelope, String digest) {
+        if (envelope.success()) {
+            return envelope.results();
+        }
+
+        throw new RuntimeException(
+                "Single-flight leader failed for key digest=" + digest + ": " + envelope.errorMessage()
+        );
+    }
+
+    private void registerWaiter(String channel, CompletableFuture<Void> signal) {
+        channelWaiters.compute(channel, (key, waiters) -> {
+            CopyOnWriteArrayList<CompletableFuture<Void>> values = waiters == null
+                    ? new CopyOnWriteArrayList<>()
+                    : waiters;
+            values.add(signal);
+            return values;
+        });
+    }
+
+    private void unregisterWaiter(String channel, CompletableFuture<Void> signal) {
+        channelWaiters.computeIfPresent(channel, (key, waiters) -> {
+            waiters.remove(signal);
+            return waiters.isEmpty() ? null : waiters;
+        });
+    }
+
+    private void onDoneMessage(Message message, byte[] pattern) {
+        String channel = new String(message.getChannel(), StandardCharsets.UTF_8);
+        List<CompletableFuture<Void>> waiters = channelWaiters.remove(channel);
+        if (waiters == null || waiters.isEmpty()) {
+            return;
+        }
+
+        for (CompletableFuture<Void> waiter : waiters) {
+            waiter.complete(null);
+        }
+    }
+
+    private KeySet buildKeySet(String word, LanguageCode targetLanguage) {
+        String normalizedWord = word.trim().toLowerCase();
+        String canonicalKey = String.join("|",
+                "word=" + normalizedWord,
+                "lang=" + targetLanguage.getCode(),
+                "prompt=" + properties.getPromptVersion(),
+                "model=" + properties.getModel(),
+                "schema=" + properties.getSchemaVersion()
+        );
+
+        String digest = sha256(canonicalKey);
+        String suffix = properties.getSchemaVersion() + ":" + digest;
+
+        return new KeySet(
+                LOCK_PREFIX + ":" + suffix,
+                RESULT_PREFIX + ":" + suffix,
+                DONE_PREFIX + ":" + suffix,
+                digest
+        );
+    }
+
+    private String sha256(String value) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(value.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 is not available", e);
+        }
+    }
+
+    private record KeySet(
+            String lockKey,
+            String resultKey,
+            String channel,
+            String digest
+    ) { }
+
+    private record ResultEnvelope(
+            boolean success,
+            List<WordAnalysisResult> results,
+            String errorMessage
+    ) {
+        static ResultEnvelope success(List<WordAnalysisResult> results) {
+            return new ResultEnvelope(true, results, null);
+        }
+
+        static ResultEnvelope failed(String errorMessage) {
+            return new ResultEnvelope(false, List.of(), errorMessage);
+        }
+    }
+}

--- a/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
+++ b/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
@@ -21,6 +21,7 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -184,7 +185,7 @@ public class WordSingleFlightRedisCoordinator {
             return envelope.results();
         }
 
-        throw new RuntimeException(
+        throw new WordSingleFlightLeaderFailureException(
                 "Single-flight leader failed for key digest=" + digest + ": " + envelope.errorMessage()
         );
     }
@@ -219,7 +220,7 @@ public class WordSingleFlightRedisCoordinator {
     }
 
     private KeySet buildKeySet(String word, LanguageCode targetLanguage) {
-        String normalizedWord = word.trim().toLowerCase();
+        String normalizedWord = word.trim().toLowerCase(Locale.ROOT);
         String canonicalKey = String.join("|",
                 "word=" + normalizedWord,
                 "lang=" + targetLanguage.getCode(),

--- a/src/main/java/com/linglevel/api/word/service/WordSingleFlightTimeoutException.java
+++ b/src/main/java/com/linglevel/api/word/service/WordSingleFlightTimeoutException.java
@@ -1,0 +1,8 @@
+package com.linglevel.api.word.service;
+
+public class WordSingleFlightTimeoutException extends RuntimeException {
+
+    public WordSingleFlightTimeoutException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -51,6 +51,15 @@ firebase.config=${FIREBASE_CONFIG_BASE64}
 # Redis
 spring.data.redis.ssl.enabled=false
 
+# Word single-flight (Redis lock + Pub/Sub + result key fallback)
+word.single-flight.enabled=true
+word.single-flight.lock-ttl-ms=20000
+word.single-flight.wait-timeout-ms=5000
+word.single-flight.result-ttl-ms=60000
+word.single-flight.prompt-version=v1
+word.single-flight.model=${spring.ai.bedrock.converse.chat.options.model:default}
+word.single-flight.schema-version=v2
+
 # AWS S3 (AI Input/Output buckets)
 aws.s3.region=${S3_REGION}
 aws.s3.ai.input.bucket=${S3_AI_INPUT_NAME}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -53,9 +53,9 @@ spring.data.redis.ssl.enabled=false
 
 # Word single-flight (Redis lock + Pub/Sub + result key fallback)
 word.single-flight.enabled=true
-word.single-flight.lock-ttl-ms=20000
-word.single-flight.wait-timeout-ms=5000
-word.single-flight.result-ttl-ms=60000
+word.single-flight.lock-ttl-ms=13000
+word.single-flight.wait-timeout-ms=11000
+word.single-flight.result-ttl-ms=25000
 word.single-flight.prompt-version=v1
 word.single-flight.model=${spring.ai.bedrock.converse.chat.options.model:default}
 word.single-flight.schema-version=v2

--- a/src/test/java/com/linglevel/api/common/filter/RateLimitFilterTest.java
+++ b/src/test/java/com/linglevel/api/common/filter/RateLimitFilterTest.java
@@ -8,19 +8,16 @@ import com.linglevel.api.common.ratelimit.filter.RateLimitFilter;
 import com.linglevel.api.common.ratelimit.filter.RateLimitResolver;
 import com.linglevel.api.user.entity.UserRole;
 import io.github.bucket4j.distributed.proxy.ProxyManager;
-import io.github.bucket4j.redis.lettuce.cas.LettuceBasedProxyManager;
-import io.lettuce.core.RedisClient;
-import io.lettuce.core.RedisURI;
-import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.codec.ByteArrayCodec;
-import io.lettuce.core.codec.RedisCodec;
-import io.lettuce.core.codec.StringCodec;
+import io.github.bucket4j.redis.redisson.Bucket4jRedisson;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -39,8 +36,7 @@ class RateLimitFilterTest extends AbstractRedisTest {
 
     private RateLimitFilter rateLimitFilter;
     private ProxyManager<String> proxyManager;
-    private RedisClient redisClient;
-    private StatefulRedisConnection<String, byte[]> redisConnection;
+    private RedissonClient redissonClient;
     private RateLimitResolver rateLimitResolver;
 
     private HttpServletRequest request;
@@ -57,19 +53,15 @@ class RateLimitFilterTest extends AbstractRedisTest {
         String host = redis.getHost();
         Integer port = redis.getMappedPort(6379);
 
-        RedisURI redisUri = RedisURI.builder()
-                .withHost(host)
-                .withPort(port)
-                .withTimeout(Duration.ofSeconds(10))
-                .build();
-
-        redisClient = RedisClient.create(redisUri);
-        redisConnection = redisClient.connect(
-                RedisCodec.of(StringCodec.UTF8, ByteArrayCodec.INSTANCE)
-        );
+        Config redissonConfig = new Config();
+        redissonConfig.useSingleServer()
+                .setAddress("redis://" + host + ":" + port)
+                .setTimeout((int) Duration.ofSeconds(10).toMillis());
+        Redisson redisson = (Redisson) Redisson.create(redissonConfig);
+        redissonClient = redisson;
 
         // ProxyManager 생성
-        proxyManager = LettuceBasedProxyManager.builderFor(redisConnection).build();
+        proxyManager = Bucket4jRedisson.casBasedBuilder(redisson.getCommandExecutor()).build();
 
         // RateLimitProperties 설정
         RateLimitProperties properties = new RateLimitProperties();
@@ -88,7 +80,7 @@ class RateLimitFilterTest extends AbstractRedisTest {
         rateLimitFilter = new RateLimitFilter(proxyManager, properties, rateLimitResolver);
 
         // Redis 플러시
-        redisConnection.sync().flushall();
+        redissonClient.getKeys().flushall();
 
         // Clear SecurityContext before each test
         SecurityContextHolder.clearContext();
@@ -106,11 +98,8 @@ class RateLimitFilterTest extends AbstractRedisTest {
 
     @AfterEach
     void tearDown() {
-        if (redisConnection != null) {
-            redisConnection.close();
-        }
-        if (redisClient != null) {
-            redisClient.shutdown();
+        if (redissonClient != null) {
+            redissonClient.shutdown();
         }
         SecurityContextHolder.clearContext();
     }

--- a/src/test/java/com/linglevel/api/streak/service/ReadingSessionServiceTest.java
+++ b/src/test/java/com/linglevel/api/streak/service/ReadingSessionServiceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -31,7 +31,7 @@ class ReadingSessionServiceTest extends AbstractRedisTest {
         config.setHostName(getRedisContainer().getHost());
         config.setPort(getRedisContainer().getMappedPort(6379));
 
-        LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(config);
+        JedisConnectionFactory connectionFactory = new JedisConnectionFactory(config);
         connectionFactory.afterPropertiesSet();
 
         // RedisTemplate 설정

--- a/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
@@ -276,4 +276,67 @@ class WordServiceTest {
 
         verify(invalidWordRepository, never()).save(any());
     }
+
+    @Test
+    @DisplayName("translation-miss 경로의 single-flight timeout도 WORD_ANALYSIS_TIMEOUT으로 변환")
+    void getOrCreateWords_translationMissTimeout_returnsDomainTimeoutError() {
+        String inputWord = "ran";
+        String originalForm = "run";
+
+        WordVariant wordVariant = WordVariant.builder()
+                .word(inputWord)
+                .originalForm(originalForm)
+                .variantTypes(List.of(VariantType.PAST_TENSE))
+                .build();
+
+        when(wordVariantRepository.findAllByWord(inputWord)).thenReturn(List.of(wordVariant));
+        when(wordRepository.findByWordAndTargetLanguageCode(originalForm, LanguageCode.KO))
+                .thenReturn(Optional.empty());
+        when(singleFlightCoordinator.execute(eq(originalForm), eq(LanguageCode.KO), any()))
+                .thenThrow(new WordSingleFlightTimeoutException("Timed out waiting single-flight result"));
+
+        assertThatThrownBy(() -> wordService.getOrCreateWords(userId, inputWord, LanguageCode.KO))
+                .isInstanceOf(WordsException.class)
+                .hasMessageContaining("temporarily delayed");
+    }
+
+    @Test
+    @DisplayName("single-flight leader 실패 재생은 invalid 캐시를 증가시키지 않고 timeout 에러를 반환")
+    void getOrCreateWords_singleFlightLeaderFailure_doesNotCacheInvalidWord() {
+        String word = "resilience";
+
+        when(wordVariantRepository.findAllByWord(word)).thenReturn(List.of());
+        when(invalidWordRepository.findByWord(word)).thenReturn(Optional.empty());
+        when(singleFlightCoordinator.execute(eq(word), eq(LanguageCode.KO), any()))
+                .thenThrow(new WordSingleFlightLeaderFailureException("Single-flight leader failed"));
+
+        assertThatThrownBy(() -> wordService.getOrCreateWords(userId, word, LanguageCode.KO))
+                .isInstanceOf(WordsException.class)
+                .hasMessageContaining("temporarily delayed");
+
+        verify(invalidWordRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("translation-miss 경로의 leader 실패 재생도 WORD_ANALYSIS_TIMEOUT으로 변환")
+    void getOrCreateWords_translationMissLeaderFailure_returnsDomainTimeoutError() {
+        String inputWord = "ran";
+        String originalForm = "run";
+
+        WordVariant wordVariant = WordVariant.builder()
+                .word(inputWord)
+                .originalForm(originalForm)
+                .variantTypes(List.of(VariantType.PAST_TENSE))
+                .build();
+
+        when(wordVariantRepository.findAllByWord(inputWord)).thenReturn(List.of(wordVariant));
+        when(wordRepository.findByWordAndTargetLanguageCode(originalForm, LanguageCode.KO))
+                .thenReturn(Optional.empty());
+        when(singleFlightCoordinator.execute(eq(originalForm), eq(LanguageCode.KO), any()))
+                .thenThrow(new WordSingleFlightLeaderFailureException("Single-flight leader failed"));
+
+        assertThatThrownBy(() -> wordService.getOrCreateWords(userId, inputWord, LanguageCode.KO))
+                .isInstanceOf(WordsException.class)
+                .hasMessageContaining("temporarily delayed");
+    }
 }

--- a/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -46,6 +47,9 @@ class WordServiceTest {
     @Mock
     private InvalidWordRepository invalidWordRepository;
 
+    @Mock
+    private WordSingleFlightRedisCoordinator singleFlightCoordinator;
+
     @InjectMocks
     private WordService wordService;
 
@@ -54,6 +58,13 @@ class WordServiceTest {
 
     @BeforeEach
     void setUp() {
+        lenient().when(singleFlightCoordinator.execute(anyString(), any(LanguageCode.class), any()))
+                .thenAnswer(invocation -> {
+                    @SuppressWarnings("unchecked")
+                    Supplier<List<WordAnalysisResult>> supplier = invocation.getArgument(2);
+                    return supplier.get();
+                });
+
         // 샘플 Word 데이터 생성
         sampleWord = Word.builder()
                 .id("word-123")
@@ -247,4 +258,3 @@ class WordServiceTest {
         assertThat(response.getResults().get(0).getBookmarked()).isTrue();
     }
 }
-

--- a/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
@@ -5,6 +5,7 @@ import com.linglevel.api.i18n.LanguageCode;
 import com.linglevel.api.word.dto.*;
 import com.linglevel.api.word.entity.Word;
 import com.linglevel.api.word.entity.WordVariant;
+import com.linglevel.api.word.exception.WordsException;
 import com.linglevel.api.word.repository.InvalidWordRepository;
 import com.linglevel.api.word.repository.WordRepository;
 import com.linglevel.api.word.repository.WordVariantRepository;
@@ -21,6 +22,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -256,5 +258,22 @@ class WordServiceTest {
 
         // then
         assertThat(response.getResults().get(0).getBookmarked()).isTrue();
+    }
+
+    @Test
+    @DisplayName("single-flight timeout은 무의미 단어로 캐시하지 않고 별도 에러를 반환")
+    void getOrCreateWords_singleFlightTimeout_doesNotCacheInvalidWord() {
+        String word = "resilience";
+
+        when(wordVariantRepository.findAllByWord(word)).thenReturn(List.of());
+        when(invalidWordRepository.findByWord(word)).thenReturn(Optional.empty());
+        when(singleFlightCoordinator.execute(eq(word), eq(LanguageCode.KO), any()))
+                .thenThrow(new WordSingleFlightTimeoutException("Timed out waiting single-flight result"));
+
+        assertThatThrownBy(() -> wordService.getOrCreateWords(userId, word, LanguageCode.KO))
+                .isInstanceOf(WordsException.class)
+                .hasMessageContaining("temporarily delayed");
+
+        verify(invalidWordRepository, never()).save(any());
     }
 }

--- a/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorIntegrationTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorIntegrationTest.java
@@ -1,0 +1,196 @@
+package com.linglevel.api.word.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linglevel.api.common.AbstractRedisTest;
+import com.linglevel.api.i18n.LanguageCode;
+import com.linglevel.api.word.dto.WordAnalysisResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.containers.GenericContainer;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WordSingleFlightRedisCoordinatorIntegrationTest extends AbstractRedisTest {
+
+    private CoordinatorFixture nodeA;
+    private CoordinatorFixture nodeB;
+
+    @BeforeEach
+    void setUp() {
+        nodeA = createNode("test-model-a", 3_000);
+        nodeB = createNode("test-model-a", 3_000);
+        flushAll(nodeA.template);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (nodeA != null) {
+            nodeA.close();
+        }
+        if (nodeB != null) {
+            nodeB.close();
+        }
+    }
+
+    @Test
+    @DisplayName("실제 Redis에서 두 인스턴스 동시 요청 시 AI 호출은 1회만 수행된다")
+    void deduplicatesAcrossTwoCoordinatorsUsingRealRedis() throws Exception {
+        AtomicInteger aiCalls = new AtomicInteger();
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch start = new CountDownLatch(1);
+
+        try {
+            Future<List<WordAnalysisResult>> f1 = executor.submit(() -> {
+                start.await(1, TimeUnit.SECONDS);
+                return nodeA.coordinator.execute("run", LanguageCode.KO, () -> {
+                    aiCalls.incrementAndGet();
+                    sleep(250);
+                    return List.of(sample("run"));
+                });
+            });
+
+            Future<List<WordAnalysisResult>> f2 = executor.submit(() -> {
+                start.await(1, TimeUnit.SECONDS);
+                return nodeB.coordinator.execute("run", LanguageCode.KO, () -> {
+                    aiCalls.incrementAndGet();
+                    return List.of(sample("run"));
+                });
+            });
+
+            start.countDown();
+
+            List<WordAnalysisResult> r1 = f1.get(5, TimeUnit.SECONDS);
+            List<WordAnalysisResult> r2 = f2.get(5, TimeUnit.SECONDS);
+
+            assertThat(r1).hasSize(1);
+            assertThat(r2).hasSize(1);
+            assertThat(r1.get(0).getOriginalForm()).isEqualTo("run");
+            assertThat(r2.get(0).getOriginalForm()).isEqualTo("run");
+            assertThat(aiCalls.get()).isEqualTo(1);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisplayName("leader 실패는 실제 Redis resultKey를 통해 follower에도 동일 전파된다")
+    void propagatesLeaderFailureAcrossTwoCoordinatorsUsingRealRedis() {
+        RuntimeException leaderFailure = new RuntimeException("bedrock unavailable");
+        AtomicInteger aiCalls = new AtomicInteger();
+
+        assertThatThrownBy(() ->
+                nodeA.coordinator.execute("left", LanguageCode.KO, () -> {
+                    aiCalls.incrementAndGet();
+                    throw leaderFailure;
+                })
+        ).isInstanceOf(RuntimeException.class)
+         .hasMessageContaining("bedrock unavailable");
+
+        assertThatThrownBy(() ->
+                nodeB.coordinator.execute("left", LanguageCode.KO, () -> {
+                    aiCalls.incrementAndGet();
+                    return List.of(sample("left"));
+                })
+        ).isInstanceOf(RuntimeException.class)
+         .hasMessageContaining("Single-flight leader failed");
+
+        assertThat(aiCalls.get()).isEqualTo(1);
+    }
+
+    private CoordinatorFixture createNode(String model, long waitTimeoutMs) {
+        GenericContainer<?> redis = getRedisContainer();
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(redis.getHost(), redis.getMappedPort(6379));
+
+        LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(config);
+        connectionFactory.afterPropertiesSet();
+
+        StringRedisTemplate template = new StringRedisTemplate();
+        template.setConnectionFactory(connectionFactory);
+        template.afterPropertiesSet();
+
+        RedisMessageListenerContainer listenerContainer = new RedisMessageListenerContainer();
+        listenerContainer.setConnectionFactory(connectionFactory);
+        listenerContainer.afterPropertiesSet();
+        listenerContainer.start();
+
+        WordSingleFlightProperties properties = new WordSingleFlightProperties();
+        properties.setEnabled(true);
+        properties.setLockTtlMs(5_000);
+        properties.setWaitTimeoutMs(waitTimeoutMs);
+        properties.setResultTtlMs(30_000);
+        properties.setPromptVersion("v1");
+        properties.setModel(model);
+        properties.setSchemaVersion("v2");
+
+        WordSingleFlightRedisCoordinator coordinator = new WordSingleFlightRedisCoordinator(
+                template,
+                listenerContainer,
+                properties,
+                new ObjectMapper()
+        );
+        ReflectionTestUtils.invokeMethod(coordinator, "subscribeDonePattern");
+
+        return new CoordinatorFixture(connectionFactory, template, listenerContainer, coordinator);
+    }
+
+    private void flushAll(StringRedisTemplate template) {
+        RedisConnection connection = template.getConnectionFactory().getConnection();
+        try {
+            connection.serverCommands().flushAll();
+        } finally {
+            connection.close();
+        }
+    }
+
+    private WordAnalysisResult sample(String originalForm) {
+        return WordAnalysisResult.builder()
+                .originalForm(originalForm)
+                .sourceLanguageCode(LanguageCode.EN)
+                .targetLanguageCode(LanguageCode.KO)
+                .build();
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private record CoordinatorFixture(
+            LettuceConnectionFactory connectionFactory,
+            StringRedisTemplate template,
+            RedisMessageListenerContainer listenerContainer,
+            WordSingleFlightRedisCoordinator coordinator
+    ) {
+        void close() {
+            try {
+                listenerContainer.stop();
+            } catch (Exception ignored) {
+            }
+            try {
+                connectionFactory.destroy();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+}

--- a/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorIntegrationTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorIntegrationTest.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linglevel.api.common.AbstractRedisTest;
 import com.linglevel.api.i18n.LanguageCode;
 import com.linglevel.api.word.dto.WordAnalysisResult;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -130,6 +133,11 @@ class WordSingleFlightRedisCoordinatorIntegrationTest extends AbstractRedisTest 
         listenerContainer.afterPropertiesSet();
         listenerContainer.start();
 
+        Config redissonConfig = new Config();
+        redissonConfig.useSingleServer()
+                .setAddress("redis://" + redis.getHost() + ":" + redis.getMappedPort(6379));
+        RedissonClient redissonClient = Redisson.create(redissonConfig);
+
         WordSingleFlightProperties properties = new WordSingleFlightProperties();
         properties.setEnabled(true);
         properties.setLockTtlMs(5_000);
@@ -142,12 +150,13 @@ class WordSingleFlightRedisCoordinatorIntegrationTest extends AbstractRedisTest 
         WordSingleFlightRedisCoordinator coordinator = new WordSingleFlightRedisCoordinator(
                 template,
                 listenerContainer,
+                redissonClient,
                 properties,
                 new ObjectMapper()
         );
         ReflectionTestUtils.invokeMethod(coordinator, "subscribeDonePattern");
 
-        return new CoordinatorFixture(connectionFactory, template, listenerContainer, coordinator);
+        return new CoordinatorFixture(connectionFactory, template, listenerContainer, redissonClient, coordinator);
     }
 
     private void flushAll(StringRedisTemplate template) {
@@ -180,11 +189,16 @@ class WordSingleFlightRedisCoordinatorIntegrationTest extends AbstractRedisTest 
             LettuceConnectionFactory connectionFactory,
             StringRedisTemplate template,
             RedisMessageListenerContainer listenerContainer,
+            RedissonClient redissonClient,
             WordSingleFlightRedisCoordinator coordinator
     ) {
         void close() {
             try {
                 listenerContainer.stop();
+            } catch (Exception ignored) {
+            }
+            try {
+                redissonClient.shutdown();
             } catch (Exception ignored) {
             }
             try {

--- a/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorIntegrationTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorIntegrationTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.RedisConnection;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -121,7 +121,7 @@ class WordSingleFlightRedisCoordinatorIntegrationTest extends AbstractRedisTest 
         GenericContainer<?> redis = getRedisContainer();
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(redis.getHost(), redis.getMappedPort(6379));
 
-        LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(config);
+        JedisConnectionFactory connectionFactory = new JedisConnectionFactory(config);
         connectionFactory.afterPropertiesSet();
 
         StringRedisTemplate template = new StringRedisTemplate();
@@ -186,7 +186,7 @@ class WordSingleFlightRedisCoordinatorIntegrationTest extends AbstractRedisTest 
     }
 
     private record CoordinatorFixture(
-            LettuceConnectionFactory connectionFactory,
+            JedisConnectionFactory connectionFactory,
             StringRedisTemplate template,
             RedisMessageListenerContainer listenerContainer,
             RedissonClient redissonClient,

--- a/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
@@ -1,0 +1,226 @@
+package com.linglevel.api.word.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linglevel.api.i18n.LanguageCode;
+import com.linglevel.api.word.dto.WordAnalysisResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class WordSingleFlightRedisCoordinatorTest {
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private RedisMessageListenerContainer redisMessageListenerContainer;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final Map<String, String> redisStore = new ConcurrentHashMap<>();
+
+    private WordSingleFlightProperties properties;
+    private WordSingleFlightRedisCoordinator coordinator;
+
+    @BeforeEach
+    void setUp() {
+        properties = new WordSingleFlightProperties();
+        properties.setEnabled(true);
+        properties.setLockTtlMs(1_000);
+        properties.setWaitTimeoutMs(120);
+        properties.setResultTtlMs(2_000);
+        properties.setPromptVersion("v1");
+        properties.setModel("test-model");
+        properties.setSchemaVersion("v2");
+
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        doAnswer(invocation -> redisStore.get(invocation.getArgument(0)))
+                .when(valueOperations).get(anyString());
+
+        doAnswer(invocation -> {
+            String key = invocation.getArgument(0);
+            String value = invocation.getArgument(1);
+            if (redisStore.containsKey(key)) {
+                return Boolean.FALSE;
+            }
+            redisStore.put(key, value);
+            return Boolean.TRUE;
+        }).when(valueOperations).setIfAbsent(anyString(), anyString(), any(Duration.class));
+
+        doAnswer(invocation -> {
+            String key = invocation.getArgument(0);
+            String value = invocation.getArgument(1);
+            redisStore.put(key, value);
+            return null;
+        }).when(valueOperations).set(anyString(), anyString(), any(Duration.class));
+
+        coordinator = new WordSingleFlightRedisCoordinator(
+                stringRedisTemplate,
+                redisMessageListenerContainer,
+                properties,
+                objectMapper
+        );
+        ReflectionTestUtils.invokeMethod(coordinator, "subscribeDonePattern");
+    }
+
+    @Test
+    @DisplayName("동일 키 동시 요청은 leader action을 한 번만 실행한다")
+    void execute_deduplicatesConcurrentRequests() throws Exception {
+        AtomicInteger aiCalls = new AtomicInteger();
+        WordAnalysisResult sample = WordAnalysisResult.builder()
+                .originalForm("run")
+                .targetLanguageCode(LanguageCode.KO)
+                .sourceLanguageCode(LanguageCode.EN)
+                .build();
+
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<List<WordAnalysisResult>> f1 = executor.submit(() -> {
+                start.await(1, TimeUnit.SECONDS);
+                return coordinator.execute("run", LanguageCode.KO, () -> {
+                    aiCalls.incrementAndGet();
+                    sleep(50);
+                    return List.of(sample);
+                });
+            });
+
+            Future<List<WordAnalysisResult>> f2 = executor.submit(() -> {
+                start.await(1, TimeUnit.SECONDS);
+                return coordinator.execute("run", LanguageCode.KO, () -> {
+                    aiCalls.incrementAndGet();
+                    return List.of(sample);
+                });
+            });
+
+            start.countDown();
+
+            List<WordAnalysisResult> r1 = f1.get(2, TimeUnit.SECONDS);
+            List<WordAnalysisResult> r2 = f2.get(2, TimeUnit.SECONDS);
+
+            assertThat(r1).hasSize(1);
+            assertThat(r2).hasSize(1);
+            assertThat(aiCalls.get()).isEqualTo(1);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisplayName("알림 유실 상황에서도 timeout 이후 resultKey 재조회로 결과를 반환한다")
+    void execute_fallbacksToResultKeyAfterTimeout() {
+        redisStore.clear();
+
+        WordAnalysisResult sample = WordAnalysisResult.builder()
+                .originalForm("book")
+                .targetLanguageCode(LanguageCode.KO)
+                .sourceLanguageCode(LanguageCode.EN)
+                .build();
+
+        String serialized = toSuccessEnvelopeJson(sample);
+        AtomicInteger getCalls = new AtomicInteger();
+
+        doAnswer(invocation -> {
+            // execute() 내부 readResult 호출 순서:
+            // 1) 캐시 확인 -> null
+            // 2) follower 진입 후 pre-check -> null
+            // 3) register 후 post-check -> null
+            // 4) timeout 후 final-check -> success
+            int n = getCalls.incrementAndGet();
+            if (n < 4) {
+                return null;
+            }
+            return serialized;
+        }).when(valueOperations).get(anyString());
+
+        doAnswer(invocation -> Boolean.FALSE)
+                .when(valueOperations).setIfAbsent(anyString(), anyString(), any(Duration.class));
+
+        List<WordAnalysisResult> result = coordinator.execute(
+                "book",
+                LanguageCode.KO,
+                () -> {
+                    throw new IllegalStateException("follower path should not run leader action");
+                }
+        );
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getOriginalForm()).isEqualTo("book");
+        assertThat(getCalls.get()).isGreaterThanOrEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("leader 실패 결과는 같은 키 요청에 동일하게 전파된다")
+    void execute_propagatesLeaderFailure() {
+        RuntimeException failure = new RuntimeException("bedrock failure");
+
+        assertThatThrownBy(() ->
+                coordinator.execute("left", LanguageCode.KO, () -> {
+                    throw failure;
+                })
+        ).isInstanceOf(RuntimeException.class)
+         .hasMessageContaining("bedrock failure");
+
+        assertThatThrownBy(() ->
+                coordinator.execute("left", LanguageCode.KO, ArrayList::new)
+        ).isInstanceOf(RuntimeException.class)
+         .hasMessageContaining("Single-flight leader failed");
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String toSuccessEnvelopeJson(WordAnalysisResult result) {
+        try {
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("success", true);
+            payload.put("results", List.of(result));
+            payload.put("errorMessage", null);
+            return objectMapper.writeValueAsString(payload);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
@@ -3,6 +3,8 @@ package com.linglevel.api.word.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linglevel.api.i18n.LanguageCode;
 import com.linglevel.api.word.dto.WordAnalysisResult;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,7 +34,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
@@ -46,6 +47,12 @@ class WordSingleFlightRedisCoordinatorTest {
 
     @Mock
     private RedisMessageListenerContainer redisMessageListenerContainer;
+
+    @Mock
+    private RedissonClient redissonClient;
+
+    @Mock
+    private RLock redissonLock;
 
     @Mock
     private ValueOperations<String, String> valueOperations;
@@ -68,19 +75,11 @@ class WordSingleFlightRedisCoordinatorTest {
         properties.setSchemaVersion("v2");
 
         when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(redissonClient.getLock(anyString())).thenReturn(redissonLock);
+        when(redissonLock.isHeldByCurrentThread()).thenReturn(true);
 
         doAnswer(invocation -> redisStore.get(invocation.getArgument(0)))
                 .when(valueOperations).get(anyString());
-
-        doAnswer(invocation -> {
-            String key = invocation.getArgument(0);
-            String value = invocation.getArgument(1);
-            if (redisStore.containsKey(key)) {
-                return Boolean.FALSE;
-            }
-            redisStore.put(key, value);
-            return Boolean.TRUE;
-        }).when(valueOperations).setIfAbsent(anyString(), anyString(), any(Duration.class));
 
         doAnswer(invocation -> {
             String key = invocation.getArgument(0);
@@ -92,6 +91,7 @@ class WordSingleFlightRedisCoordinatorTest {
         coordinator = new WordSingleFlightRedisCoordinator(
                 stringRedisTemplate,
                 redisMessageListenerContainer,
+                redissonClient,
                 properties,
                 objectMapper
         );
@@ -101,6 +101,8 @@ class WordSingleFlightRedisCoordinatorTest {
     @Test
     @DisplayName("동일 키 동시 요청은 leader action을 한 번만 실행한다")
     void execute_deduplicatesConcurrentRequests() throws Exception {
+        stubTryLock(true, false);
+
         AtomicInteger aiCalls = new AtomicInteger();
         WordAnalysisResult sample = WordAnalysisResult.builder()
                 .originalForm("run")
@@ -145,6 +147,8 @@ class WordSingleFlightRedisCoordinatorTest {
     @Test
     @DisplayName("알림 유실 상황에서도 timeout 이후 resultKey 재조회로 결과를 반환한다")
     void execute_fallbacksToResultKeyAfterTimeout() {
+        stubTryLock(false);
+
         redisStore.clear();
 
         WordAnalysisResult sample = WordAnalysisResult.builder()
@@ -169,9 +173,6 @@ class WordSingleFlightRedisCoordinatorTest {
             return serialized;
         }).when(valueOperations).get(anyString());
 
-        doAnswer(invocation -> Boolean.FALSE)
-                .when(valueOperations).setIfAbsent(anyString(), anyString(), any(Duration.class));
-
         List<WordAnalysisResult> result = coordinator.execute(
                 "book",
                 LanguageCode.KO,
@@ -188,6 +189,8 @@ class WordSingleFlightRedisCoordinatorTest {
     @Test
     @DisplayName("leader 실패 결과는 같은 키 요청에 동일하게 전파된다")
     void execute_propagatesLeaderFailure() {
+        stubTryLock(true, false);
+
         RuntimeException failure = new RuntimeException("bedrock failure");
 
         assertThatThrownBy(() ->
@@ -220,6 +223,21 @@ class WordSingleFlightRedisCoordinatorTest {
             payload.put("errorMessage", null);
             return objectMapper.writeValueAsString(payload);
         } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void stubTryLock(boolean first, boolean... others) {
+        Boolean[] sequence = new Boolean[others.length + 1];
+        sequence[0] = first;
+        for (int i = 0; i < others.length; i++) {
+            sequence[i + 1] = others[i];
+        }
+
+        try {
+            when(redissonLock.tryLock(0, properties.getLockTtlMs(), TimeUnit.MILLISECONDS))
+                    .thenReturn(sequence[0], java.util.Arrays.copyOfRange(sequence, 1, sequence.length));
+        } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
## Summary
word 동적 AI 생성 경로의 single-flight 중복 완화 구조를 추가/안정화하고, Redis 락 및 Redis 클라이언트 경로를 Redisson 중심으로 정리했습니다.

## Problem
- 멀티 인스턴스 환경에서 동일 단어 요청이 동시에 들어오면 AI 호출이 중복될 수 있음
- follower 대기/leader 실패 처리 정책이 부족해 timeout/실패 전파가 불명확함
- Lettuce/Redisson 혼용으로 Redis 경로가 분산되어 운영 복잡도가 높음

## Solution
- Redis 기반 single-flight coordinator를 도입해 leader/follower 흐름으로 중복 호출을 완화
- leader 실패/대기 timeout을 명시적 예외로 분리해 WordService에서 처리
- 락 경로를 Redisson으로 전환하고 Redis 공통 경로(Bucket4j 포함)를 Redisson+Jedis 기반으로 통일
- single-flight 관련 TTL 기본값을 운영 관점에서 재조정

## Changes
- `WordSingleFlightRedisCoordinator`, `WordSingleFlightProperties`, timeout/failure 예외 추가
- `WordService`에 single-flight 실행 및 예외 매핑 반영
- `RedisConfig`에 `RedissonClient` 추가, `JedisConnectionFactory` 기반으로 정리
- `Bucket4jConfig`를 Redisson CAS 기반 proxy manager로 전환
- `build.gradle`에서 Lettuce 의존 제거 및 Redisson/Jedis 의존 정리
- 단위/통합 테스트 추가 및 관련 테스트 코드 마이그레이션

## Example
- 동일 `(word, targetLanguage, promptVersion, model, schemaVersion)` 키 요청이 동시 유입되면
  - 1개 요청만 leader로 AI 호출 실행
  - 나머지는 follower로 결과 key 또는 pub/sub done 신호를 대기 후 동일 결과를 재사용

## Related Issues
- 미정