### PR TITLE
fix(word): patch single-flight lock expiry and follower error semantics

### DIFF
--- a/src/main/java/com/linglevel/api/word/exception/WordsException.java
+++ b/src/main/java/com/linglevel/api/word/exception/WordsException.java
@@ -6,9 +6,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 public class WordsException extends RuntimeException {
     private final HttpStatus status;
+    private final WordsErrorCode errorCode;
 
     public WordsException(WordsErrorCode errorCode) {
         super(errorCode.getMessage());
+        this.errorCode = errorCode;
         this.status = errorCode.getStatus();
     }
 }

--- a/src/main/java/com/linglevel/api/word/service/WordService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordService.java
@@ -60,10 +60,12 @@ public class WordService {
                                     targetLanguage.getCode()
                             )
                     );
-                } catch (WordSingleFlightTimeoutException | WordSingleFlightLeaderFailureException e) {
+                } catch (WordSingleFlightTimeoutException e) {
                     log.warn("Single-flight temporary failure for originalForm '{}'. Returning timeout error.",
                             wordVariant.getOriginalForm(), e);
                     throw new WordsException(WordsErrorCode.WORD_ANALYSIS_TIMEOUT);
+                } catch (WordSingleFlightLeaderFailureException e) {
+                    throw mapLeaderFailure(wordVariant.getOriginalForm(), e, false);
                 }
 
                 // Word 생성 및 저장 (빈 결과는 WordAiService에서 예외 발생)
@@ -127,9 +129,11 @@ public class WordService {
                     word, invalidWord.getAttemptCount());
             });
 
-        } catch (WordSingleFlightTimeoutException | WordSingleFlightLeaderFailureException e) {
+        } catch (WordSingleFlightTimeoutException e) {
             log.warn("Single-flight temporary failure for word '{}'. Keeping invalid-word cache untouched.", word, e);
             throw new WordsException(WordsErrorCode.WORD_ANALYSIS_TIMEOUT);
+        } catch (WordSingleFlightLeaderFailureException e) {
+            throw mapLeaderFailure(word, e, true);
         } catch (Exception e) {
             // AI 호출 실패 또는 무의미한 단어인 경우 InvalidWord로 캐싱
             log.warn("AI call failed for word '{}'. Caching as invalid word to prevent retries.", word, e);
@@ -346,6 +350,19 @@ public class WordService {
                 .bookmarked(isBookmarked)
                 .isEssential(word.getIsEssential())
                 .build();
+    }
+
+    private WordsException mapLeaderFailure(String word, WordSingleFlightLeaderFailureException e, boolean cacheInvalidWord) {
+        if (e.getLeaderErrorCode() == WordsErrorCode.WORD_IS_MEANINGLESS) {
+            log.warn("Single-flight leader classified word '{}' as meaningless.", word, e);
+            if (cacheInvalidWord) {
+                saveInvalidWord(word);
+            }
+            return new WordsException(WordsErrorCode.WORD_IS_MEANINGLESS);
+        }
+
+        log.warn("Single-flight temporary failure for word '{}'. Keeping invalid-word cache untouched.", word, e);
+        return new WordsException(WordsErrorCode.WORD_ANALYSIS_TIMEOUT);
     }
 
     /**

--- a/src/main/java/com/linglevel/api/word/service/WordService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordService.java
@@ -91,7 +91,7 @@ public class WordService {
                 .build();
     }
 
-    @Transactional
+    @Transactional(noRollbackFor = WordsException.class)
     public List<WordVariant> getOrCreateWordEntities(String word, LanguageCode targetLanguage) {
         // 1. WordVariant에서 검색 (변형 형태인지 확인)
         List<WordVariant> existingVariants = wordVariantRepository.findAllByWord(word);

--- a/src/main/java/com/linglevel/api/word/service/WordSingleFlightLeaderFailureException.java
+++ b/src/main/java/com/linglevel/api/word/service/WordSingleFlightLeaderFailureException.java
@@ -1,8 +1,19 @@
 package com.linglevel.api.word.service;
 
+import com.linglevel.api.word.exception.WordsErrorCode;
+import lombok.Getter;
+
+@Getter
 public class WordSingleFlightLeaderFailureException extends RuntimeException {
 
+    private final WordsErrorCode leaderErrorCode;
+
     public WordSingleFlightLeaderFailureException(String message) {
+        this(message, null);
+    }
+
+    public WordSingleFlightLeaderFailureException(String message, WordsErrorCode leaderErrorCode) {
         super(message);
+        this.leaderErrorCode = leaderErrorCode;
     }
 }

--- a/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
+++ b/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linglevel.api.i18n.LanguageCode;
 import com.linglevel.api.word.dto.WordAnalysisResult;
+import com.linglevel.api.word.exception.WordsErrorCode;
+import com.linglevel.api.word.exception.WordsException;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -90,7 +92,7 @@ public class WordSingleFlightRedisCoordinator {
             publishDone(keys.channel());
             return result;
         } catch (RuntimeException e) {
-            writeResult(keys.resultKey(), ResultEnvelope.failed(e.getMessage()));
+            writeResult(keys.resultKey(), ResultEnvelope.failed(e.getMessage(), resolveLeaderErrorCode(e)));
             publishDone(keys.channel());
             throw e;
         } finally {
@@ -189,9 +191,35 @@ public class WordSingleFlightRedisCoordinator {
             return envelope.results();
         }
 
+        WordsErrorCodㅌ8e leaderErrorCode = parseLeaderErrorCode(envelope.errorCode());
         throw new WordSingleFlightLeaderFailureException(
-                "Single-flight leader failed for key digest=" + digest + ": " + envelope.errorMessage()
+                "Single-flight leader failed for key digest=" + digest + ": " + envelope.errorMessage(),
+                leaderErrorCode
         );
+    }
+
+    private String resolveLeaderErrorCode(Throwable throwable) {
+        Throwable cursor = throwable;
+        while (cursor != null) {
+            if (cursor instanceof WordsException wordsException && wordsException.getErrorCode() != null) {
+                return wordsException.getErrorCode().name();
+            }
+            cursor = cursor.getCause();
+        }
+        return null;
+    }
+
+    private WordsErrorCode parseLeaderErrorCode(String rawErrorCode) {
+        if (rawErrorCode == null || rawErrorCode.isBlank()) {
+            return null;
+        }
+
+        try {
+            return WordsErrorCode.valueOf(rawErrorCode);
+        } catch (IllegalArgumentException e) {
+            log.warn("Unknown single-flight leader error code: {}", rawErrorCode);
+            return null;
+        }
     }
 
     private void registerWaiter(String channel, CompletableFuture<Void> signal) {
@@ -264,14 +292,15 @@ public class WordSingleFlightRedisCoordinator {
     private record ResultEnvelope(
             boolean success,
             List<WordAnalysisResult> results,
-            String errorMessage
+            String errorMessage,
+            String errorCode
     ) {
         static ResultEnvelope success(List<WordAnalysisResult> results) {
-            return new ResultEnvelope(true, results, null);
+            return new ResultEnvelope(true, results, null, null);
         }
 
-        static ResultEnvelope failed(String errorMessage) {
-            return new ResultEnvelope(false, List.of(), errorMessage);
+        static ResultEnvelope failed(String errorMessage, String errorCode) {
+            return new ResultEnvelope(false, List.of(), errorMessage, errorCode);
         }
     }
 }

--- a/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
+++ b/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
@@ -191,7 +191,7 @@ public class WordSingleFlightRedisCoordinator {
             return envelope.results();
         }
 
-        WordsErrorCodㅌ8e leaderErrorCode = parseLeaderErrorCode(envelope.errorCode());
+        WordsErrorCode leaderErrorCode = parseLeaderErrorCode(envelope.errorCode());
         throw new WordSingleFlightLeaderFailureException(
                 "Single-flight leader failed for key digest=" + digest + ": " + envelope.errorMessage(),
                 leaderErrorCode

--- a/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
+++ b/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
@@ -100,7 +100,9 @@ public class WordSingleFlightRedisCoordinator {
 
     private boolean tryAcquireLeaderLock(RLock lock) {
         try {
-            return lock.tryLock(0, properties.getLockTtlMs(), TimeUnit.MILLISECONDS);
+            // Use Redisson watchdog mode (no fixed lease time) to keep lock alive
+            // while leaderAction is still running, and release promptly on unlock.
+            return lock.tryLock(0, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException("Interrupted while acquiring single-flight lock", e);

--- a/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
@@ -301,25 +301,28 @@ class WordServiceTest {
     }
 
     @Test
-    @DisplayName("single-flight leader 실패 재생은 invalid 캐시를 증가시키지 않고 timeout 에러를 반환")
-    void getOrCreateWords_singleFlightLeaderFailure_doesNotCacheInvalidWord() {
+    @DisplayName("single-flight leader가 무의미 단어로 실패하면 follower도 동일 도메인 에러를 반환하고 invalid 캐시에 반영")
+    void getOrCreateWords_singleFlightLeaderFailureMeaningless_mapsToDomainError() {
         String word = "resilience";
 
         when(wordVariantRepository.findAllByWord(word)).thenReturn(List.of());
         when(invalidWordRepository.findByWord(word)).thenReturn(Optional.empty());
         when(singleFlightCoordinator.execute(eq(word), eq(LanguageCode.KO), any()))
-                .thenThrow(new WordSingleFlightLeaderFailureException("Single-flight leader failed"));
+                .thenThrow(new WordSingleFlightLeaderFailureException(
+                        "Single-flight leader failed",
+                        com.linglevel.api.word.exception.WordsErrorCode.WORD_IS_MEANINGLESS
+                ));
 
         assertThatThrownBy(() -> wordService.getOrCreateWords(userId, word, LanguageCode.KO))
                 .isInstanceOf(WordsException.class)
-                .hasMessageContaining("temporarily delayed");
+                .hasMessageContaining("meaningless");
 
-        verify(invalidWordRepository, never()).save(any());
+        verify(invalidWordRepository).save(any());
     }
 
     @Test
-    @DisplayName("translation-miss 경로의 leader 실패 재생도 WORD_ANALYSIS_TIMEOUT으로 변환")
-    void getOrCreateWords_translationMissLeaderFailure_returnsDomainTimeoutError() {
+    @DisplayName("translation-miss 경로의 leader 실패가 무의미 단어면 동일 도메인 에러를 반환")
+    void getOrCreateWords_translationMissLeaderFailure_mapsToDomainMeaninglessError() {
         String inputWord = "ran";
         String originalForm = "run";
 
@@ -333,10 +336,13 @@ class WordServiceTest {
         when(wordRepository.findByWordAndTargetLanguageCode(originalForm, LanguageCode.KO))
                 .thenReturn(Optional.empty());
         when(singleFlightCoordinator.execute(eq(originalForm), eq(LanguageCode.KO), any()))
-                .thenThrow(new WordSingleFlightLeaderFailureException("Single-flight leader failed"));
+                .thenThrow(new WordSingleFlightLeaderFailureException(
+                        "Single-flight leader failed",
+                        com.linglevel.api.word.exception.WordsErrorCode.WORD_IS_MEANINGLESS
+                ));
 
         assertThatThrownBy(() -> wordService.getOrCreateWords(userId, inputWord, LanguageCode.KO))
                 .isInstanceOf(WordsException.class)
-                .hasMessageContaining("temporarily delayed");
+                .hasMessageContaining("meaningless");
     }
 }

--- a/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
@@ -235,7 +235,7 @@ class WordSingleFlightRedisCoordinatorTest {
         }
 
         try {
-            when(redissonLock.tryLock(0, properties.getLockTtlMs(), TimeUnit.MILLISECONDS))
+            when(redissonLock.tryLock(0, TimeUnit.MILLISECONDS))
                     .thenReturn(sequence[0], java.util.Arrays.copyOfRange(sequence, 1, sequence.length));
         } catch (InterruptedException e) {
             throw new RuntimeException(e);

--- a/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
@@ -3,6 +3,8 @@ package com.linglevel.api.word.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linglevel.api.i18n.LanguageCode;
 import com.linglevel.api.word.dto.WordAnalysisResult;
+import com.linglevel.api.word.exception.WordsErrorCode;
+import com.linglevel.api.word.exception.WordsException;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.junit.jupiter.api.BeforeEach;
@@ -204,6 +206,26 @@ class WordSingleFlightRedisCoordinatorTest {
                 coordinator.execute("left", LanguageCode.KO, ArrayList::new)
         ).isInstanceOf(RuntimeException.class)
          .hasMessageContaining("Single-flight leader failed");
+    }
+
+    @Test
+    @DisplayName("leader의 WordsErrorCode는 follower leader-failure 예외로 전달된다")
+    void execute_propagatesLeaderDomainErrorCode() {
+        stubTryLock(true, false);
+
+        RuntimeException failure = new RuntimeException("wrapped", new WordsException(WordsErrorCode.WORD_IS_MEANINGLESS));
+
+        assertThatThrownBy(() ->
+                coordinator.execute("typooo", LanguageCode.KO, () -> {
+                    throw failure;
+                })
+        ).isInstanceOf(RuntimeException.class);
+
+        assertThatThrownBy(() ->
+                coordinator.execute("typooo", LanguageCode.KO, ArrayList::new)
+        ).isInstanceOf(WordSingleFlightLeaderFailureException.class)
+         .satisfies(ex -> assertThat(((WordSingleFlightLeaderFailureException) ex).getLeaderErrorCode())
+                 .isEqualTo(WordsErrorCode.WORD_IS_MEANINGLESS));
     }
 
     private void sleep(long millis) {


### PR DESCRIPTION
## Summary
develop 최신 기준으로 single-flight 관련 긴급 버그 픽스 3개 커밋만 이관한 PR입니다.

## Problem
- leader lock이 고정 lease 만료로 중간 해제될 수 있음
- follower가 leader 도메인 실패를 timeout으로만 매핑해 의미가 손실됨
- coordinator 내부 타입 오타로 컴파일 실패 가능성

## Solution
- Redisson watchdog 기반 lock 획득으로 전환
- leader failure의 도메인 error code를 follower로 전달/복원
- 타입 오타 수정

## Changes
- `WordSingleFlightRedisCoordinator`: watchdog lock + failure envelope(`errorCode`) 처리
- `WordSingleFlightLeaderFailureException`: leader error code 필드 추가
- `WordsException`: error code 노출
- `WordService`: leader failure 도메인 매핑 보존
- 관련 테스트 보강/수정 (`WordServiceTest`, `WordSingleFlightRedisCoordinatorTest`)

## Example
- leader가 `WORD_IS_MEANINGLESS`로 실패하면 follower도 동일하게 `WORD_IS_MEANINGLESS`를 반환

## Related Issues
- single-flight 리뷰 코멘트 P1/P2 대응