### PR TITLE
feat(word): Redlock 기반 single-flight 적용 및 검증

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,15 @@ services:
       # 컨테이너 내부에서 localhost는 도커 네트워크에서 자신의 주소
       - SPRING_DATA_MONGODB_URI=mongodb://mongo:27017/llv_api_local
       - SPRING_DATA_REDIS_HOST=redis
+      # Redlock 기본 활성화
+      - WORD_SINGLE_FLIGHT_REDLOCK_ENABLED=true
+      - WORD_SINGLE_FLIGHT_REDLOCK_NODE_ADDRESSES=redis://redis-a:6379,redis://redis-b:6379,redis://redis-c:6379
     depends_on:
       - mongo
       - redis
+      - redis-a
+      - redis-b
+      - redis-c
     volumes:
       - ./logs:/app/logs
   mongo:
@@ -34,6 +40,39 @@ services:
       - redis_data:/data
     restart: unless-stopped
 
+  redis-a:
+    image: redis:7-alpine
+    container_name: llv-redis-a
+    ports:
+      - "6380:6379"
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis_a_data:/data
+    restart: unless-stopped
+
+  redis-b:
+    image: redis:7-alpine
+    container_name: llv-redis-b
+    ports:
+      - "6381:6379"
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis_b_data:/data
+    restart: unless-stopped
+
+  redis-c:
+    image: redis:7-alpine
+    container_name: llv-redis-c
+    ports:
+      - "6382:6379"
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis_c_data:/data
+    restart: unless-stopped
+
 volumes:
   mongo_data:
   redis_data:
+  redis_a_data:
+  redis_b_data:
+  redis_c_data:

--- a/src/main/java/com/linglevel/api/word/service/WordSingleFlightProperties.java
+++ b/src/main/java/com/linglevel/api/word/service/WordSingleFlightProperties.java
@@ -5,6 +5,9 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 @Setter
 @Component
@@ -24,4 +27,8 @@ public class WordSingleFlightProperties {
     private String model = "default";
 
     private String schemaVersion = "v2";
+
+    private boolean redlockEnabled = false;
+
+    private List<String> redlockNodeAddresses = new ArrayList<>();
 }

--- a/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
+++ b/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
@@ -7,10 +7,14 @@ import com.linglevel.api.word.dto.WordAnalysisResult;
 import com.linglevel.api.word.exception.WordsErrorCode;
 import com.linglevel.api.word.exception.WordsException;
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.Redisson;
+import org.redisson.RedissonRedLock;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -22,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Locale;
@@ -49,12 +54,26 @@ public class WordSingleFlightRedisCoordinator {
     private final ObjectMapper objectMapper;
 
     private final ConcurrentHashMap<String, CopyOnWriteArrayList<CompletableFuture<Void>>> channelWaiters = new ConcurrentHashMap<>();
+    private final List<RedissonClient> redlockClients = new ArrayList<>();
 
     private final MessageListener doneListener = this::onDoneMessage;
 
     @PostConstruct
-    void subscribeDonePattern() {
+    void initialize() {
         redisMessageListenerContainer.addMessageListener(doneListener, new PatternTopic(DONE_PATTERN));
+        initializeRedlockClients();
+    }
+
+    @PreDestroy
+    void shutdown() {
+        for (RedissonClient client : redlockClients) {
+            try {
+                client.shutdown();
+            } catch (Exception e) {
+                log.warn("Failed to shutdown single-flight Redlock client", e);
+            }
+        }
+        redlockClients.clear();
     }
 
     public List<WordAnalysisResult> execute(
@@ -72,7 +91,7 @@ public class WordSingleFlightRedisCoordinator {
             return unwrap(cached, keys.digest());
         }
 
-        RLock lock = redissonClient.getLock(keys.lockKey());
+        RLock lock = createLeaderLock(keys.lockKey());
         boolean lockAcquired = tryAcquireLeaderLock(lock);
         if (lockAcquired) {
             return executeAsLeader(keys, lock, leaderAction);
@@ -151,12 +170,65 @@ public class WordSingleFlightRedisCoordinator {
 
     private void releaseLock(RLock lock, String lockKey) {
         try {
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
+            lock.unlock();
+        } catch (IllegalMonitorStateException e) {
+            log.warn("Single-flight lock was not held at release time key={}", lockKey, e);
         } catch (Exception e) {
             log.warn("Failed to release single-flight lock key={}", lockKey, e);
         }
+    }
+
+    private RLock createLeaderLock(String lockKey) {
+        if (properties.isRedlockEnabled() && redlockClients.size() >= 3) {
+            RLock[] locks = redlockClients.stream()
+                    .map(client -> client.getLock(lockKey))
+                    .toArray(RLock[]::new);
+            return new RedissonRedLock(locks);
+        }
+
+        if (properties.isRedlockEnabled()) {
+            log.warn("Redlock is enabled but usable node count is {} (<3). Fallback to single RLock.",
+                    redlockClients.size());
+        }
+        return redissonClient.getLock(lockKey);
+    }
+
+    private void initializeRedlockClients() {
+        if (!properties.isRedlockEnabled()) {
+            return;
+        }
+
+        List<String> addresses = properties.getRedlockNodeAddresses().stream()
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .toList();
+
+        if (addresses.isEmpty()) {
+            log.warn("Redlock is enabled but no node addresses configured. Fallback to single RLock.");
+            return;
+        }
+
+        for (String rawAddress : addresses) {
+            String address = normalizeAddress(rawAddress);
+            Config config = new Config();
+            config.useSingleServer().setAddress(address);
+            redlockClients.add(Redisson.create(config));
+        }
+
+        if (redlockClients.size() < 3) {
+            log.warn("Redlock requires at least 3 independent nodes, but only {} configured. Fallback to single RLock.",
+                    redlockClients.size());
+            return;
+        }
+
+        log.info("Single-flight Redlock mode initialized with {} nodes.", redlockClients.size());
+    }
+
+    private String normalizeAddress(String rawAddress) {
+        if (rawAddress.startsWith("redis://") || rawAddress.startsWith("rediss://")) {
+            return rawAddress;
+        }
+        return "redis://" + rawAddress;
     }
 
     private ResultEnvelope readResult(String resultKey) {

--- a/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
+++ b/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
@@ -210,9 +210,18 @@ public class WordSingleFlightRedisCoordinator {
 
         for (String rawAddress : addresses) {
             String address = normalizeAddress(rawAddress);
-            Config config = new Config();
-            config.useSingleServer().setAddress(address);
-            redlockClients.add(Redisson.create(config));
+            try {
+                Config config = new Config();
+                config.useSingleServer().setAddress(address);
+                redlockClients.add(Redisson.create(config));
+            } catch (Exception e) {
+                log.warn("Skipping invalid/unavailable Redlock node address '{}'. Fallback candidates will continue.", rawAddress, e);
+            }
+        }
+
+        if (redlockClients.isEmpty()) {
+            log.warn("Redlock is enabled but no valid/usable nodes initialized. Fallback to single RLock.");
+            return;
         }
 
         if (redlockClients.size() < 3) {

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -9,6 +9,10 @@ spring.data.mongodb.database=llv_api_local
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
 
+# Redlock (local default)
+word.single-flight.redlock-enabled=true
+word.single-flight.redlock-node-addresses=redis://localhost:6379,redis://localhost:6380,redis://localhost:6381
+
 # Logging for Local Development
 logging.level.com.linglevel.api=DEBUG
 logging.level.org.springframework.data.mongodb=DEBUG

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -59,6 +59,8 @@ word.single-flight.result-ttl-ms=25000
 word.single-flight.prompt-version=v1
 word.single-flight.model=${spring.ai.bedrock.converse.chat.options.model:default}
 word.single-flight.schema-version=v2
+word.single-flight.redlock-enabled=false
+word.single-flight.redlock-node-addresses=
 
 # AWS S3 (AI Input/Output buckets)
 aws.s3.region=${S3_REGION}

--- a/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorIntegrationTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorIntegrationTest.java
@@ -18,6 +18,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -31,6 +32,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class WordSingleFlightRedisCoordinatorIntegrationTest extends AbstractRedisTest {
+
+    private static final GenericContainer<?> redlockRedisA;
+    private static final GenericContainer<?> redlockRedisB;
+    private static final GenericContainer<?> redlockRedisC;
+
+    static {
+        redlockRedisA = new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+                .withExposedPorts(6379)
+                .withReuse(true);
+        redlockRedisB = new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+                .withExposedPorts(6379)
+                .withReuse(true);
+        redlockRedisC = new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+                .withExposedPorts(6379)
+                .withReuse(true);
+        redlockRedisA.start();
+        redlockRedisB.start();
+        redlockRedisC.start();
+    }
 
     private CoordinatorFixture nodeA;
     private CoordinatorFixture nodeB;
@@ -117,7 +137,57 @@ class WordSingleFlightRedisCoordinatorIntegrationTest extends AbstractRedisTest 
         assertThat(aiCalls.get()).isEqualTo(1);
     }
 
+    @Test
+    @DisplayName("Redlock(3노드) 구성에서도 두 인스턴스 동시 요청은 1회만 실행된다")
+    void deduplicatesAcrossTwoCoordinatorsUsingRealRedisWithRedlock() throws Exception {
+        CoordinatorFixture redlockNodeA = createNode("test-model-redlock", 3_000, true, redlockNodeAddresses());
+        CoordinatorFixture redlockNodeB = createNode("test-model-redlock", 3_000, true, redlockNodeAddresses());
+        flushAll(redlockNodeA.template);
+
+        AtomicInteger aiCalls = new AtomicInteger();
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch start = new CountDownLatch(1);
+
+        try {
+            Future<List<WordAnalysisResult>> f1 = executor.submit(() -> {
+                start.await(1, TimeUnit.SECONDS);
+                return redlockNodeA.coordinator.execute("sprint", LanguageCode.KO, () -> {
+                    aiCalls.incrementAndGet();
+                    sleep(250);
+                    return List.of(sample("sprint"));
+                });
+            });
+
+            Future<List<WordAnalysisResult>> f2 = executor.submit(() -> {
+                start.await(1, TimeUnit.SECONDS);
+                return redlockNodeB.coordinator.execute("sprint", LanguageCode.KO, () -> {
+                    aiCalls.incrementAndGet();
+                    return List.of(sample("sprint"));
+                });
+            });
+
+            start.countDown();
+
+            List<WordAnalysisResult> r1 = f1.get(5, TimeUnit.SECONDS);
+            List<WordAnalysisResult> r2 = f2.get(5, TimeUnit.SECONDS);
+
+            assertThat(r1).hasSize(1);
+            assertThat(r2).hasSize(1);
+            assertThat(r1.get(0).getOriginalForm()).isEqualTo("sprint");
+            assertThat(r2.get(0).getOriginalForm()).isEqualTo("sprint");
+            assertThat(aiCalls.get()).isEqualTo(1);
+        } finally {
+            executor.shutdownNow();
+            redlockNodeA.close();
+            redlockNodeB.close();
+        }
+    }
+
     private CoordinatorFixture createNode(String model, long waitTimeoutMs) {
+        return createNode(model, waitTimeoutMs, false, List.of());
+    }
+
+    private CoordinatorFixture createNode(String model, long waitTimeoutMs, boolean redlockEnabled, List<String> redlockNodeAddresses) {
         GenericContainer<?> redis = getRedisContainer();
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(redis.getHost(), redis.getMappedPort(6379));
 
@@ -146,6 +216,8 @@ class WordSingleFlightRedisCoordinatorIntegrationTest extends AbstractRedisTest 
         properties.setPromptVersion("v1");
         properties.setModel(model);
         properties.setSchemaVersion("v2");
+        properties.setRedlockEnabled(redlockEnabled);
+        properties.setRedlockNodeAddresses(redlockNodeAddresses);
 
         WordSingleFlightRedisCoordinator coordinator = new WordSingleFlightRedisCoordinator(
                 template,
@@ -157,6 +229,18 @@ class WordSingleFlightRedisCoordinatorIntegrationTest extends AbstractRedisTest 
         ReflectionTestUtils.invokeMethod(coordinator, "initialize");
 
         return new CoordinatorFixture(connectionFactory, template, listenerContainer, redissonClient, coordinator);
+    }
+
+    private List<String> redlockNodeAddresses() {
+        return List.of(
+                toRedisAddress(redlockRedisA),
+                toRedisAddress(redlockRedisB),
+                toRedisAddress(redlockRedisC)
+        );
+    }
+
+    private String toRedisAddress(GenericContainer<?> container) {
+        return "redis://" + container.getHost() + ":" + container.getMappedPort(6379);
     }
 
     private void flushAll(StringRedisTemplate template) {
@@ -193,6 +277,10 @@ class WordSingleFlightRedisCoordinatorIntegrationTest extends AbstractRedisTest 
             WordSingleFlightRedisCoordinator coordinator
     ) {
         void close() {
+            try {
+                ReflectionTestUtils.invokeMethod(coordinator, "shutdown");
+            } catch (Exception ignored) {
+            }
             try {
                 listenerContainer.stop();
             } catch (Exception ignored) {

--- a/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorIntegrationTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorIntegrationTest.java
@@ -154,7 +154,7 @@ class WordSingleFlightRedisCoordinatorIntegrationTest extends AbstractRedisTest 
                 properties,
                 new ObjectMapper()
         );
-        ReflectionTestUtils.invokeMethod(coordinator, "subscribeDonePattern");
+        ReflectionTestUtils.invokeMethod(coordinator, "initialize");
 
         return new CoordinatorFixture(connectionFactory, template, listenerContainer, redissonClient, coordinator);
     }

--- a/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
@@ -5,6 +5,7 @@ import com.linglevel.api.i18n.LanguageCode;
 import com.linglevel.api.word.dto.WordAnalysisResult;
 import com.linglevel.api.word.exception.WordsErrorCode;
 import com.linglevel.api.word.exception.WordsException;
+import org.redisson.RedissonRedLock;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +39,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -226,6 +229,45 @@ class WordSingleFlightRedisCoordinatorTest {
         ).isInstanceOf(WordSingleFlightLeaderFailureException.class)
          .satisfies(ex -> assertThat(((WordSingleFlightLeaderFailureException) ex).getLeaderErrorCode())
                  .isEqualTo(WordsErrorCode.WORD_IS_MEANINGLESS));
+    }
+
+    @Test
+    @DisplayName("Redlock 활성 + 3개 노드 구성 시 RedissonRedLock을 사용한다")
+    void createLeaderLock_usesRedlockWhenConfigured() {
+        properties.setRedlockEnabled(true);
+        properties.setRedlockNodeAddresses(List.of(
+                "redis://127.0.0.1:6379",
+                "redis://127.0.0.1:6380",
+                "redis://127.0.0.1:6381"
+        ));
+
+        ReflectionTestUtils.invokeMethod(coordinator, "initializeRedlockClients");
+        try {
+            RLock lock = ReflectionTestUtils.invokeMethod(coordinator, "createLeaderLock", "sf:word:lock:redlock");
+            assertThat(lock).isInstanceOf(RedissonRedLock.class);
+            verify(redissonClient, never()).getLock("sf:word:lock:redlock");
+        } finally {
+            ReflectionTestUtils.invokeMethod(coordinator, "shutdown");
+        }
+    }
+
+    @Test
+    @DisplayName("Redlock 활성 + 노드 2개 구성 시 single RLock으로 폴백한다")
+    void createLeaderLock_fallsBackToSingleRLockWhenInsufficientNodes() {
+        properties.setRedlockEnabled(true);
+        properties.setRedlockNodeAddresses(List.of(
+                "redis://127.0.0.1:6379",
+                "redis://127.0.0.1:6380"
+        ));
+
+        ReflectionTestUtils.invokeMethod(coordinator, "initializeRedlockClients");
+        try {
+            RLock lock = ReflectionTestUtils.invokeMethod(coordinator, "createLeaderLock", "sf:word:lock:fallback");
+            assertThat(lock).isSameAs(redissonLock);
+            verify(redissonClient).getLock("sf:word:lock:fallback");
+        } finally {
+            ReflectionTestUtils.invokeMethod(coordinator, "shutdown");
+        }
     }
 
     private void sleep(long millis) {

--- a/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -268,6 +269,20 @@ class WordSingleFlightRedisCoordinatorTest {
         } finally {
             ReflectionTestUtils.invokeMethod(coordinator, "shutdown");
         }
+    }
+
+    @Test
+    @DisplayName("Redlock 노드 주소가 잘못되어도 초기화 예외 없이 single RLock으로 폴백한다")
+    void initializeRedlockClients_doesNotFailStartupOnBadAddress() {
+        properties.setRedlockEnabled(true);
+        properties.setRedlockNodeAddresses(List.of("bad address with space"));
+
+        assertThatCode(() -> ReflectionTestUtils.invokeMethod(coordinator, "initializeRedlockClients"))
+                .doesNotThrowAnyException();
+
+        RLock lock = ReflectionTestUtils.invokeMethod(coordinator, "createLeaderLock", "sf:word:lock:bad-address");
+        assertThat(lock).isSameAs(redissonLock);
+        verify(redissonClient).getLock("sf:word:lock:bad-address");
     }
 
     private void sleep(long millis) {

--- a/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -236,39 +237,41 @@ class WordSingleFlightRedisCoordinatorTest {
     @DisplayName("Redlock 활성 + 3개 노드 구성 시 RedissonRedLock을 사용한다")
     void createLeaderLock_usesRedlockWhenConfigured() {
         properties.setRedlockEnabled(true);
-        properties.setRedlockNodeAddresses(List.of(
-                "redis://127.0.0.1:6379",
-                "redis://127.0.0.1:6380",
-                "redis://127.0.0.1:6381"
-        ));
 
-        ReflectionTestUtils.invokeMethod(coordinator, "initializeRedlockClients");
-        try {
-            RLock lock = ReflectionTestUtils.invokeMethod(coordinator, "createLeaderLock", "sf:word:lock:redlock");
-            assertThat(lock).isInstanceOf(RedissonRedLock.class);
-            verify(redissonClient, never()).getLock("sf:word:lock:redlock");
-        } finally {
-            ReflectionTestUtils.invokeMethod(coordinator, "shutdown");
-        }
+        RedissonClient nodeA = mock(RedissonClient.class);
+        RedissonClient nodeB = mock(RedissonClient.class);
+        RedissonClient nodeC = mock(RedissonClient.class);
+        when(nodeA.getLock(anyString())).thenReturn(mock(RLock.class));
+        when(nodeB.getLock(anyString())).thenReturn(mock(RLock.class));
+        when(nodeC.getLock(anyString())).thenReturn(mock(RLock.class));
+
+        @SuppressWarnings("unchecked")
+        List<RedissonClient> clients = (List<RedissonClient>) ReflectionTestUtils.getField(coordinator, "redlockClients");
+        clients.add(nodeA);
+        clients.add(nodeB);
+        clients.add(nodeC);
+
+        RLock lock = ReflectionTestUtils.invokeMethod(coordinator, "createLeaderLock", "sf:word:lock:redlock");
+        assertThat(lock).isInstanceOf(RedissonRedLock.class);
+        verify(redissonClient, never()).getLock("sf:word:lock:redlock");
     }
 
     @Test
     @DisplayName("Redlock 활성 + 노드 2개 구성 시 single RLock으로 폴백한다")
     void createLeaderLock_fallsBackToSingleRLockWhenInsufficientNodes() {
         properties.setRedlockEnabled(true);
-        properties.setRedlockNodeAddresses(List.of(
-                "redis://127.0.0.1:6379",
-                "redis://127.0.0.1:6380"
-        ));
 
-        ReflectionTestUtils.invokeMethod(coordinator, "initializeRedlockClients");
-        try {
-            RLock lock = ReflectionTestUtils.invokeMethod(coordinator, "createLeaderLock", "sf:word:lock:fallback");
-            assertThat(lock).isSameAs(redissonLock);
-            verify(redissonClient).getLock("sf:word:lock:fallback");
-        } finally {
-            ReflectionTestUtils.invokeMethod(coordinator, "shutdown");
-        }
+        RedissonClient nodeA = mock(RedissonClient.class);
+        RedissonClient nodeB = mock(RedissonClient.class);
+
+        @SuppressWarnings("unchecked")
+        List<RedissonClient> clients = (List<RedissonClient>) ReflectionTestUtils.getField(coordinator, "redlockClients");
+        clients.add(nodeA);
+        clients.add(nodeB);
+
+        RLock lock = ReflectionTestUtils.invokeMethod(coordinator, "createLeaderLock", "sf:word:lock:fallback");
+        assertThat(lock).isSameAs(redissonLock);
+        verify(redissonClient).getLock("sf:word:lock:fallback");
     }
 
     @Test

--- a/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
@@ -97,7 +97,7 @@ class WordSingleFlightRedisCoordinatorTest {
                 properties,
                 objectMapper
         );
-        ReflectionTestUtils.invokeMethod(coordinator, "subscribeDonePattern");
+        ReflectionTestUtils.invokeMethod(coordinator, "initialize");
     }
 
     @Test


### PR DESCRIPTION
## 요약
- `WordSingleFlightRedisCoordinator`에 Redlock 기반 락 선택 경로를 추가했습니다.
- 로컬에서 검증할 수 있도록 Redis 3노드 구성 및 Redlock 설정값을 추가했습니다.
- Redlock 경로 선택/폴백과 3노드 통합 중복제거 동작을 테스트로 보강했습니다.

## 검증
- `./gradlew test --tests com.linglevel.api.word.service.WordSingleFlightRedisCoordinatorTest --tests com.linglevel.api.word.service.WordSingleFlightRedisCoordinatorIntegrationTest`