### PR TITLE
refactor(word): optimize indexes and transaction boundaries

### DIFF
--- a/src/main/java/com/linglevel/api/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/linglevel/api/auth/repository/RefreshTokenRepository.java
@@ -15,5 +15,4 @@ public interface RefreshTokenRepository extends MongoRepository<RefreshToken, St
     
     void deleteByUserId(String userId);
     
-    void deleteByTokenId(String tokenId);
 }

--- a/src/main/java/com/linglevel/api/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/linglevel/api/bookmark/service/BookmarkService.java
@@ -76,16 +76,9 @@ public class BookmarkService {
     
     public void removeWordBookmark(String userId, String wordStr) {
         List<String> originalForms = wordVariantService.getOriginalForms(wordStr);
-        if (originalForms.isEmpty()) {
-            throw new BookmarksException(BookmarksErrorCode.WORD_NOT_FOUND);
-        }
+        String bookmarkedWord = resolveBookmarkedWord(userId, wordStr, originalForms);
 
-        String originalForm = originalForms.get(0);
-        if (!wordBookmarkRepository.existsByUserIdAndWord(userId, originalForm)) {
-            throw new BookmarksException(BookmarksErrorCode.WORD_BOOKMARK_NOT_FOUND);
-        }
-
-        wordBookmarkRepository.deleteByUserIdAndWord(userId, originalForm);
+        wordBookmarkRepository.deleteByUserIdAndWord(userId, bookmarkedWord);
     }
     
     public boolean toggleWordBookmark(String userId, String wordStr) {
@@ -155,6 +148,20 @@ public class BookmarkService {
         }
 
         return originalForms.get(0);
+    }
+
+    private String resolveBookmarkedWord(String userId, String wordStr, List<String> originalForms) {
+        for (String originalForm : originalForms) {
+            if (wordBookmarkRepository.existsByUserIdAndWord(userId, originalForm)) {
+                return originalForm;
+            }
+        }
+
+        if (wordBookmarkRepository.existsByUserIdAndWord(userId, wordStr)) {
+            return wordStr;
+        }
+
+        throw new BookmarksException(BookmarksErrorCode.WORD_BOOKMARK_NOT_FOUND);
     }
 
     private List<String> extractDistinctOriginalForms(WordSearchResponse wordSearchResponse) {

--- a/src/main/java/com/linglevel/api/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/linglevel/api/bookmark/service/BookmarkService.java
@@ -19,7 +19,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -57,7 +56,6 @@ public class BookmarkService {
         }
     }
     
-    @Transactional
     public void addWordBookmark(String userId, String wordStr) {
         var wordSearchResponse = wordService.getOrCreateWords(userId, wordStr, LanguageCode.KO);
         String originalForm = resolveFirstOriginalForm(wordSearchResponse);
@@ -76,7 +74,6 @@ public class BookmarkService {
         log.info("Bookmark added: userId={}, word={}", userId, originalForm);
     }
     
-    @Transactional
     public void removeWordBookmark(String userId, String wordStr) {
         List<String> originalForms = wordVariantService.getOriginalForms(wordStr);
         if (originalForms.isEmpty()) {
@@ -91,7 +88,6 @@ public class BookmarkService {
         wordBookmarkRepository.deleteByUserIdAndWord(userId, originalForm);
     }
     
-    @Transactional
     public boolean toggleWordBookmark(String userId, String wordStr) {
         var wordSearchResponse = wordService.getOrCreateWords(userId, wordStr, LanguageCode.KO);
         String originalForm = resolveFirstOriginalForm(wordSearchResponse);
@@ -115,7 +111,6 @@ public class BookmarkService {
         return true;
     }
     
-    @Transactional
     public boolean toggleWordBookmarkById(String userId, String wordId) {
         Word word = wordRepository.findById(wordId)
                 .orElseThrow(() -> new BookmarksException(BookmarksErrorCode.WORD_NOT_FOUND));

--- a/src/main/java/com/linglevel/api/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/linglevel/api/bookmark/service/BookmarkService.java
@@ -151,14 +151,14 @@ public class BookmarkService {
     }
 
     private String resolveBookmarkedWord(String userId, String wordStr, List<String> originalForms) {
+        if (wordBookmarkRepository.existsByUserIdAndWord(userId, wordStr)) {
+            return wordStr;
+        }
+
         for (String originalForm : originalForms) {
             if (wordBookmarkRepository.existsByUserIdAndWord(userId, originalForm)) {
                 return originalForm;
             }
-        }
-
-        if (wordBookmarkRepository.existsByUserIdAndWord(userId, wordStr)) {
-            return wordStr;
         }
 
         throw new BookmarksException(BookmarksErrorCode.WORD_BOOKMARK_NOT_FOUND);

--- a/src/main/java/com/linglevel/api/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/linglevel/api/bookmark/service/BookmarkService.java
@@ -6,8 +6,8 @@ import com.linglevel.api.bookmark.exception.BookmarksErrorCode;
 import com.linglevel.api.bookmark.exception.BookmarksException;
 import com.linglevel.api.bookmark.repository.WordBookmarkRepository;
 import com.linglevel.api.i18n.LanguageCode;
+import com.linglevel.api.word.dto.WordSearchResponse;
 import com.linglevel.api.word.entity.Word;
-import com.linglevel.api.word.entity.WordVariant;
 import com.linglevel.api.word.repository.WordRepository;
 import com.linglevel.api.word.service.WordService;
 import com.linglevel.api.word.service.WordVariantService;
@@ -24,7 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -61,9 +60,7 @@ public class BookmarkService {
     @Transactional
     public void addWordBookmark(String userId, String wordStr) {
         var wordSearchResponse = wordService.getOrCreateWords(userId, wordStr, LanguageCode.KO);
-
-        // 첫 번째 원형 사용 (대부분의 경우 하나만 반환됨)
-        String originalForm = wordSearchResponse.getResults().get(0).getOriginalForm();
+        String originalForm = resolveFirstOriginalForm(wordSearchResponse);
 
         if (wordBookmarkRepository.existsByUserIdAndWord(userId, originalForm)) {
             throw new BookmarksException(BookmarksErrorCode.WORD_ALREADY_BOOKMARKED);
@@ -81,13 +78,12 @@ public class BookmarkService {
     
     @Transactional
     public void removeWordBookmark(String userId, String wordStr) {
-        // 단어의 원형 찾기 (언어 중립적)
-        String originalForm = wordVariantService.getOriginalForm(wordStr);
-
-        if (!wordVariantService.exists(originalForm)) {
+        List<String> originalForms = wordVariantService.getOriginalForms(wordStr);
+        if (originalForms.isEmpty()) {
             throw new BookmarksException(BookmarksErrorCode.WORD_NOT_FOUND);
         }
 
+        String originalForm = originalForms.get(0);
         if (!wordBookmarkRepository.existsByUserIdAndWord(userId, originalForm)) {
             throw new BookmarksException(BookmarksErrorCode.WORD_BOOKMARK_NOT_FOUND);
         }
@@ -98,10 +94,7 @@ public class BookmarkService {
     @Transactional
     public boolean toggleWordBookmark(String userId, String wordStr) {
         var wordSearchResponse = wordService.getOrCreateWords(userId, wordStr, LanguageCode.KO);
-
-        // 첫 번째 원형 사용 (대부분의 경우 하나만 반환됨)
-        String originalForm = wordSearchResponse.getResults().get(0).getOriginalForm();
-
+        String originalForm = resolveFirstOriginalForm(wordSearchResponse);
         boolean isBookmarked = wordBookmarkRepository.existsByUserIdAndWord(userId, originalForm);
 
         if (isBookmarked) {
@@ -109,17 +102,17 @@ public class BookmarkService {
             wordBookmarkRepository.deleteByUserIdAndWord(userId, originalForm);
             log.info("Bookmark removed: userId={}, word={}", userId, originalForm);
             return false;
-        } else {
-            // 북마크 추가
-            WordBookmark bookmark = WordBookmark.builder()
-                    .userId(userId)
-                    .word(originalForm)
-                    .bookmarkedAt(LocalDateTime.now())
-                    .build();
-            wordBookmarkRepository.save(bookmark);
-            log.info("Bookmark added: userId={}, word={}", userId, originalForm);
-            return true;
         }
+        
+        // 북마크 추가
+        WordBookmark bookmark = WordBookmark.builder()
+                .userId(userId)
+                .word(originalForm)
+                .bookmarkedAt(LocalDateTime.now())
+                .build();
+        wordBookmarkRepository.save(bookmark);
+        log.info("Bookmark added: userId={}, word={}", userId, originalForm);
+        return true;
     }
     
     @Transactional
@@ -158,5 +151,21 @@ public class BookmarkService {
         }
 
         return new PageImpl<>(responses, bookmarks.getPageable(), bookmarks.getTotalElements());
+    }
+
+    private String resolveFirstOriginalForm(WordSearchResponse wordSearchResponse) {
+        List<String> originalForms = extractDistinctOriginalForms(wordSearchResponse);
+        if (originalForms.isEmpty()) {
+            throw new BookmarksException(BookmarksErrorCode.WORD_NOT_FOUND);
+        }
+
+        return originalForms.get(0);
+    }
+
+    private List<String> extractDistinctOriginalForms(WordSearchResponse wordSearchResponse) {
+        return wordSearchResponse.getResults().stream()
+                .map(result -> result.getOriginalForm())
+                .distinct()
+                .toList();
     }
 }

--- a/src/main/java/com/linglevel/api/content/article/repository/ArticleRepository.java
+++ b/src/main/java/com/linglevel/api/content/article/repository/ArticleRepository.java
@@ -1,23 +1,7 @@
 package com.linglevel.api.content.article.repository;
 
 import com.linglevel.api.content.article.entity.Article;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.mongodb.repository.Query;
-
-import java.util.List;
 
 public interface ArticleRepository extends MongoRepository<Article, String>, ArticleRepositoryCustom {
-    
-    // 제목 또는 작가로 키워드 검색
-    @Query("{'$or': [{'title': {'$regex': ?0, '$options': 'i'}}, {'author': {'$regex': ?0, '$options': 'i'}}]}")
-    Page<Article> findByTitleOrAuthorContaining(String keyword, Pageable pageable);
-    
-    // 태그와 키워드 모두 적용
-    @Query("{'$and': [{'tags': {'$in': ?0}}, {'$or': [{'title': {'$regex': ?1, '$options': 'i'}}, {'author': {'$regex': ?1, '$options': 'i'}}]}]}")
-    Page<Article> findByTagsInAndTitleOrAuthorContaining(List<String> tags, String keyword, Pageable pageable);
-    
-    // 태그 목록으로 필터링
-    Page<Article> findByTagsIn(List<String> tags, Pageable pageable);
 }

--- a/src/main/java/com/linglevel/api/content/book/repository/ChunkRepository.java
+++ b/src/main/java/com/linglevel/api/content/book/repository/ChunkRepository.java
@@ -13,8 +13,6 @@ import org.springframework.data.mongodb.repository.Aggregation;
 import java.util.Optional;
 
 public interface ChunkRepository extends MongoRepository<Chunk, String> {
-    Page<Chunk> findByChapterId(String chapterId, Pageable pageable);
-
     Page<Chunk> findByChapterIdAndDifficultyLevel(String chapterId, DifficultyLevel difficultyLevel, Pageable pageable);
 
     Optional<Chunk> findFirstByChapterIdOrderByChunkNumberAsc(String chapterId);

--- a/src/main/java/com/linglevel/api/content/custom/repository/CustomContentChunkRepository.java
+++ b/src/main/java/com/linglevel/api/content/custom/repository/CustomContentChunkRepository.java
@@ -29,8 +29,6 @@ public interface CustomContentChunkRepository extends MongoRepository<CustomCont
     
     Optional<CustomContentChunk> findByIdAndCustomContentIdAndIsDeletedFalse(String id, String customContentId);
     
-    long countByCustomContentIdAndIsDeletedFalse(String customContentId);
-
     Optional<CustomContentChunk> findFirstByCustomContentIdAndIsDeletedFalseOrderByChapterNumAscChunkNumAsc(String customContentId);
 
     // V2 Progress: Count chunks by difficulty level

--- a/src/main/java/com/linglevel/api/content/custom/repository/CustomContentRepository.java
+++ b/src/main/java/com/linglevel/api/content/custom/repository/CustomContentRepository.java
@@ -13,11 +13,7 @@ public interface CustomContentRepository extends MongoRepository<CustomContent, 
     
     Page<CustomContent> findByUserIdAndIsDeletedFalse(String userId, Pageable pageable);
     
-    Optional<CustomContent> findByIdAndUserIdAndIsDeletedFalse(String id, String userId);
-    
     Optional<CustomContent> findByIdAndIsDeletedFalse(String id);
-
-    Optional<CustomContent> findByContentRequestIdAndIsDeletedFalse(String contentRequestId);
 
     Optional<CustomContent> findByOriginUrlAndIsDeletedFalse(String originUrl);
 }

--- a/src/main/java/com/linglevel/api/content/custom/repository/UserCustomContentRepository.java
+++ b/src/main/java/com/linglevel/api/content/custom/repository/UserCustomContentRepository.java
@@ -18,11 +18,5 @@ public interface UserCustomContentRepository extends MongoRepository<UserCustomC
 
     List<UserCustomContent> findByUserId(String userId);
 
-    long countByCustomContentId(String customContentId);
-
-    Optional<UserCustomContent> findByUserIdAndContentRequestId(String userId, String contentRequestId);
-
-    Optional<UserCustomContent> findByContentRequestId(String contentRequestId);
-
     boolean existsByUserIdAndCustomContentId(String userId, String customContentId);
 }

--- a/src/main/java/com/linglevel/api/streak/repository/UserStudyReportRepository.java
+++ b/src/main/java/com/linglevel/api/streak/repository/UserStudyReportRepository.java
@@ -16,17 +16,6 @@ public interface UserStudyReportRepository extends MongoRepository<UserStudyRepo
     List<UserStudyReport> findByCurrentStreakGreaterThan(int currentStreak);
 
     /**
-     * 최적 타이밍 알림을 위한 사용자 조회
-     * lastLearningTimestamp가 특정 시간 범위 내에 있고, 활성 스트릭을 가진 사용자를 찾습니다.
-     *
-     * @param startTime 시작 시간 (23시간 전)
-     * @param endTime 종료 시간 (24시간 전)
-     * @return 해당 조건을 만족하는 사용자 리포트 목록
-     */
-    @Query("{ 'lastLearningTimestamp': { $gte: ?0, $lt: ?1 }, 'currentStreak': { $gt: 0 } }")
-    List<UserStudyReport> findUsersForOptimalTimingReminder(Instant startTime, Instant endTime);
-
-    /**
      * 이탈 유저 복귀 알림을 위한 사용자 조회 (currentStreak = 0)
      * 마지막 학습 시간이 특정 범위 내에 있는 이탈 유저를 찾습니다.
      *

--- a/src/main/java/com/linglevel/api/user/ticket/repository/TicketTransactionRepository.java
+++ b/src/main/java/com/linglevel/api/user/ticket/repository/TicketTransactionRepository.java
@@ -16,8 +16,6 @@ public interface TicketTransactionRepository extends MongoRepository<TicketTrans
 
     Page<TicketTransaction> findByUserIdAndStatusOrderByCreatedAtDesc(String userId, TransactionStatus status, Pageable pageable);
 
-    List<TicketTransaction> findByReservationId(String reservationId);
-
     Optional<TicketTransaction> findByReservationIdAndStatus(String reservationId, TransactionStatus status);
 
     List<TicketTransaction> findByUserIdAndAmountAndCreatedAtBetween(String userId, Integer amount, LocalDateTime startDateTime, LocalDateTime endDateTime);

--- a/src/main/java/com/linglevel/api/word/entity/Word.java
+++ b/src/main/java/com/linglevel/api/word/entity/Word.java
@@ -26,17 +26,9 @@ import java.util.List;
 @Document(collection = "words")
 @CompoundIndexes({
     @CompoundIndex(
-        name = "word_language_pair_idx",
-        def = "{'word': 1, 'sourceLanguageCode': 1, 'targetLanguageCode': 1}",
+        name = "word_target_source_language_unique_idx",
+        def = "{'word': 1, 'targetLanguageCode': 1, 'sourceLanguageCode': 1}",
         unique = true
-    ),
-    @CompoundIndex(
-        name = "word_target_language_idx",
-        def = "{'word': 1, 'targetLanguageCode': 1}"
-    ),
-    @CompoundIndex(
-        name = "essential_target_language_idx",
-        def = "{'isEssential': 1, 'targetLanguageCode': 1}"
     )
 })
 public class Word {
@@ -45,7 +37,7 @@ public class Word {
 
     /**
      * 원형 단어 (예: "pretty", "see", "run")
-     * 복합 unique index의 일부 (word + sourceLanguageCode + targetLanguageCode)
+     * 복합 unique index의 일부 (word + targetLanguageCode + sourceLanguageCode)
      */
     private String word;
 

--- a/src/main/java/com/linglevel/api/word/entity/Word.java
+++ b/src/main/java/com/linglevel/api/word/entity/Word.java
@@ -33,6 +33,10 @@ import java.util.List;
     @CompoundIndex(
         name = "word_target_language_idx",
         def = "{'word': 1, 'targetLanguageCode': 1}"
+    ),
+    @CompoundIndex(
+        name = "essential_target_language_idx",
+        def = "{'isEssential': 1, 'targetLanguageCode': 1}"
     )
 })
 public class Word {

--- a/src/main/java/com/linglevel/api/word/entity/WordVariant.java
+++ b/src/main/java/com/linglevel/api/word/entity/WordVariant.java
@@ -4,7 +4,6 @@ import com.linglevel.api.word.dto.VariantType;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
-import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.util.List;
@@ -20,7 +19,6 @@ public class WordVariant {
     @Id
     private String id;
 
-    @Indexed
     private String word;
 
     private String originalForm;

--- a/src/main/java/com/linglevel/api/word/exception/WordsErrorCode.java
+++ b/src/main/java/com/linglevel/api/word/exception/WordsErrorCode.java
@@ -12,6 +12,7 @@ public enum WordsErrorCode {
     WORD_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "Word already exists."),
     WORD_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "Word not found with id."),
     WORD_ANALYSIS_TIMEOUT(HttpStatus.SERVICE_UNAVAILABLE, "Word analysis is temporarily delayed. Please try again."),
+    WORD_ANALYSIS_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "Word analysis failed. Please try again."),
     INVALID_WORD_FORMAT(HttpStatus.BAD_REQUEST, "Word contains invalid characters (spaces, tabs, newlines, or special characters are not allowed)."),
     WORD_TOO_LONG(HttpStatus.BAD_REQUEST, "Word is too long (maximum 50 characters)."),
     SAME_SOURCE_TARGET_LANGUAGE(HttpStatus.BAD_REQUEST, "Source and target languages cannot be the same.");

--- a/src/main/java/com/linglevel/api/word/exception/WordsException.java
+++ b/src/main/java/com/linglevel/api/word/exception/WordsException.java
@@ -13,4 +13,10 @@ public class WordsException extends RuntimeException {
         this.errorCode = errorCode;
         this.status = errorCode.getStatus();
     }
+
+    public WordsException(WordsErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+        this.status = errorCode.getStatus();
+    }
 }

--- a/src/main/java/com/linglevel/api/word/repository/InvalidWordRepository.java
+++ b/src/main/java/com/linglevel/api/word/repository/InvalidWordRepository.java
@@ -10,6 +10,4 @@ import java.util.Optional;
 public interface InvalidWordRepository extends MongoRepository<InvalidWord, String> {
 
     Optional<InvalidWord> findByWord(String word);
-
-    boolean existsByWord(String word);
 }

--- a/src/main/java/com/linglevel/api/word/repository/WordRepository.java
+++ b/src/main/java/com/linglevel/api/word/repository/WordRepository.java
@@ -35,8 +35,6 @@ public interface WordRepository extends MongoRepository<Word, String> {
     @Query("{'word': {$regex: ?0, $options: 'i'}}")
     Page<Word> findByWordContainingIgnoreCase(String word, Pageable pageable);
 
-    boolean existsByWord(String word);
-
     /**
      * isEssential 필드로 필터링
      */
@@ -51,9 +49,4 @@ public interface WordRepository extends MongoRepository<Word, String> {
      * 필수 단어 중 특정 target 언어로 필터링
      */
     List<Word> findAllByIsEssentialAndTargetLanguageCode(Boolean isEssential, LanguageCode targetLanguageCode);
-
-    /**
-     * 필수 단어를 페이징으로 조회
-     */
-    Page<Word> findAllByIsEssential(Boolean isEssential, Pageable pageable);
 }

--- a/src/main/java/com/linglevel/api/word/repository/WordVariantRepository.java
+++ b/src/main/java/com/linglevel/api/word/repository/WordVariantRepository.java
@@ -9,8 +9,6 @@ import java.util.Optional;
 
 @Repository
 public interface WordVariantRepository extends MongoRepository<WordVariant, String> {
-    Optional<WordVariant> findByWord(String word);
-
     List<WordVariant> findAllByWord(String word);
 
     List<WordVariant> findByWordIn(List<String> words);

--- a/src/main/java/com/linglevel/api/word/service/WordAiService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordAiService.java
@@ -227,7 +227,7 @@ public class WordAiService {
             throw e;
         } catch (Exception e) {
             log.error("Failed to analyze word '{}' with AI (target: {})", word, targetLanguage, e);
-            throw new RuntimeException("AI word analysis failed for word: " + word, e);
+            throw new WordsException(WordsErrorCode.WORD_ANALYSIS_FAILED, e);
         }
     }
 

--- a/src/main/java/com/linglevel/api/word/service/WordAiService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordAiService.java
@@ -223,6 +223,8 @@ public class WordAiService {
             log.info("✅ AI analysis completed for '{}': {} result(s) - {}", word, mergedResults.size(), summary);
 
             return mergedResults;
+        } catch (WordsException e) {
+            throw e;
         } catch (Exception e) {
             log.error("Failed to analyze word '{}' with AI (target: {})", word, targetLanguage, e);
             throw new RuntimeException("AI word analysis failed for word: " + word, e);

--- a/src/main/java/com/linglevel/api/word/service/WordPersistenceService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordPersistenceService.java
@@ -1,0 +1,268 @@
+package com.linglevel.api.word.service;
+
+import com.linglevel.api.i18n.LanguageCode;
+import com.linglevel.api.word.dto.RelatedForms;
+import com.linglevel.api.word.dto.VariantType;
+import com.linglevel.api.word.dto.WordAnalysisResult;
+import com.linglevel.api.word.entity.InvalidWord;
+import com.linglevel.api.word.entity.Word;
+import com.linglevel.api.word.entity.WordVariant;
+import com.linglevel.api.word.repository.InvalidWordRepository;
+import com.linglevel.api.word.repository.WordRepository;
+import com.linglevel.api.word.repository.WordVariantRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WordPersistenceService {
+
+    private final WordRepository wordRepository;
+    private final WordVariantRepository wordVariantRepository;
+    private final InvalidWordRepository invalidWordRepository;
+
+    @Transactional
+    public List<WordVariant> saveAnalysisResults(
+            String word,
+            List<WordAnalysisResult> analysisResults,
+            Optional<InvalidWord> cachedInvalidWord
+    ) {
+        List<WordVariant> savedVariants = new ArrayList<>();
+        for (WordAnalysisResult analysisResult : analysisResults) {
+            WordVariant savedVariant = saveWordFromAnalysis(word, analysisResult);
+            savedVariants.add(savedVariant);
+        }
+
+        cachedInvalidWord.ifPresent(invalidWord -> {
+            invalidWordRepository.delete(invalidWord);
+            log.info("Removed word '{}' from invalid word cache after successful AI analysis (was attempt {}/3)",
+                    word, invalidWord.getAttemptCount());
+        });
+
+        return savedVariants;
+    }
+
+    @Transactional
+    public List<WordVariant> forceSaveAnalysisResults(
+            String word,
+            LanguageCode targetLanguage,
+            boolean overwrite,
+            boolean deleteVariants,
+            List<WordAnalysisResult> analysisResults
+    ) {
+        if (overwrite) {
+            deleteExistingWords(word, targetLanguage, deleteVariants);
+        }
+
+        List<WordVariant> savedVariants = new ArrayList<>();
+        for (WordAnalysisResult analysisResult : analysisResults) {
+            WordVariant savedVariant = saveWordFromAnalysis(word, analysisResult);
+            savedVariants.add(savedVariant);
+        }
+
+        return savedVariants;
+    }
+
+    @Transactional
+    public Word saveWord(WordAnalysisResult analysisResult) {
+        Word newWord = convertAnalysisResultToWord(analysisResult);
+        return wordRepository.save(newWord);
+    }
+
+    private WordVariant saveWordFromAnalysis(String word, WordAnalysisResult analysisResult) {
+        String originalForm = analysisResult.getOriginalForm();
+        LanguageCode sourceLanguageCode = analysisResult.getSourceLanguageCode();
+        LanguageCode targetLanguageCode = analysisResult.getTargetLanguageCode();
+
+        wordRepository.findByWordAndSourceLanguageCodeAndTargetLanguageCode(
+                originalForm, sourceLanguageCode, targetLanguageCode
+        ).orElseGet(() -> {
+            Word newWord = convertAnalysisResultToWord(analysisResult);
+            Word savedWord = wordRepository.save(newWord);
+            log.info("Saved new word: {} ({} -> {})", originalForm, sourceLanguageCode, targetLanguageCode);
+
+            saveWordVariants(savedWord);
+
+            return savedWord;
+        });
+
+        Optional<WordVariant> existingVariant = wordVariantRepository.findByWordAndOriginalForm(word, originalForm);
+        if (existingVariant.isPresent()) {
+            log.info("Variant already exists: {} -> {}", word, originalForm);
+            return existingVariant.get();
+        }
+
+        List<VariantType> variantTypes = analysisResult.getVariantTypes() != null && !analysisResult.getVariantTypes().isEmpty()
+                ? analysisResult.getVariantTypes()
+                : List.of(VariantType.ORIGINAL_FORM);
+
+        WordVariant inputVariant = createVariant(word, originalForm, variantTypes);
+        wordVariantRepository.save(inputVariant);
+        log.info("Saved input variant: {} -> {} ({})", word, originalForm, variantTypes);
+
+        return inputVariant;
+    }
+
+    private void saveWordVariants(Word word) {
+        List<WordVariant> variants = new ArrayList<>();
+
+        RelatedForms relatedForms = word.getRelatedForms();
+        if (relatedForms == null) {
+            return;
+        }
+
+        if (relatedForms.getConjugations() != null) {
+            var conj = relatedForms.getConjugations();
+            if (conj.getPast() != null && !conj.getPast().equals(word.getWord())) {
+                variants.add(createVariant(conj.getPast(), word.getWord(), List.of(VariantType.PAST_TENSE)));
+            }
+            if (conj.getPastParticiple() != null && !conj.getPastParticiple().equals(word.getWord())) {
+                variants.add(createVariant(conj.getPastParticiple(), word.getWord(), List.of(VariantType.PAST_PARTICIPLE)));
+            }
+            if (conj.getPresentParticiple() != null && !conj.getPresentParticiple().equals(word.getWord())) {
+                variants.add(createVariant(conj.getPresentParticiple(), word.getWord(), List.of(VariantType.PRESENT_PARTICIPLE)));
+            }
+            if (conj.getThirdPerson() != null && !conj.getThirdPerson().equals(word.getWord())) {
+                variants.add(createVariant(conj.getThirdPerson(), word.getWord(), List.of(VariantType.THIRD_PERSON)));
+            }
+        }
+
+        if (relatedForms.getComparatives() != null) {
+            var comp = relatedForms.getComparatives();
+            if (comp.getComparative() != null && !comp.getComparative().equals(word.getWord())) {
+                variants.add(createVariant(comp.getComparative(), word.getWord(), List.of(VariantType.COMPARATIVE)));
+            }
+            if (comp.getSuperlative() != null && !comp.getSuperlative().equals(word.getWord())) {
+                variants.add(createVariant(comp.getSuperlative(), word.getWord(), List.of(VariantType.SUPERLATIVE)));
+            }
+        }
+
+        if (relatedForms.getPlural() != null) {
+            var plural = relatedForms.getPlural();
+            if (plural.getPlural() != null && !plural.getPlural().equals(word.getWord())) {
+                variants.add(createVariant(plural.getPlural(), word.getWord(), List.of(VariantType.PLURAL)));
+            }
+        }
+
+        if (!variants.isEmpty()) {
+            List<WordVariant> uniqueVariants = variants.stream()
+                    .collect(Collectors.toMap(
+                            WordVariant::getWord,
+                            variant -> variant,
+                            (existing, replacement) -> {
+                                List<VariantType> mergedTypes = new ArrayList<>(existing.getVariantTypes());
+                                replacement.getVariantTypes().forEach(type -> {
+                                    if (!mergedTypes.contains(type)) {
+                                        mergedTypes.add(type);
+                                    }
+                                });
+                                existing.setVariantTypes(mergedTypes);
+                                return existing;
+                            }
+                    ))
+                    .values()
+                    .stream()
+                    .toList();
+
+            List<String> variantWords = uniqueVariants.stream()
+                    .map(WordVariant::getWord)
+                    .collect(Collectors.toList());
+
+            List<WordVariant> existingVariants = wordVariantRepository.findByWordIn(variantWords);
+            List<String> existingWords = existingVariants.stream()
+                    .map(WordVariant::getWord)
+                    .toList();
+
+            List<WordVariant> newVariants = uniqueVariants.stream()
+                    .filter(variant -> !existingWords.contains(variant.getWord()))
+                    .collect(Collectors.toList());
+
+            if (!newVariants.isEmpty()) {
+                wordVariantRepository.saveAll(newVariants);
+                newVariants.forEach(variant ->
+                        log.info("Saved variant: {} -> {} ({})", variant.getWord(), variant.getOriginalForm(), variant.getVariantTypes())
+                );
+            }
+        }
+    }
+
+    @Transactional
+    public void saveInvalidWord(String word) {
+        Optional<InvalidWord> existingInvalidWord = invalidWordRepository.findByWord(word);
+
+        if (existingInvalidWord.isPresent()) {
+            InvalidWord invalidWord = existingInvalidWord.get();
+            invalidWord.setAttemptCount(invalidWord.getAttemptCount() + 1);
+            invalidWordRepository.save(invalidWord);
+            log.info("Updated invalid word '{}' attempt count: {}", word, invalidWord.getAttemptCount());
+            return;
+        }
+
+        InvalidWord invalidWord = InvalidWord.builder()
+                .word(word)
+                .attemptedAt(LocalDateTime.now())
+                .attemptCount(1)
+                .build();
+        invalidWordRepository.save(invalidWord);
+        log.info("Cached invalid word '{}' permanently (attempt 1/3)", word);
+    }
+
+    private void deleteExistingWords(String word, LanguageCode targetLanguage, boolean deleteVariants) {
+        List<WordVariant> existingVariants = wordVariantRepository.findAllByWord(word);
+        if (existingVariants.isEmpty()) {
+            return;
+        }
+
+        for (WordVariant variant : existingVariants) {
+            String originalForm = variant.getOriginalForm();
+            wordRepository.findByWordAndTargetLanguageCode(
+                    originalForm, targetLanguage
+            ).ifPresent(wordToDelete -> {
+                wordRepository.delete(wordToDelete);
+                log.info("Deleted Word: {} (targetLanguage={})", originalForm, targetLanguage);
+            });
+        }
+
+        if (deleteVariants) {
+            wordVariantRepository.deleteAll(existingVariants);
+            log.info("Deleted {} existing WordVariants for word '{}' (complete reset)", existingVariants.size(), word);
+            return;
+        }
+
+        log.info("Kept {} existing WordVariants for word '{}' (only Word deleted)", existingVariants.size(), word);
+    }
+
+    private Word convertAnalysisResultToWord(WordAnalysisResult result) {
+        RelatedForms relatedForms = RelatedForms.builder()
+                .conjugations(result.getConjugations())
+                .comparatives(result.getComparatives())
+                .plural(result.getPlural())
+                .build();
+
+        return Word.builder()
+                .word(result.getOriginalForm())
+                .sourceLanguageCode(result.getSourceLanguageCode())
+                .targetLanguageCode(result.getTargetLanguageCode())
+                .summary(result.getSummary())
+                .meanings(result.getMeanings())
+                .relatedForms(relatedForms)
+                .build();
+    }
+
+    private WordVariant createVariant(String variantWord, String originalForm, List<VariantType> types) {
+        return WordVariant.builder()
+                .word(variantWord)
+                .originalForm(originalForm)
+                .variantTypes(types)
+                .build();
+    }
+}

--- a/src/main/java/com/linglevel/api/word/service/WordService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordService.java
@@ -14,13 +14,10 @@ import com.linglevel.api.word.repository.WordVariantRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +30,7 @@ public class WordService {
     private final InvalidWordRepository invalidWordRepository;
     private final WordAiService wordAiService;
     private final WordSingleFlightRedisCoordinator singleFlightCoordinator;
+    private final WordPersistenceService wordPersistenceService;
 
     public WordSearchResponse getOrCreateWords(String userId, String word, LanguageCode targetLanguage) {
         List<WordVariant> wordVariants = getOrCreateWordEntities(word, targetLanguage);
@@ -58,8 +56,7 @@ public class WordService {
                                     wordVariant.getOriginalForm(),
                                     targetLanguage.getCode()
                             );
-                            Word newWord = convertAnalysisResultToWord(analysisResults.get(0));
-                            return wordRepository.save(newWord);
+                            return wordPersistenceService.saveWord(analysisResults.get(0));
                         },
                         () -> wordRepository.findByWordAndTargetLanguageCode(
                                 wordVariant.getOriginalForm(),
@@ -86,7 +83,6 @@ public class WordService {
                 .build();
     }
 
-    @Transactional(noRollbackFor = WordsException.class)
     public List<WordVariant> getOrCreateWordEntities(String word, LanguageCode targetLanguage) {
         // 1. WordVariant에서 검색 (변형 형태인지 확인)
         List<WordVariant> existingVariants = wordVariantRepository.findAllByWord(word);
@@ -118,17 +114,9 @@ public class WordService {
                 () -> {
                     List<WordAnalysisResult> analysisResults = analyzeWordAndUpdateInvalidCache(
                             word,
-                            targetLanguage,
-                            cachedInvalidWord
+                            targetLanguage
                     );
-
-                    List<WordVariant> savedVariants = new ArrayList<>();
-                    for (WordAnalysisResult analysisResult : analysisResults) {
-                        WordVariant savedVariant = saveWordFromAnalysis(word, analysisResult);
-                        savedVariants.add(savedVariant);
-                    }
-
-                    return savedVariants;
+                    return wordPersistenceService.saveAnalysisResults(word, analysisResults, cachedInvalidWord);
                 },
                 () -> findWordVariantsAfterSingleFlight(word, invalidAttemptCountBeforeSingleFlight)
         );
@@ -158,215 +146,19 @@ public class WordService {
     private void cacheInvalidWordIfMeaningless(String word, WordsException e) {
         if (e.getErrorCode() == WordsErrorCode.WORD_IS_MEANINGLESS) {
             log.warn("AI classified word '{}' as meaningless. Updating invalid-word cache.", word, e);
-            saveInvalidWord(word);
+            wordPersistenceService.saveInvalidWord(word);
         }
     }
 
     private List<WordAnalysisResult> analyzeWordAndUpdateInvalidCache(
             String word,
-            LanguageCode targetLanguage,
-            Optional<InvalidWord> cachedInvalidWord
+            LanguageCode targetLanguage
     ) {
-        List<WordAnalysisResult> analysisResults;
         try {
-            analysisResults = wordAiService.analyzeWord(word, targetLanguage.getCode());
+            return wordAiService.analyzeWord(word, targetLanguage.getCode());
         } catch (WordsException e) {
             cacheInvalidWordIfMeaningless(word, e);
             throw e;
-        }
-
-        cachedInvalidWord.ifPresent(invalidWord -> {
-            invalidWordRepository.delete(invalidWord);
-            log.info("Removed word '{}' from invalid word cache after successful AI analysis (was attempt {}/3)",
-                    word, invalidWord.getAttemptCount());
-        });
-
-        return analysisResults;
-    }
-
-
-    @Transactional
-    public WordVariant saveWordFromAnalysis(String word, WordAnalysisResult analysisResult) {
-        // 1. 원형 단어가 해당 언어 쌍으로 이미 존재하는지 확인
-        String originalForm = analysisResult.getOriginalForm();
-        LanguageCode sourceLanguageCode = analysisResult.getSourceLanguageCode();
-        LanguageCode targetLanguageCode = analysisResult.getTargetLanguageCode();
-
-        wordRepository.findByWordAndSourceLanguageCodeAndTargetLanguageCode(
-                originalForm, sourceLanguageCode, targetLanguageCode
-        ).orElseGet(() -> {
-            // 해당 언어 쌍으로 번역된 Word가 없으면 새로 저장
-            Word newWord = convertAnalysisResultToWord(analysisResult);
-            Word savedWord = wordRepository.save(newWord);
-            log.info("Saved new word: {} ({} -> {})", originalForm, sourceLanguageCode, targetLanguageCode);
-
-            // 변형 형태들을 WordVariant에 저장 (언어 중립적)
-            saveWordVariants(savedWord);
-
-            return savedWord;
-        });
-
-        // 2. 입력 단어를 WordVariant에 저장 (언어 중립적, 중복 체크)
-        // 중요: word와 originalForm 둘 다 체크해야 함 (homograph 대응)
-        Optional<WordVariant> existingVariant = wordVariantRepository.findByWordAndOriginalForm(word, originalForm);
-        if (existingVariant.isPresent()) {
-            log.info("Variant already exists: {} -> {}", word, originalForm);
-            return existingVariant.get();
-        }
-
-        List<VariantType> variantTypes = analysisResult.getVariantTypes() != null && !analysisResult.getVariantTypes().isEmpty()
-                ? analysisResult.getVariantTypes()
-                : List.of(VariantType.ORIGINAL_FORM);
-
-        WordVariant inputVariant = createVariant(word, originalForm, variantTypes);
-        wordVariantRepository.save(inputVariant);
-        log.info("Saved input variant: {} -> {} ({})", word, originalForm, variantTypes);
-
-        return inputVariant;
-    }
-
-    private Word convertAnalysisResultToWord(WordAnalysisResult result) {
-        // RelatedForms 구성
-        RelatedForms relatedForms = RelatedForms.builder()
-                .conjugations(result.getConjugations())
-                .comparatives(result.getComparatives())
-                .plural(result.getPlural())
-                .build();
-
-        return Word.builder()
-                .word(result.getOriginalForm())
-                .sourceLanguageCode(result.getSourceLanguageCode())
-                .targetLanguageCode(result.getTargetLanguageCode())
-                .summary(result.getSummary())
-                .meanings(result.getMeanings())  // AI의 Meaning을 그대로 저장
-                .relatedForms(relatedForms)
-                .build();
-    }
-
-    @Transactional
-    public void saveWordVariants(Word word) {
-        List<WordVariant> variants = new ArrayList<>();
-
-        RelatedForms relatedForms = word.getRelatedForms();
-        if (relatedForms == null) {
-            return;
-        }
-
-        // 동사 변형 저장
-        if (relatedForms.getConjugations() != null) {
-            var conj = relatedForms.getConjugations();
-            if (conj.getPast() != null && !conj.getPast().equals(word.getWord())) {
-                variants.add(createVariant(conj.getPast(), word.getWord(), List.of(VariantType.PAST_TENSE)));
-            }
-            if (conj.getPastParticiple() != null && !conj.getPastParticiple().equals(word.getWord())) {
-                variants.add(createVariant(conj.getPastParticiple(), word.getWord(), List.of(VariantType.PAST_PARTICIPLE)));
-            }
-            if (conj.getPresentParticiple() != null && !conj.getPresentParticiple().equals(word.getWord())) {
-                variants.add(createVariant(conj.getPresentParticiple(), word.getWord(), List.of(VariantType.PRESENT_PARTICIPLE)));
-            }
-            if (conj.getThirdPerson() != null && !conj.getThirdPerson().equals(word.getWord())) {
-                variants.add(createVariant(conj.getThirdPerson(), word.getWord(), List.of(VariantType.THIRD_PERSON)));
-            }
-        }
-
-        // 형용사/부사 변형 저장
-        if (relatedForms.getComparatives() != null) {
-            var comp = relatedForms.getComparatives();
-            if (comp.getComparative() != null && !comp.getComparative().equals(word.getWord())) {
-                variants.add(createVariant(comp.getComparative(), word.getWord(), List.of(VariantType.COMPARATIVE)));
-            }
-            if (comp.getSuperlative() != null && !comp.getSuperlative().equals(word.getWord())) {
-                variants.add(createVariant(comp.getSuperlative(), word.getWord(), List.of(VariantType.SUPERLATIVE)));
-            }
-        }
-
-        // 명사 복수형 저장
-        if (relatedForms.getPlural() != null) {
-            var plural = relatedForms.getPlural();
-            if (plural.getPlural() != null && !plural.getPlural().equals(word.getWord())) {
-                variants.add(createVariant(plural.getPlural(), word.getWord(), List.of(VariantType.PLURAL)));
-            }
-        }
-
-        // N+1 문제 해결: 한 번에 조회 후 필터링
-        if (!variants.isEmpty()) {
-            // 중복 제거 및 variantTypes 병합: 같은 단어가 여러 번 추가되는 경우 variantTypes를 합침
-            List<WordVariant> uniqueVariants = variants.stream()
-                    .collect(Collectors.toMap(
-                            WordVariant::getWord,
-                            variant -> variant,
-                            (existing, replacement) -> {
-                                // 같은 단어인 경우 variantTypes를 병합
-                                List<VariantType> mergedTypes = new ArrayList<>(existing.getVariantTypes());
-                                replacement.getVariantTypes().forEach(type -> {
-                                    if (!mergedTypes.contains(type)) {
-                                        mergedTypes.add(type);
-                                    }
-                                });
-                                existing.setVariantTypes(mergedTypes);
-                                return existing;
-                            }
-                    ))
-                    .values()
-                    .stream()
-                    .collect(Collectors.toList());
-
-            List<String> variantWords = uniqueVariants.stream()
-                    .map(WordVariant::getWord)
-                    .collect(Collectors.toList());
-
-            // 이미 존재하는 variant들을 한 번의 쿼리로 조회
-            List<WordVariant> existingVariants = wordVariantRepository.findByWordIn(variantWords);
-            List<String> existingWords = existingVariants.stream()
-                    .map(WordVariant::getWord)
-                    .collect(Collectors.toList());
-
-            // 새로운 variant만 필터링하여 배치 저장
-            List<WordVariant> newVariants = uniqueVariants.stream()
-                    .filter(variant -> !existingWords.contains(variant.getWord()))
-                    .collect(Collectors.toList());
-
-            if (!newVariants.isEmpty()) {
-                wordVariantRepository.saveAll(newVariants);
-                newVariants.forEach(variant ->
-                    log.info("Saved variant: {} -> {} ({})", variant.getWord(), variant.getOriginalForm(), variant.getVariantTypes())
-                );
-            }
-        }
-    }
-
-    private WordVariant createVariant(String variantWord, String originalForm, List<VariantType> types) {
-        return WordVariant.builder()
-                .word(variantWord)
-                .originalForm(originalForm)
-                .variantTypes(types)
-                .build();
-    }
-
-    /**
-     * 유효하지 않은 단어를 캐시에 저장 (AI 재호출 방지)
-     */
-    @Transactional
-    public void saveInvalidWord(String word) {
-        Optional<InvalidWord> existingInvalidWord = invalidWordRepository.findByWord(word);
-
-        if (existingInvalidWord.isPresent()) {
-            // 이미 존재하면 시도 횟수만 증가
-            InvalidWord invalidWord = existingInvalidWord.get();
-            invalidWord.setAttemptCount(invalidWord.getAttemptCount() + 1);
-            invalidWordRepository.save(invalidWord);
-            log.info("Updated invalid word '{}' attempt count: {}", word, invalidWord.getAttemptCount());
-        } else {
-            // 새로 저장
-            LocalDateTime now = LocalDateTime.now();
-
-            InvalidWord invalidWord = InvalidWord.builder()
-                    .word(word)
-                    .attemptedAt(now)
-                    .attemptCount(1)
-                    .build();
-            invalidWordRepository.save(invalidWord);
-            log.info("Cached invalid word '{}' permanently (attempt 1/3)", word);
         }
     }
 
@@ -388,14 +180,12 @@ public class WordService {
     /**
      * 관리자 전용: 단어를 AI로 강제 재분석
      *
-     * @param word 재분석할 단어
+     * @param word           재분석할 단어
      * @param targetLanguage 번역 대상 언어
-     * @param overwrite true: 기존 데이터 삭제 후 재생성, false: 기존 유지 + 새로운 의미 추가
-     * @return WordSearchResponse
+     * @param overwrite      true: 기존 데이터 삭제 후 재생성, false: 기존 유지 + 새로운 의미 추가
      */
-    @Transactional
-    public WordSearchResponse forceReanalyzeWord(String word, LanguageCode targetLanguage, boolean overwrite) {
-        return forceReanalyzeWord(word, targetLanguage, overwrite, false);
+    public void forceReanalyzeWord(String word, LanguageCode targetLanguage, boolean overwrite) {
+        forceReanalyzeWord(word, targetLanguage, overwrite, false);
     }
 
     /**
@@ -407,46 +197,22 @@ public class WordService {
      * @param deleteVariants true: Variant도 함께 삭제 (완전 초기화), false: Variant 유지 (기본값)
      * @return WordSearchResponse
      */
-    @Transactional
     public WordSearchResponse forceReanalyzeWord(String word, LanguageCode targetLanguage, boolean overwrite, boolean deleteVariants) {
         log.info("Force re-analyzing word '{}' with targetLanguage={}, overwrite={}, deleteVariants={}",
                 word, targetLanguage, overwrite, deleteVariants);
-
-        if (overwrite) {
-            List<WordVariant> existingVariants = wordVariantRepository.findAllByWord(word);
-            if (!existingVariants.isEmpty()) {
-                // 관련된 원형 단어들의 Word 엔티티 삭제
-                for (WordVariant variant : existingVariants) {
-                    String originalForm = variant.getOriginalForm();
-                    wordRepository.findByWordAndTargetLanguageCode(
-                            originalForm, targetLanguage
-                    ).ifPresent(wordToDelete -> {
-                        wordRepository.delete(wordToDelete);
-                        log.info("Deleted Word: {} (targetLanguage={})", originalForm, targetLanguage);
-                    });
-                }
-
-                if (deleteVariants) {
-                    // Variant도 함께 삭제 (완전 초기화)
-                    wordVariantRepository.deleteAll(existingVariants);
-                    log.info("Deleted {} existing WordVariants for word '{}' (complete reset)", existingVariants.size(), word);
-                } else {
-                    // Variant는 유지 (AI가 기존 관계 + 새로운 homograph 추가 가능)
-                    log.info("Kept {} existing WordVariants for word '{}' (only Word deleted)", existingVariants.size(), word);
-                }
-            }
-        }
 
         // AI로 재분석
         log.info("Calling AI to re-analyze word '{}'...", word);
         List<WordAnalysisResult> analysisResults = wordAiService.analyzeWord(word, targetLanguage.getCode());
 
         // 분석 결과를 DB에 저장 (빈 결과는 WordAiService에서 예외 발생, overwrite=false면 중복 체크로 인해 새로운 것만 추가됨)
-        List<WordVariant> savedVariants = new ArrayList<>();
-        for (WordAnalysisResult analysisResult : analysisResults) {
-            WordVariant savedVariant = saveWordFromAnalysis(word, analysisResult);
-            savedVariants.add(savedVariant);
-        }
+        List<WordVariant> savedVariants = wordPersistenceService.forceSaveAnalysisResults(
+                word,
+                targetLanguage,
+                overwrite,
+                deleteVariants,
+                analysisResults
+        );
 
         log.info("Force re-analysis completed. Saved {} variants", savedVariants.size());
 

--- a/src/main/java/com/linglevel/api/word/service/WordService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordService.java
@@ -173,10 +173,6 @@ public class WordService {
         } catch (WordsException e) {
             cacheInvalidWordIfMeaningless(word, e);
             throw e;
-        } catch (RuntimeException e) {
-            log.warn("AI call failed for word '{}'. Caching as invalid word to prevent retries.", word, e);
-            saveInvalidWord(word);
-            throw new WordsException(WordsErrorCode.WORD_IS_MEANINGLESS);
         }
 
         cachedInvalidWord.ifPresent(invalidWord -> {

--- a/src/main/java/com/linglevel/api/word/service/WordVariantService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordVariantService.java
@@ -11,8 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * WordVariant 전용 서비스 (언어 중립적)
@@ -30,33 +30,35 @@ public class WordVariantService {
     private final WordAiService wordAiService;
 
     /**
-     * 단어의 원형을 반환 (언어 중립적)
+     * 단어의 원형 후보들을 반환 (언어 중립적)
      *
      * @param word 검색할 단어 (변형 형태 가능)
-     * @return 원형 단어
+     * @return 원형 단어 후보 목록
      */
     @Transactional
-    public String getOriginalForm(String word) {
-        WordVariant variant = getOrCreateWordVariant(word);
-        return variant.getOriginalForm();
+    public List<String> getOriginalForms(String word) {
+        return getOrCreateWordVariants(word).stream()
+                .map(WordVariant::getOriginalForm)
+                .distinct()
+                .toList();
     }
 
     /**
      * WordVariant 조회 또는 생성
-     * DB에 없으면 AI로 분석하여 원형 찾기
+     * DB에 없으면 AI로 분석하여 가능한 원형들을 찾기
      *
      * @param word 검색할 단어
-     * @return WordVariant
+     * @return WordVariant 목록
      */
     @Transactional
-    public WordVariant getOrCreateWordVariant(String word) {
+    public List<WordVariant> getOrCreateWordVariants(String word) {
         // 1. WordVariant에서 검색
-        Optional<WordVariant> variantOpt = wordVariantRepository.findByWord(word);
-        if (variantOpt.isPresent()) {
-            return variantOpt.get();
+        List<WordVariant> existingVariants = wordVariantRepository.findAllByWord(word);
+        if (!existingVariants.isEmpty()) {
+            return existingVariants;
         }
 
-        // 2. DB에 없으면 AI 호출 (기본 언어 KO 사용 - 언어는 중요하지 않음, 원형만 필요)
+        // 2. DB에 없으면 AI 호출 (기본 언어 KO 사용 - 언어는 중요하지 않음, 원형 후보만 필요)
         log.info("WordVariant '{}' not found. Calling AI to find original form...", word);
         List<WordAnalysisResult> analysisResults = wordAiService.analyzeWord(word, LanguageCode.KO.getCode());
 
@@ -64,24 +66,29 @@ public class WordVariantService {
             log.warn("AI could not find original form for word '{}'", word);
             throw new WordsException(WordsErrorCode.WORD_IS_MEANINGLESS);
         }
-        // 3. 첫 번째 결과로 WordVariant 생성 및 저장
-        WordAnalysisResult result = analysisResults.get(0);
-        WordVariant newVariant = WordVariant.builder()
-                .word(word)
-                .originalForm(result.getOriginalForm())
-                .variantTypes(result.getVariantTypes())
-                .build();
+        // 3. 분석 결과의 원형 후보들을 모두 저장한다. 같은 원형이 중복되면 첫 결과를 유지한다.
+        List<WordVariant> newVariants = new ArrayList<>();
+        for (WordAnalysisResult result : analysisResults) {
+            boolean alreadyAdded = newVariants.stream()
+                    .anyMatch(variant -> variant.getOriginalForm().equals(result.getOriginalForm()));
+            if (alreadyAdded) {
+                continue;
+            }
 
-        WordVariant savedVariant = wordVariantRepository.save(newVariant);
-        log.info("Saved new WordVariant: {} -> {} ({})", word, result.getOriginalForm(), result.getVariantTypes());
+            newVariants.add(WordVariant.builder()
+                    .word(word)
+                    .originalForm(result.getOriginalForm())
+                    .variantTypes(result.getVariantTypes())
+                    .build());
+        }
 
-        return savedVariant;
+        List<WordVariant> savedVariants = wordVariantRepository.saveAll(newVariants);
+        savedVariants.forEach(variant ->
+                log.info("Saved new WordVariant: {} -> {} ({})",
+                        word, variant.getOriginalForm(), variant.getVariantTypes())
+        );
+
+        return savedVariants;
     }
 
-    /**
-     * 단어가 WordVariant에 존재하는지 확인
-     */
-    public boolean exists(String word) {
-        return wordVariantRepository.findByWord(word).isPresent();
-    }
 }

--- a/src/main/java/com/linglevel/api/word/service/WordVariantService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordVariantService.java
@@ -1,17 +1,11 @@
 package com.linglevel.api.word.service;
 
-import com.linglevel.api.i18n.LanguageCode;
-import com.linglevel.api.word.dto.WordAnalysisResult;
 import com.linglevel.api.word.entity.WordVariant;
-import com.linglevel.api.word.exception.WordsErrorCode;
-import com.linglevel.api.word.exception.WordsException;
 import com.linglevel.api.word.repository.WordVariantRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -27,7 +21,6 @@ import java.util.List;
 public class WordVariantService {
 
     private final WordVariantRepository wordVariantRepository;
-    private final WordAiService wordAiService;
 
     /**
      * 단어의 원형 후보들을 반환 (언어 중립적)
@@ -35,60 +28,10 @@ public class WordVariantService {
      * @param word 검색할 단어 (변형 형태 가능)
      * @return 원형 단어 후보 목록
      */
-    @Transactional
     public List<String> getOriginalForms(String word) {
-        return getOrCreateWordVariants(word).stream()
+        return wordVariantRepository.findAllByWord(word).stream()
                 .map(WordVariant::getOriginalForm)
                 .distinct()
                 .toList();
     }
-
-    /**
-     * WordVariant 조회 또는 생성
-     * DB에 없으면 AI로 분석하여 가능한 원형들을 찾기
-     *
-     * @param word 검색할 단어
-     * @return WordVariant 목록
-     */
-    @Transactional
-    public List<WordVariant> getOrCreateWordVariants(String word) {
-        // 1. WordVariant에서 검색
-        List<WordVariant> existingVariants = wordVariantRepository.findAllByWord(word);
-        if (!existingVariants.isEmpty()) {
-            return existingVariants;
-        }
-
-        // 2. DB에 없으면 AI 호출 (기본 언어 KO 사용 - 언어는 중요하지 않음, 원형 후보만 필요)
-        log.info("WordVariant '{}' not found. Calling AI to find original form...", word);
-        List<WordAnalysisResult> analysisResults = wordAiService.analyzeWord(word, LanguageCode.KO.getCode());
-
-        if (analysisResults.isEmpty()) {
-            log.warn("AI could not find original form for word '{}'", word);
-            throw new WordsException(WordsErrorCode.WORD_IS_MEANINGLESS);
-        }
-        // 3. 분석 결과의 원형 후보들을 모두 저장한다. 같은 원형이 중복되면 첫 결과를 유지한다.
-        List<WordVariant> newVariants = new ArrayList<>();
-        for (WordAnalysisResult result : analysisResults) {
-            boolean alreadyAdded = newVariants.stream()
-                    .anyMatch(variant -> variant.getOriginalForm().equals(result.getOriginalForm()));
-            if (alreadyAdded) {
-                continue;
-            }
-
-            newVariants.add(WordVariant.builder()
-                    .word(word)
-                    .originalForm(result.getOriginalForm())
-                    .variantTypes(result.getVariantTypes())
-                    .build());
-        }
-
-        List<WordVariant> savedVariants = wordVariantRepository.saveAll(newVariants);
-        savedVariants.forEach(variant ->
-                log.info("Saved new WordVariant: {} -> {} ({})",
-                        word, variant.getOriginalForm(), variant.getVariantTypes())
-        );
-
-        return savedVariants;
-    }
-
 }

--- a/src/test/java/com/linglevel/api/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/com/linglevel/api/bookmark/service/BookmarkServiceTest.java
@@ -55,15 +55,31 @@ class BookmarkServiceTest {
     void removeWordBookmark_variantCandidates_deletesExistingBookmarkedOriginalForm() {
         // given
         String userId = "user-1";
-        String word = "saw";
-        when(wordVariantService.getOriginalForms(word)).thenReturn(List.of("see", "saw"));
-        when(wordBookmarkRepository.existsByUserIdAndWord(userId, "see")).thenReturn(false);
-        when(wordBookmarkRepository.existsByUserIdAndWord(userId, "saw")).thenReturn(true);
+        String word = "ran";
+        when(wordVariantService.getOriginalForms(word)).thenReturn(List.of("run"));
+        when(wordBookmarkRepository.existsByUserIdAndWord(userId, word)).thenReturn(false);
+        when(wordBookmarkRepository.existsByUserIdAndWord(userId, "run")).thenReturn(true);
 
         // when
         bookmarkService.removeWordBookmark(userId, word);
 
         // then
-        verify(wordBookmarkRepository).deleteByUserIdAndWord(userId, "saw");
+        verify(wordBookmarkRepository).deleteByUserIdAndWord(userId, "run");
+    }
+
+    @Test
+    @DisplayName("입력 단어와 variant 원형 후보가 모두 북마크되어 있으면 입력 단어를 우선 삭제한다")
+    void removeWordBookmark_exactBookmarkExists_deletesInputWordBeforeVariantCandidate() {
+        // given
+        String userId = "user-1";
+        String word = "saw";
+        when(wordVariantService.getOriginalForms(word)).thenReturn(List.of("see", "saw"));
+        when(wordBookmarkRepository.existsByUserIdAndWord(userId, word)).thenReturn(true);
+
+        // when
+        bookmarkService.removeWordBookmark(userId, word);
+
+        // then
+        verify(wordBookmarkRepository).deleteByUserIdAndWord(userId, word);
     }
 }

--- a/src/test/java/com/linglevel/api/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/com/linglevel/api/bookmark/service/BookmarkServiceTest.java
@@ -1,0 +1,69 @@
+package com.linglevel.api.bookmark.service;
+
+import com.linglevel.api.bookmark.repository.WordBookmarkRepository;
+import com.linglevel.api.word.repository.WordRepository;
+import com.linglevel.api.word.service.WordService;
+import com.linglevel.api.word.service.WordVariantService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BookmarkServiceTest {
+
+    @Mock
+    private WordBookmarkRepository wordBookmarkRepository;
+
+    @Mock
+    private WordRepository wordRepository;
+
+    @Mock
+    private WordVariantService wordVariantService;
+
+    @Mock
+    private WordService wordService;
+
+    @InjectMocks
+    private BookmarkService bookmarkService;
+
+    @Test
+    @DisplayName("variant 원형 후보가 없어도 입력 단어 북마크가 있으면 삭제한다")
+    void removeWordBookmark_noVariantCandidate_deletesBookmarkByInputWord() {
+        // given
+        String userId = "user-1";
+        String word = "run";
+        when(wordVariantService.getOriginalForms(word)).thenReturn(List.of());
+        when(wordBookmarkRepository.existsByUserIdAndWord(userId, word)).thenReturn(true);
+
+        // when
+        bookmarkService.removeWordBookmark(userId, word);
+
+        // then
+        verify(wordBookmarkRepository).deleteByUserIdAndWord(userId, word);
+    }
+
+    @Test
+    @DisplayName("variant 원형 후보 중 실제 북마크된 단어를 찾아 삭제한다")
+    void removeWordBookmark_variantCandidates_deletesExistingBookmarkedOriginalForm() {
+        // given
+        String userId = "user-1";
+        String word = "saw";
+        when(wordVariantService.getOriginalForms(word)).thenReturn(List.of("see", "saw"));
+        when(wordBookmarkRepository.existsByUserIdAndWord(userId, "see")).thenReturn(false);
+        when(wordBookmarkRepository.existsByUserIdAndWord(userId, "saw")).thenReturn(true);
+
+        // when
+        bookmarkService.removeWordBookmark(userId, word);
+
+        // then
+        verify(wordBookmarkRepository).deleteByUserIdAndWord(userId, "saw");
+    }
+}

--- a/src/test/java/com/linglevel/api/word/service/WordAiServiceIntegrationTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordAiServiceIntegrationTest.java
@@ -3,6 +3,7 @@ package com.linglevel.api.word.service;
 import com.linglevel.api.word.dto.PartOfSpeech;
 import com.linglevel.api.word.dto.VariantType;
 import com.linglevel.api.word.dto.WordAnalysisResult;
+import com.linglevel.api.word.exception.WordsErrorCode;
 import com.linglevel.api.word.exception.WordsException;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
@@ -339,13 +340,12 @@ class WordAiServiceIntegrationTest {
         String targetLanguage = "KO";
 
         // when & then
-        // AI가 의미 없는 단어에 대해 빈 배열을 반환하면 WordsException을 던짐 (RuntimeException으로 래핑됨)
-        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+        // AI가 의미 없는 단어에 대해 빈 배열을 반환하면 WordsException을 그대로 던짐
+        WordsException exception = assertThrows(WordsException.class, () -> {
             wordAiService.analyzeWord(word, targetLanguage);
         });
 
-        // RuntimeException의 cause가 WordsException인지 확인
-        assertThat(exception.getCause()).isInstanceOf(WordsException.class);
+        assertThat(exception.getErrorCode()).isEqualTo(WordsErrorCode.WORD_IS_MEANINGLESS);
     }
 
     // ===== 실패 사례 기반 추가 테스트 =====

--- a/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
@@ -309,10 +309,10 @@ class WordServiceTest {
     }
 
     @Test
-    @DisplayName("AI 호출 실패는 invalid 캐시에 반영하지 않고 그대로 전파")
-    void getOrCreateWords_aiRuntimeFailure_doesNotCacheInvalidWord() {
+    @DisplayName("AI 분석 실패는 invalid 캐시에 반영하지 않고 분석 실패 에러로 전파")
+    void getOrCreateWords_aiAnalysisFailure_doesNotCacheInvalidWord() {
         String word = "resilience";
-        RuntimeException failure = new RuntimeException("bedrock failure");
+        WordsException failure = new WordsException(WordsErrorCode.WORD_ANALYSIS_FAILED);
 
         when(wordVariantRepository.findAllByWord(word)).thenReturn(List.of());
         when(invalidWordRepository.findByWord(word)).thenReturn(Optional.empty());
@@ -320,7 +320,9 @@ class WordServiceTest {
                 .thenThrow(failure);
 
         assertThatThrownBy(() -> wordService.getOrCreateWords(userId, word, LanguageCode.KO))
-                .isSameAs(failure);
+                .isSameAs(failure)
+                .satisfies(ex -> assertThat(((WordsException) ex).getErrorCode())
+                        .isEqualTo(WordsErrorCode.WORD_ANALYSIS_FAILED));
 
         verify(invalidWordRepository, never()).save(any());
     }

--- a/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -55,14 +54,29 @@ class WordServiceTest {
     @Mock
     private WordSingleFlightRedisCoordinator singleFlightCoordinator;
 
-    @InjectMocks
     private WordService wordService;
+    private WordPersistenceService wordPersistenceService;
 
     private Word sampleWord;
     private String userId = "test-user-123";
 
     @BeforeEach
     void setUp() {
+        wordPersistenceService = new WordPersistenceService(
+                wordRepository,
+                wordVariantRepository,
+                invalidWordRepository
+        );
+        wordService = new WordService(
+                wordRepository,
+                wordBookmarkRepository,
+                wordVariantRepository,
+                invalidWordRepository,
+                wordAiService,
+                singleFlightCoordinator,
+                wordPersistenceService
+        );
+
         lenient().when(singleFlightCoordinator.execute(anyString(), any(LanguageCode.class), any(), any()))
                 .thenAnswer(invocation -> {
                     Supplier<Optional<?>> lookup = invocation.getArgument(3);
@@ -236,10 +250,26 @@ class WordServiceTest {
     @DisplayName("단어 저장 시 모든 변형 형태를 WordVariant에 저장")
     void saveWordVariants_모든_변형_형태_저장() {
         // given
+        WordAnalysisResult analysisResult = WordAnalysisResult.builder()
+                .originalForm(sampleWord.getWord())
+                .variantTypes(List.of(VariantType.ORIGINAL_FORM))
+                .sourceLanguageCode(sampleWord.getSourceLanguageCode())
+                .targetLanguageCode(sampleWord.getTargetLanguageCode())
+                .summary(sampleWord.getSummary())
+                .meanings(sampleWord.getMeanings())
+                .conjugations(sampleWord.getRelatedForms().getConjugations())
+                .build();
+
+        when(wordRepository.findByWordAndSourceLanguageCodeAndTargetLanguageCode(
+                sampleWord.getWord(),
+                sampleWord.getSourceLanguageCode(),
+                sampleWord.getTargetLanguageCode()
+        )).thenReturn(Optional.empty());
+        when(wordRepository.save(any(Word.class))).thenReturn(sampleWord);
         when(wordVariantRepository.findByWordIn(anyList())).thenReturn(List.of());
 
         // when
-        wordService.saveWordVariants(sampleWord);
+        wordPersistenceService.saveAnalysisResults("run", List.of(analysisResult), Optional.empty());
 
         // then
         // 동사 변형 4개가 저장되어야 함 (past, pastParticiple, presentParticiple, thirdPerson)

--- a/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
@@ -309,20 +309,20 @@ class WordServiceTest {
     }
 
     @Test
-    @DisplayName("AI 호출 실패가 발생하면 invalid 캐시에 반영")
-    void getOrCreateWords_aiRuntimeFailure_cachesInvalidWord() {
+    @DisplayName("AI 호출 실패는 invalid 캐시에 반영하지 않고 그대로 전파")
+    void getOrCreateWords_aiRuntimeFailure_doesNotCacheInvalidWord() {
         String word = "resilience";
+        RuntimeException failure = new RuntimeException("bedrock failure");
 
         when(wordVariantRepository.findAllByWord(word)).thenReturn(List.of());
         when(invalidWordRepository.findByWord(word)).thenReturn(Optional.empty());
         when(wordAiService.analyzeWord(word, LanguageCode.KO.getCode()))
-                .thenThrow(new RuntimeException("bedrock failure"));
+                .thenThrow(failure);
 
         assertThatThrownBy(() -> wordService.getOrCreateWords(userId, word, LanguageCode.KO))
-                .isInstanceOf(WordsException.class)
-                .hasMessageContaining("meaningless");
+                .isSameAs(failure);
 
-        verify(invalidWordRepository).save(any());
+        verify(invalidWordRepository, never()).save(any());
     }
 
     @Test

--- a/src/test/java/com/linglevel/api/word/service/WordVariantServiceTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordVariantServiceTest.java
@@ -1,0 +1,94 @@
+package com.linglevel.api.word.service;
+
+import com.linglevel.api.i18n.LanguageCode;
+import com.linglevel.api.word.dto.VariantType;
+import com.linglevel.api.word.dto.WordAnalysisResult;
+import com.linglevel.api.word.entity.WordVariant;
+import com.linglevel.api.word.repository.WordVariantRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WordVariantServiceTest {
+
+    @Mock
+    private WordVariantRepository wordVariantRepository;
+
+    @Mock
+    private WordAiService wordAiService;
+
+    @InjectMocks
+    private WordVariantService wordVariantService;
+
+    @Test
+    @DisplayName("기존 WordVariant가 여러 개 있으면 모두 원형 후보로 반환한다")
+    void getOriginalForms_existingVariants_returnsAllOriginalForms() {
+        // given
+        String word = "saw";
+        when(wordVariantRepository.findAllByWord(word)).thenReturn(List.of(
+                WordVariant.builder()
+                        .word(word)
+                        .originalForm("see")
+                        .variantTypes(List.of(VariantType.PAST_TENSE))
+                        .build(),
+                WordVariant.builder()
+                        .word(word)
+                        .originalForm("saw")
+                        .variantTypes(List.of(VariantType.ORIGINAL_FORM))
+                        .build()
+        ));
+
+        // when
+        List<String> originalForms = wordVariantService.getOriginalForms(word);
+
+        // then
+        assertThat(originalForms).containsExactly("see", "saw");
+        verify(wordAiService, never()).analyzeWord(word, LanguageCode.KO.getCode());
+    }
+
+    @Test
+    @DisplayName("DB에 없으면 AI 분석 결과의 여러 원형 후보를 모두 저장한다")
+    void getOrCreateWordVariants_aiReturnsMultipleResults_savesAllVariants() {
+        // given
+        String word = "saw";
+        List<WordAnalysisResult> analysisResults = List.of(
+                WordAnalysisResult.builder()
+                        .originalForm("see")
+                        .variantTypes(List.of(VariantType.PAST_TENSE))
+                        .sourceLanguageCode(LanguageCode.EN)
+                        .targetLanguageCode(LanguageCode.KO)
+                        .build(),
+                WordAnalysisResult.builder()
+                        .originalForm("saw")
+                        .variantTypes(List.of(VariantType.ORIGINAL_FORM))
+                        .sourceLanguageCode(LanguageCode.EN)
+                        .targetLanguageCode(LanguageCode.KO)
+                        .build()
+        );
+
+        when(wordVariantRepository.findAllByWord(word)).thenReturn(List.of());
+        when(wordAiService.analyzeWord(word, LanguageCode.KO.getCode())).thenReturn(analysisResults);
+        when(wordVariantRepository.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        List<WordVariant> variants = wordVariantService.getOrCreateWordVariants(word);
+
+        // then
+        assertThat(variants)
+                .extracting(WordVariant::getOriginalForm)
+                .containsExactly("see", "saw");
+        verify(wordVariantRepository).saveAll(anyList());
+    }
+}

--- a/src/test/java/com/linglevel/api/word/service/WordVariantServiceTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordVariantServiceTest.java
@@ -1,8 +1,6 @@
 package com.linglevel.api.word.service;
 
-import com.linglevel.api.i18n.LanguageCode;
 import com.linglevel.api.word.dto.VariantType;
-import com.linglevel.api.word.dto.WordAnalysisResult;
 import com.linglevel.api.word.entity.WordVariant;
 import com.linglevel.api.word.repository.WordVariantRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -15,9 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -25,9 +20,6 @@ class WordVariantServiceTest {
 
     @Mock
     private WordVariantRepository wordVariantRepository;
-
-    @Mock
-    private WordAiService wordAiService;
 
     @InjectMocks
     private WordVariantService wordVariantService;
@@ -55,40 +47,19 @@ class WordVariantServiceTest {
 
         // then
         assertThat(originalForms).containsExactly("see", "saw");
-        verify(wordAiService, never()).analyzeWord(word, LanguageCode.KO.getCode());
     }
 
     @Test
-    @DisplayName("DB에 없으면 AI 분석 결과의 여러 원형 후보를 모두 저장한다")
-    void getOrCreateWordVariants_aiReturnsMultipleResults_savesAllVariants() {
+    @DisplayName("기존 WordVariant가 없으면 빈 원형 후보 목록을 반환한다")
+    void getOriginalForms_noExistingVariants_returnsEmptyList() {
         // given
         String word = "saw";
-        List<WordAnalysisResult> analysisResults = List.of(
-                WordAnalysisResult.builder()
-                        .originalForm("see")
-                        .variantTypes(List.of(VariantType.PAST_TENSE))
-                        .sourceLanguageCode(LanguageCode.EN)
-                        .targetLanguageCode(LanguageCode.KO)
-                        .build(),
-                WordAnalysisResult.builder()
-                        .originalForm("saw")
-                        .variantTypes(List.of(VariantType.ORIGINAL_FORM))
-                        .sourceLanguageCode(LanguageCode.EN)
-                        .targetLanguageCode(LanguageCode.KO)
-                        .build()
-        );
-
         when(wordVariantRepository.findAllByWord(word)).thenReturn(List.of());
-        when(wordAiService.analyzeWord(word, LanguageCode.KO.getCode())).thenReturn(analysisResults);
-        when(wordVariantRepository.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
 
         // when
-        List<WordVariant> variants = wordVariantService.getOrCreateWordVariants(word);
+        List<String> originalForms = wordVariantService.getOriginalForms(word);
 
         // then
-        assertThat(variants)
-                .extracting(WordVariant::getOriginalForm)
-                .containsExactly("see", "saw");
-        verify(wordVariantRepository).saveAll(anyList());
+        assertThat(originalForms).isEmpty();
     }
 }


### PR DESCRIPTION
## Summary
word 도메인의 인덱스와 트랜잭션 경계를 재정리하고, 단어 변형 조회/북마크 흐름의 부수 효과를 줄였습니다.

## Problem
- `WordService` 내부 저장 메서드에 `@Transactional`이 붙어 있었지만 self-invocation 구조라 실제 트랜잭션 경계가 불명확했습니다.
- 북마크 서비스의 트랜잭션이 단어 생성/저장 흐름까지 감싸면서 word persistence 작업이 의도보다 넓은 트랜잭션에 참여할 수 있었습니다.
- 북마크 삭제 경로에서 `WordVariantService`가 variant가 없으면 AI 호출 후 새 variant를 저장할 수 있어, 삭제 API에 생성 side effect가 있었습니다.
- word/variant 인덱스와 repository 메서드 중 현재 조회 패턴과 맞지 않거나 사용되지 않는 항목이 남아 있었습니다.

## Solution
- `WordPersistenceService`를 분리해 `Word`, `WordVariant`, `InvalidWord` 저장 책임과 트랜잭션 경계를 별도 Bean으로 이동했습니다.
- `BookmarkService`의 불필요한 트랜잭션을 제거해 북마크 작업이 word persistence 트랜잭션을 감싸지 않도록 했습니다.
- `WordVariantService`를 조회 전용으로 축소해 북마크 삭제 경로에서 AI 호출/저장이 발생하지 않도록 했습니다.
- 단어 조회 패턴에 맞춰 word compound index를 정리하고, 사용하지 않는 repository 메서드를 제거했습니다.
- AI 분석 실패를 invalid word로 캐시하지 않고 도메인 실패로 전파하도록 정리했습니다.

## Changes
- `WordPersistenceService` 추가: 분석 결과 저장, 강제 재분석 저장, invalid word 저장 책임 분리
- `WordService`: 저장 로직 제거, AI 호출/조회/single-flight 흐름 조율 중심으로 축소
- `WordVariantService`: `getOriginalForms()` 조회 전용화, `getOrCreateWordVariants()` 제거
- `BookmarkService`: bookmark write 메서드의 `@Transactional` 제거
- `Word`, `WordVariant`: compound index 정리 및 중복/불필요 인덱스 제거
- `WordRepository`, `WordVariantRepository`, 기타 repository: 미사용 메서드 제거
- `WordAiService`, `WordsException`: AI 분석 실패 도메인 에러 전파 보강
- 관련 단위 테스트 수정/추가

## Example
- 단어 생성 요청은 AI 분석 후 `WordPersistenceService`에서 `Word + WordVariant + InvalidWord` 저장 구간만 처리합니다.
- 북마크 삭제 요청은 기존 `WordVariant` 매핑만 조회하고, 매핑이 없더라도 AI 호출이나 새 variant 저장을 수행하지 않습니다.
- homograph처럼 하나의 입력 단어가 여러 원형 후보를 가질 수 있는 경우 응답은 여러 결과를 유지하고, 북마크는 기존 정책대로 첫 번째 원형을 사용합니다.

검증:
- `./gradlew compileJava`
- `./gradlew test --tests com.linglevel.api.word.service.WordServiceTest --tests com.linglevel.api.word.service.WordVariantServiceTest --tests com.linglevel.api.word.service.WordSingleFlightRedisCoordinatorTest`

## Related Issues
없음