### PR TITLE
refactor(word): clean up API boundary handling

### DIFF
--- a/src/main/java/com/linglevel/api/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/linglevel/api/common/handler/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 import jakarta.validation.ConstraintViolationException;
 
@@ -51,6 +52,16 @@ public class GlobalExceptionHandler {
 
 		CommonException commonException = new CommonException(CommonErrorCode.INVALID_INPUT, specificError);
 		log.warn("Constraint violation: {}", specificError);
+		return ResponseEntity.status(commonException.getStatus()).body(new ExceptionResponse(commonException));
+	}
+
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<ExceptionResponse> handleMethodArgumentTypeMismatchException(
+			MethodArgumentTypeMismatchException e) {
+		String specificError = String.format("%s: 올바르지 않은 값입니다", e.getName());
+
+		CommonException commonException = new CommonException(CommonErrorCode.INVALID_INPUT, specificError);
+		log.warn("Type mismatch: {}", specificError);
 		return ResponseEntity.status(commonException.getStatus()).body(new ExceptionResponse(commonException));
 	}
 

--- a/src/main/java/com/linglevel/api/word/controller/WordsAdminController.java
+++ b/src/main/java/com/linglevel/api/word/controller/WordsAdminController.java
@@ -5,9 +5,11 @@ import com.linglevel.api.i18n.LanguageCode;
 import com.linglevel.api.word.dto.EssentialWordsStatsResponse;
 import com.linglevel.api.word.dto.Oxford3000InitResponse;
 import com.linglevel.api.word.dto.WordSearchResponse;
+import com.linglevel.api.word.exception.WordsErrorCode;
 import com.linglevel.api.word.exception.WordsException;
 import com.linglevel.api.word.service.Oxford3000Service;
 import com.linglevel.api.word.service.WordService;
+import com.linglevel.api.word.validator.WordValidator;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -36,6 +38,8 @@ public class WordsAdminController {
 	private final WordService wordService;
 
 	private final Oxford3000Service oxford3000Service;
+
+	private final WordValidator wordValidator;
 
 	@Operation(summary = "단어 강제 재분석", description = """
 			관리자 전용: 단어를 AI로 강제 재분석합니다.
@@ -69,7 +73,13 @@ public class WordsAdminController {
 		log.info("Admin force-analyze: word='{}', targetLanguage={}, overwrite={}, deleteVariants={}", word,
 				targetLanguage, overwrite, deleteVariants);
 
-		WordSearchResponse response = wordService.forceReanalyzeWord(word, targetLanguage, overwrite, deleteVariants);
+		if (targetLanguage == LanguageCode.EN) {
+			throw new WordsException(WordsErrorCode.SAME_SOURCE_TARGET_LANGUAGE);
+		}
+
+		String validatedWord = wordValidator.validateAndPreprocess(word);
+		WordSearchResponse response = wordService.forceReanalyzeWord(validatedWord, targetLanguage, overwrite,
+				deleteVariants);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/linglevel/api/word/controller/WordsAdminController.java
+++ b/src/main/java/com/linglevel/api/word/controller/WordsAdminController.java
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -33,6 +34,7 @@ import java.util.List;
 @Slf4j
 @Tag(name = "Words Admin", description = "단어 관리 API (관리자 전용)")
 @SecurityRequirement(name = "adminApiKey")
+@PreAuthorize("hasRole('ADMIN')")
 public class WordsAdminController {
 
 	private final WordService wordService;

--- a/src/main/java/com/linglevel/api/word/controller/WordsController.java
+++ b/src/main/java/com/linglevel/api/word/controller/WordsController.java
@@ -2,10 +2,11 @@ package com.linglevel.api.word.controller;
 
 import com.linglevel.api.auth.jwt.JwtClaims;
 import com.linglevel.api.common.dto.ExceptionResponse;
+import com.linglevel.api.common.ratelimit.annotation.RateLimit;
+import com.linglevel.api.common.ratelimit.annotation.RateLimit.KeyType;
 import com.linglevel.api.i18n.LanguageCode;
 import com.linglevel.api.word.dto.WordSearchRequest;
 import com.linglevel.api.word.dto.WordSearchResponse;
-import com.linglevel.api.word.entity.Word;
 import com.linglevel.api.word.exception.WordsErrorCode;
 import com.linglevel.api.word.exception.WordsException;
 import com.linglevel.api.word.service.WordService;
@@ -21,17 +22,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.data.mongodb.core.mapping.Language;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import com.linglevel.api.common.ratelimit.annotation.RateLimit;
-import com.linglevel.api.common.ratelimit.annotation.RateLimit.KeyType;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/words")

--- a/src/main/java/com/linglevel/api/word/dto/WordAnalysisResult.java
+++ b/src/main/java/com/linglevel/api/word/dto/WordAnalysisResult.java
@@ -2,6 +2,8 @@ package com.linglevel.api.word.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.linglevel.api.i18n.LanguageCode;
+import com.linglevel.api.word.model.Meaning;
+import com.linglevel.api.word.model.RelatedForms;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;

--- a/src/main/java/com/linglevel/api/word/dto/WordResponse.java
+++ b/src/main/java/com/linglevel/api/word/dto/WordResponse.java
@@ -1,6 +1,8 @@
 package com.linglevel.api.word.dto;
 
 import com.linglevel.api.i18n.LanguageCode;
+import com.linglevel.api.word.model.Meaning;
+import com.linglevel.api.word.model.RelatedForms;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/linglevel/api/word/entity/Word.java
+++ b/src/main/java/com/linglevel/api/word/entity/Word.java
@@ -1,8 +1,8 @@
 package com.linglevel.api.word.entity;
 
 import com.linglevel.api.i18n.LanguageCode;
-import com.linglevel.api.word.dto.Meaning;
-import com.linglevel.api.word.dto.RelatedForms;
+import com.linglevel.api.word.model.Meaning;
+import com.linglevel.api.word.model.RelatedForms;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.CompoundIndex;

--- a/src/main/java/com/linglevel/api/word/mapper/WordResponseMapper.java
+++ b/src/main/java/com/linglevel/api/word/mapper/WordResponseMapper.java
@@ -1,0 +1,34 @@
+package com.linglevel.api.word.mapper;
+
+import com.linglevel.api.word.dto.VariantType;
+import com.linglevel.api.word.dto.WordResponse;
+import com.linglevel.api.word.dto.WordSearchResponse;
+import com.linglevel.api.word.entity.Word;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class WordResponseMapper {
+
+	public WordResponse toWordResponse(Word word, boolean bookmarked, List<VariantType> variantTypes,
+			String originalForm) {
+		return WordResponse.builder()
+			.id(word.getId())
+			.originalForm(originalForm)
+			.variantTypes(variantTypes)
+			.sourceLanguageCode(word.getSourceLanguageCode())
+			.targetLanguageCode(word.getTargetLanguageCode())
+			.summary(word.getSummary())
+			.meanings(word.getMeanings())
+			.relatedForms(word.getRelatedForms())
+			.bookmarked(bookmarked)
+			.isEssential(word.getIsEssential())
+			.build();
+	}
+
+	public WordSearchResponse toWordSearchResponse(String searchedWord, List<WordResponse> results) {
+		return WordSearchResponse.builder().searchedWord(searchedWord).results(results).build();
+	}
+
+}

--- a/src/main/java/com/linglevel/api/word/model/Meaning.java
+++ b/src/main/java/com/linglevel/api/word/model/Meaning.java
@@ -1,5 +1,6 @@
-package com.linglevel.api.word.dto;
+package com.linglevel.api.word.model;
 
+import com.linglevel.api.word.dto.PartOfSpeech;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/linglevel/api/word/model/RelatedForms.java
+++ b/src/main/java/com/linglevel/api/word/model/RelatedForms.java
@@ -1,4 +1,4 @@
-package com.linglevel.api.word.dto;
+package com.linglevel.api.word.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/linglevel/api/word/service/WordAiService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordAiService.java
@@ -3,6 +3,7 @@ package com.linglevel.api.word.service;
 import com.linglevel.api.word.dto.WordAnalysisResult;
 import com.linglevel.api.word.exception.WordsErrorCode;
 import com.linglevel.api.word.exception.WordsException;
+import com.linglevel.api.word.model.Meaning;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
@@ -313,12 +314,12 @@ public class WordAiService {
 			}
 
 			// 2. 유효한 PartOfSpeech를 가진 meanings만 필터링
-			List<com.linglevel.api.word.dto.Meaning> originalMeanings = result.getMeanings();
-			List<com.linglevel.api.word.dto.Meaning> validMeanings = new ArrayList<>();
+			List<Meaning> originalMeanings = result.getMeanings();
+			List<Meaning> validMeanings = new ArrayList<>();
 
 			if (originalMeanings != null) {
 				int invalidCount = 0;
-				for (com.linglevel.api.word.dto.Meaning meaning : originalMeanings) {
+				for (Meaning meaning : originalMeanings) {
 					if (meaning.getPartOfSpeech() != null) {
 						validMeanings.add(meaning);
 					}
@@ -377,7 +378,7 @@ public class WordAiService {
 			.collect(Collectors.toList());
 
 		// meanings 병합 (중복 제거 - partOfSpeech와 meaning이 같은 것은 제외)
-		List<com.linglevel.api.word.dto.Meaning> mergedMeanings = results.stream()
+		List<Meaning> mergedMeanings = results.stream()
 			.flatMap(r -> r.getMeanings().stream())
 			.collect(Collectors.toMap(m -> m.getPartOfSpeech() + ":" + m.getMeaning(), m -> m,
 					(existing, replacement) -> existing))

--- a/src/main/java/com/linglevel/api/word/service/WordPersistenceService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordPersistenceService.java
@@ -1,12 +1,12 @@
 package com.linglevel.api.word.service;
 
 import com.linglevel.api.i18n.LanguageCode;
-import com.linglevel.api.word.dto.RelatedForms;
 import com.linglevel.api.word.dto.VariantType;
 import com.linglevel.api.word.dto.WordAnalysisResult;
 import com.linglevel.api.word.entity.InvalidWord;
 import com.linglevel.api.word.entity.Word;
 import com.linglevel.api.word.entity.WordVariant;
+import com.linglevel.api.word.model.RelatedForms;
 import com.linglevel.api.word.repository.InvalidWordRepository;
 import com.linglevel.api.word.repository.WordRepository;
 import com.linglevel.api.word.repository.WordVariantRepository;

--- a/src/main/java/com/linglevel/api/word/service/WordService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordService.java
@@ -8,6 +8,7 @@ import com.linglevel.api.word.entity.Word;
 import com.linglevel.api.word.entity.WordVariant;
 import com.linglevel.api.word.exception.WordsErrorCode;
 import com.linglevel.api.word.exception.WordsException;
+import com.linglevel.api.word.mapper.WordResponseMapper;
 import com.linglevel.api.word.repository.InvalidWordRepository;
 import com.linglevel.api.word.repository.WordRepository;
 import com.linglevel.api.word.repository.WordVariantRepository;
@@ -38,6 +39,8 @@ public class WordService {
 
 	private final WordPersistenceService wordPersistenceService;
 
+	private final WordResponseMapper wordResponseMapper;
+
 	public WordSearchResponse getOrCreateWords(String userId, String word, LanguageCode targetLanguage) {
 		List<WordVariant> wordVariants = getOrCreateWordEntities(word, targetLanguage);
 
@@ -63,13 +66,13 @@ public class WordService {
 
 			boolean isBookmarked = wordBookmarkRepository.existsByUserIdAndWord(userId, wordVariant.getOriginalForm());
 
-			WordResponse response = convertToResponse(originalWord, isBookmarked, wordVariant.getVariantTypes(),
-					wordVariant.getOriginalForm());
+			WordResponse response = wordResponseMapper.toWordResponse(originalWord, isBookmarked,
+					wordVariant.getVariantTypes(), wordVariant.getOriginalForm());
 
 			results.add(response);
 		}
 
-		return WordSearchResponse.builder().searchedWord(word).results(results).build();
+		return wordResponseMapper.toWordSearchResponse(word, results);
 	}
 
 	public List<WordVariant> getOrCreateWordEntities(String word, LanguageCode targetLanguage) {
@@ -137,22 +140,6 @@ public class WordService {
 		}
 	}
 
-	private WordResponse convertToResponse(Word word, boolean isBookmarked, List<VariantType> variantTypes,
-			String originalForm) {
-		return WordResponse.builder()
-			.id(word.getId())
-			.originalForm(originalForm)
-			.variantTypes(variantTypes)
-			.sourceLanguageCode(word.getSourceLanguageCode())
-			.targetLanguageCode(word.getTargetLanguageCode())
-			.summary(word.getSummary())
-			.meanings(word.getMeanings()) // Meaning을 그대로 사용
-			.relatedForms(word.getRelatedForms())
-			.bookmarked(isBookmarked)
-			.isEssential(word.getIsEssential())
-			.build();
-	}
-
 	/**
 	 * 관리자 전용: 단어를 AI로 강제 재분석
 	 * @param word 재분석할 단어
@@ -195,13 +182,12 @@ public class WordService {
 				.findByWordAndTargetLanguageCode(wordVariant.getOriginalForm(), targetLanguage)
 				.orElseThrow(() -> new WordsException(WordsErrorCode.WORD_NOT_FOUND));
 
-			WordResponse response = convertToResponse(originalWord, false, // 어드민 API이므로
-																			// 북마크 체크하지 않음
+			WordResponse response = wordResponseMapper.toWordResponse(originalWord, false,
 					wordVariant.getVariantTypes(), wordVariant.getOriginalForm());
 			results.add(response);
 		}
 
-		return WordSearchResponse.builder().searchedWord(word).results(results).build();
+		return wordResponseMapper.toWordSearchResponse(word, results);
 	}
 
 }

--- a/src/test/java/com/linglevel/api/common/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/linglevel/api/common/handler/GlobalExceptionHandlerTest.java
@@ -1,0 +1,31 @@
+package com.linglevel.api.common.handler;
+
+import com.linglevel.api.common.dto.ExceptionResponse;
+import com.linglevel.api.i18n.LanguageCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalExceptionHandlerTest {
+
+	private final GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();
+
+	@Test
+	@DisplayName("요청 파라미터 타입 변환 실패는 400 Bad Request로 응답")
+	void handleMethodArgumentTypeMismatchException_returnsBadRequest() {
+		MethodArgumentTypeMismatchException exception = new MethodArgumentTypeMismatchException("INVALID",
+				LanguageCode.class, "targetLanguage", null, null);
+
+		ResponseEntity<ExceptionResponse> response = globalExceptionHandler
+			.handleMethodArgumentTypeMismatchException(exception);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+		assertThat(response.getBody()).isNotNull();
+		assertThat(response.getBody().getMessage()).isEqualTo("targetLanguage: 올바르지 않은 값입니다");
+	}
+
+}

--- a/src/test/java/com/linglevel/api/word/controller/WordsAdminControllerTest.java
+++ b/src/test/java/com/linglevel/api/word/controller/WordsAdminControllerTest.java
@@ -1,0 +1,68 @@
+package com.linglevel.api.word.controller;
+
+import com.linglevel.api.i18n.LanguageCode;
+import com.linglevel.api.word.dto.WordSearchResponse;
+import com.linglevel.api.word.exception.WordsErrorCode;
+import com.linglevel.api.word.exception.WordsException;
+import com.linglevel.api.word.service.Oxford3000Service;
+import com.linglevel.api.word.service.WordService;
+import com.linglevel.api.word.validator.WordValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WordsAdminControllerTest {
+
+	@Mock
+	private WordService wordService;
+
+	@Mock
+	private Oxford3000Service oxford3000Service;
+
+	private WordsAdminController wordsAdminController;
+
+	@BeforeEach
+	void setUp() {
+		wordsAdminController = new WordsAdminController(wordService, oxford3000Service, new WordValidator());
+	}
+
+	@Test
+	@DisplayName("강제 재분석 단어는 일반 조회 API와 동일하게 정규화 후 서비스로 전달")
+	void forceAnalyzeWord_normalizesWordBeforeServiceCall() {
+		WordSearchResponse expectedResponse = WordSearchResponse.builder()
+			.searchedWord("run")
+			.results(List.of())
+			.build();
+		when(wordService.forceReanalyzeWord("run", LanguageCode.KO, true, false)).thenReturn(expectedResponse);
+
+		ResponseEntity<WordSearchResponse> response = wordsAdminController.forceAnalyzeWord("Run!", LanguageCode.KO,
+				true, false);
+
+		assertThat(response.getBody()).isSameAs(expectedResponse);
+		verify(wordService).forceReanalyzeWord("run", LanguageCode.KO, true, false);
+	}
+
+	@Test
+	@DisplayName("강제 재분석 대상 언어가 영어면 서비스 호출 전 차단")
+	void forceAnalyzeWord_rejectsEnglishTargetLanguage() {
+		assertThatThrownBy(() -> wordsAdminController.forceAnalyzeWord("run", LanguageCode.EN, false, false))
+			.isInstanceOfSatisfying(WordsException.class,
+					e -> assertThat(e.getErrorCode()).isEqualTo(WordsErrorCode.SAME_SOURCE_TARGET_LANGUAGE));
+
+		verify(wordService, never()).forceReanalyzeWord("run", LanguageCode.EN, false, false);
+	}
+
+}

--- a/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
@@ -8,6 +8,7 @@ import com.linglevel.api.word.entity.Word;
 import com.linglevel.api.word.entity.WordVariant;
 import com.linglevel.api.word.exception.WordsErrorCode;
 import com.linglevel.api.word.exception.WordsException;
+import com.linglevel.api.word.mapper.WordResponseMapper;
 import com.linglevel.api.word.repository.InvalidWordRepository;
 import com.linglevel.api.word.repository.WordRepository;
 import com.linglevel.api.word.repository.WordVariantRepository;
@@ -57,6 +58,8 @@ class WordServiceTest {
 
 	private WordPersistenceService wordPersistenceService;
 
+	private WordResponseMapper wordResponseMapper;
+
 	private Word sampleWord;
 
 	private String userId = "test-user-123";
@@ -65,8 +68,10 @@ class WordServiceTest {
 	void setUp() {
 		wordPersistenceService = new WordPersistenceService(wordRepository, wordVariantRepository,
 				invalidWordRepository);
+		wordResponseMapper = new WordResponseMapper();
 		wordService = new WordService(wordRepository, wordBookmarkRepository, wordVariantRepository,
-				invalidWordRepository, wordAiService, singleFlightCoordinator, wordPersistenceService);
+				invalidWordRepository, wordAiService, singleFlightCoordinator, wordPersistenceService,
+				wordResponseMapper);
 
 		lenient().when(singleFlightCoordinator.execute(anyString(), any(LanguageCode.class), any(), any()))
 			.thenAnswer(invocation -> {

--- a/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
@@ -9,6 +9,8 @@ import com.linglevel.api.word.entity.WordVariant;
 import com.linglevel.api.word.exception.WordsErrorCode;
 import com.linglevel.api.word.exception.WordsException;
 import com.linglevel.api.word.mapper.WordResponseMapper;
+import com.linglevel.api.word.model.Meaning;
+import com.linglevel.api.word.model.RelatedForms;
 import com.linglevel.api.word.repository.InvalidWordRepository;
 import com.linglevel.api.word.repository.WordRepository;
 import com.linglevel.api.word.repository.WordVariantRepository;


### PR DESCRIPTION
## Summary

word 도메인의 API 경계 처리를 정리합니다.

- 단어 응답 DTO 생성 책임을 `WordResponseMapper`로 분리
- enum/request parameter 타입 변환 실패를 400 Bad Request로 처리
- 관리자 강제 단어 분석 API의 입력 검증/정규화 경로를 일반 조회 API와 일치
- 관리자 단어 컨트롤러에 `@PreAuthorize("hasRole('ADMIN')")` 명시
- `Meaning`, `RelatedForms`를 DTO 패키지에서 도메인 공유 값 모델 패키지로 이동
- `WordsController` 미사용 import 정리

## Problem

기존 word API 경계에는 몇 가지 책임 혼재가 있었습니다.

- `WordService`가 비즈니스 흐름과 응답 DTO 조립을 함께 담당했습니다.
- 잘못된 enum 파라미터가 generic 예외 처리로 넘어갈 수 있었습니다.
- 관리자 강제 분석 API가 일반 조회 API와 다른 입력 검증 경로를 탔습니다.
- `Meaning`, `RelatedForms`가 DTO 패키지에 있으면서 엔티티 저장 모델에도 사용되었습니다.

## Solution

컨트롤러, 서비스, DTO, 도메인 값 모델의 책임을 더 명확히 분리했습니다.

- 복잡한 응답 조립은 `WordResponseMapper`로 위임했습니다.
- 타입 변환 실패는 공통 예외 핸들러에서 `INVALID_INPUT` 기반 400 응답으로 처리합니다.
- 관리자 API도 `WordValidator`를 통해 단어를 검증/정규화합니다.
- word 도메인 내부에서 공유되는 값 모델은 `word.model` 패키지로 이동했습니다.

## Changes

- `WordResponseMapper` 추가
- `GlobalExceptionHandler`에 `MethodArgumentTypeMismatchException` 처리 추가
- `WordsAdminController` 입력 검증 및 관리자 권한 명시
- `Meaning`, `RelatedForms` 패키지 이동: `word.dto` -> `word.model`
- 관련 단위 테스트 추가 및 수정

## Example

잘못된 요청 파라미터:

```http
GET /api/v1/words/run?targetLanguage=INVALID
```

이제 서버 내부 오류가 아니라 400 응답으로 처리됩니다.

```json
{
  "message": "targetLanguage: 올바르지 않은 값입니다"
}
```

관리자 강제 분석 API도 입력 단어를 동일하게 정규화합니다.

```text
Run! -> run
```

## Validation

- `./gradlew compileJava`
- `./gradlew test --tests com.linglevel.api.word.service.WordServiceTest`
- `./gradlew test --tests com.linglevel.api.common.handler.GlobalExceptionHandlerTest --tests com.linglevel.api.word.service.WordServiceTest`
- `./gradlew test --tests com.linglevel.api.word.controller.WordsAdminControllerTest --tests com.linglevel.api.word.service.WordServiceTest`
- `./gradlew test --tests com.linglevel.api.word.service.WordServiceTest --tests com.linglevel.api.word.service.WordVariantServiceTest --tests com.linglevel.api.word.controller.WordsAdminControllerTest --tests com.linglevel.api.word.validator.WordValidatorTest`

## Related Issues

- N/A