### PR TITLE
refactor(word): clean up word generation flow

### DIFF
--- a/src/main/java/com/linglevel/api/word/controller/WordsAdminController.java
+++ b/src/main/java/com/linglevel/api/word/controller/WordsAdminController.java
@@ -108,8 +108,6 @@ public class WordsAdminController {
 	public ResponseEntity<Oxford3000InitResponse> initializeOxford3000(@Parameter(description = "번역 대상 언어",
 			example = "KO") @RequestParam(defaultValue = "KO") LanguageCode targetLanguage) {
 
-		log.info("Admin initialize-oxford3000: targetLanguage={}", targetLanguage);
-
 		Oxford3000InitResponse response = oxford3000Service.initializeOxford3000(targetLanguage);
 		return ResponseEntity.ok(response);
 	}
@@ -127,8 +125,6 @@ public class WordsAdminController {
 					content = @Content(schema = @Schema(implementation = ExceptionResponse.class))) })
 	@GetMapping("/essential/stats")
 	public ResponseEntity<EssentialWordsStatsResponse> getEssentialWordsStats() {
-		log.info("Admin get essential words stats");
-
 		EssentialWordsStatsResponse response = oxford3000Service.getEssentialWordsStats();
 		return ResponseEntity.ok(response);
 	}
@@ -151,8 +147,6 @@ public class WordsAdminController {
 	public ResponseEntity<List<String>> getEssentialWords(@Parameter(description = "번역 대상 언어 (선택)",
 			example = "KO") @RequestParam(required = false) LanguageCode targetLanguage) {
 
-		log.info("Admin get essential words: targetLanguage={}", targetLanguage);
-
 		List<String> words = oxford3000Service.getEssentialWordsList(targetLanguage);
 		return ResponseEntity.ok(words);
 	}
@@ -174,15 +168,12 @@ public class WordsAdminController {
 			@Parameter(description = "단어 ID", example = "507f1f77bcf86cd799439011") @PathVariable String wordId,
 			@Parameter(description = "필수 단어 여부", example = "true") @RequestParam boolean isEssential) {
 
-		log.info("Admin update essential status: wordId={}, isEssential={}", wordId, isEssential);
-
 		oxford3000Service.updateEssentialStatus(wordId, isEssential);
 		return ResponseEntity.ok().build();
 	}
 
 	@ExceptionHandler(WordsException.class)
 	public ResponseEntity<ExceptionResponse> handleWordsException(WordsException e) {
-		log.info("Words Admin Exception: {}", e.getMessage());
 		return ResponseEntity.status(e.getStatus()).body(new ExceptionResponse(e));
 	}
 

--- a/src/main/java/com/linglevel/api/word/controller/WordsController.java
+++ b/src/main/java/com/linglevel/api/word/controller/WordsController.java
@@ -20,7 +20,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -29,7 +28,6 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/words")
 @RequiredArgsConstructor
-@Slf4j
 @Tag(name = "Words", description = "단어 관련 API")
 public class WordsController {
 
@@ -60,7 +58,6 @@ public class WordsController {
 
 	@ExceptionHandler(WordsException.class)
 	public ResponseEntity<ExceptionResponse> handleWordsException(WordsException e) {
-		log.info("Words Exception: {}", e.getMessage());
 		return ResponseEntity.status(e.getStatus()).body(new ExceptionResponse(e));
 	}
 

--- a/src/main/java/com/linglevel/api/word/service/Oxford3000Service.java
+++ b/src/main/java/com/linglevel/api/word/service/Oxford3000Service.java
@@ -51,18 +51,12 @@ public class Oxford3000Service {
 	@Transactional
 	public Oxford3000InitResponse initializeOxford3000(LanguageCode targetLanguage) {
 		LocalDateTime startedAt = LocalDateTime.now();
-		log.info("============================================================");
-		log.info("Starting Oxford 3000 initialization");
-		log.info("Target Language: {}", targetLanguage);
-		log.info("============================================================");
 
 		// 1. CSV 파일에서 단어 읽기
 		List<String> csvWords = readOxford3000Words();
-		log.info("Step 1: Loaded {} words from Oxford 3000 CSV", csvWords.size());
 
 		// 2. 이미 등록된 essential 단어 목록 조회 (대소문자 무시)
 		List<String> existingEssentialWords = getEssentialWordsList(targetLanguage);
-		log.info("Step 2: Found {} already registered essential words", existingEssentialWords.size());
 
 		// 3. 차집합 계산 (등록이 필요한 단어만 필터링)
 		List<String> wordsToProcess = csvWords.stream()
@@ -70,11 +64,8 @@ public class Oxford3000Service {
 			.collect(Collectors.toList());
 
 		int skippedCount = csvWords.size() - wordsToProcess.size();
-		log.info("Step 3: {} words already registered, {} words to process", skippedCount, wordsToProcess.size());
-
-		log.info("============================================================");
-		log.info("Processing {} words...", wordsToProcess.size());
-		log.info("============================================================");
+		log.info("Starting Oxford 3000 initialization: targetLanguage={}, totalWords={}, skipped={}, toProcess={}",
+				targetLanguage, csvWords.size(), skippedCount, wordsToProcess.size());
 
 		// 4. 통계 정보
 		int successCount = 0;
@@ -130,19 +121,13 @@ public class Oxford3000Service {
 		LocalDateTime completedAt = LocalDateTime.now();
 		long durationSeconds = java.time.Duration.between(startedAt, completedAt).getSeconds();
 
-		log.info("============================================================");
-		log.info("Oxford 3000 initialization completed!");
-		log.info("Duration: {} seconds ({} minutes)", durationSeconds, durationSeconds / 60);
-		log.info("Total CSV words: {}", csvWords.size());
-		log.info("Already registered (skipped): {}", skippedCount);
-		log.info("Attempted to process: {}", wordsToProcess.size());
-		log.info("Successfully processed: {}", successCount);
-		log.info("Newly created: {}", newlyCreatedCount);
-		log.info("Failed: {}", failureCount);
+		log.info(
+				"Oxford 3000 initialization completed: durationSeconds={}, totalWords={}, skipped={}, attempted={}, succeeded={}, newlyCreated={}, failed={}",
+				durationSeconds, csvWords.size(), skippedCount, wordsToProcess.size(), successCount, newlyCreatedCount,
+				failureCount);
 		if (!failedWords.isEmpty()) {
-			log.error("Failed words: {}", String.join(", ", failedWords));
+			log.warn("Oxford 3000 failed words: {}", String.join(", ", failedWords));
 		}
-		log.info("============================================================");
 
 		return Oxford3000InitResponse.builder()
 			.startedAt(startedAt)
@@ -167,7 +152,6 @@ public class Oxford3000Service {
 	@Transactional
 	public boolean processWord(String word, LanguageCode targetLanguage) {
 		String validatedWord = wordValidator.validateAndPreprocess(word);
-		log.debug("Word validated and preprocessed: '{}' -> '{}'", word, validatedWord);
 
 		// 1. WordVariant에서 원형 찾기
 		List<WordVariant> variants = wordVariantRepository.findAllByWord(validatedWord);
@@ -175,7 +159,6 @@ public class Oxford3000Service {
 
 		if (!variants.isEmpty()) {
 			originalForm = variants.get(0).getOriginalForm();
-			log.info("Found variant '{}' -> original form '{}'", validatedWord, originalForm);
 		}
 		else {
 			originalForm = validatedWord;
@@ -190,7 +173,6 @@ public class Oxford3000Service {
 		if (existed) {
 			// 이미 존재하면 재사용
 			wordToUpdate = existingWord.get();
-			log.info("Word '{}' already exists for target language {}, reusing", originalForm, targetLanguage);
 		}
 		else {
 			// 없으면 AI로 생성
@@ -205,7 +187,6 @@ public class Oxford3000Service {
 		if (!Boolean.TRUE.equals(wordToUpdate.getIsEssential())) {
 			wordToUpdate.setIsEssential(true);
 			wordRepository.save(wordToUpdate);
-			log.info("Set isEssential=true for Oxford 3000 word: {}", wordToUpdate.getWord());
 		}
 
 		return existed;
@@ -268,11 +249,9 @@ public class Oxford3000Service {
 
 		if (targetLanguage != null) {
 			essentialWords = wordRepository.findAllByIsEssentialAndTargetLanguageCode(true, targetLanguage);
-			log.info("Found {} essential words for target language: {}", essentialWords.size(), targetLanguage);
 		}
 		else {
 			essentialWords = wordRepository.findAllByIsEssential(true);
-			log.info("Found {} total essential words (all languages)", essentialWords.size());
 		}
 
 		// 원형들 추출
@@ -295,8 +274,6 @@ public class Oxford3000Service {
 
 		List<String> result = allFormsIncludingVariants.stream().distinct().sorted().collect(Collectors.toList());
 
-		log.info("Returning {} unique essential word strings (including {} variants)", result.size(),
-				result.size() - originalForms.size());
 		return result;
 	}
 

--- a/src/main/java/com/linglevel/api/word/service/Oxford3000Service.java
+++ b/src/main/java/com/linglevel/api/word/service/Oxford3000Service.java
@@ -8,6 +8,8 @@ import com.linglevel.api.word.entity.WordVariant;
 import com.linglevel.api.word.exception.WordsErrorCode;
 import com.linglevel.api.word.exception.WordsException;
 import com.linglevel.api.word.repository.WordRepository;
+import com.linglevel.api.word.repository.WordVariantRepository;
+import com.linglevel.api.word.validator.WordValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ClassPathResource;
@@ -33,9 +35,9 @@ public class Oxford3000Service {
 
 	private final WordService wordService;
 
-	private final com.linglevel.api.word.validator.WordValidator wordValidator;
+	private final WordValidator wordValidator;
 
-	private final com.linglevel.api.word.repository.WordVariantRepository wordVariantRepository;
+	private final WordVariantRepository wordVariantRepository;
 
 	private static final String OXFORD3000_CSV_PATH = "data/oxford3000_final_cleaned.csv";
 

--- a/src/main/java/com/linglevel/api/word/service/WordAiService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordAiService.java
@@ -29,6 +29,10 @@ public class WordAiService {
 
 	private static final String PROMPT_TEMPLATE_PATH = "prompts/word-analysis.md";
 
+	private static final double LLAMA4_SCOUT_INPUT_COST_PER_1K_TOKENS_USD = 0.00017;
+
+	private static final double LLAMA4_SCOUT_OUTPUT_COST_PER_1K_TOKENS_USD = 0.00066;
+
 	private final ChatModel chatModel;
 
 	private final Validator validator;
@@ -73,17 +77,14 @@ public class WordAiService {
 				long outputTokens = tokenCountOrZero(usage.getCompletionTokens());
 				long totalTokens = tokenCountOrDefault(usage.getTotalTokens(), inputTokens + outputTokens);
 
-				double inputCostUsd = (inputTokens / 1000.0) * 0.00017;
-				double outputCostUsd = (outputTokens / 1000.0) * 0.000085;
+				double inputCostUsd = (inputTokens / 1000.0) * LLAMA4_SCOUT_INPUT_COST_PER_1K_TOKENS_USD;
+				double outputCostUsd = (outputTokens / 1000.0) * LLAMA4_SCOUT_OUTPUT_COST_PER_1K_TOKENS_USD;
 				double totalCostUsd = inputCostUsd + outputCostUsd;
-
-				// 환율: 1 USD = 1430 KRW
-				double totalCostKrw = totalCostUsd * 1430;
 
 				log.info("📊 Token Usage for word '{}': Input={}, Output={}, Total={}", word, inputTokens, outputTokens,
 						totalTokens);
-				log.info("💰 Cost: ${} (₩{}) = Input: ${} + Output: ${}", String.format("%.6f", totalCostUsd),
-						String.format("%.2f", totalCostKrw), String.format("%.6f", inputCostUsd),
+				log.info("💰 Cost USD for word '{}': Total=${}, Input=${}, Output=${}", word,
+						String.format("%.6f", totalCostUsd), String.format("%.6f", inputCostUsd),
 						String.format("%.6f", outputCostUsd));
 			}
 

--- a/src/main/java/com/linglevel/api/word/service/WordAiService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordAiService.java
@@ -75,30 +75,26 @@ public class WordAiService {
 
 			String response = chatResponse.getResult().getOutput().getText();
 
-			// 토큰 사용량 및 비용 로깅
+			boolean hasUsage = false;
+			long inputTokens = 0;
+			long outputTokens = 0;
+			long totalTokens = 0;
+			double inputCostUsd = 0;
+			double outputCostUsd = 0;
+			double totalCostUsd = 0;
 			if (chatResponse.getMetadata() != null && chatResponse.getMetadata().getUsage() != null) {
 				var usage = chatResponse.getMetadata().getUsage();
-				long inputTokens = tokenCountOrZero(usage.getPromptTokens());
-				long outputTokens = tokenCountOrZero(usage.getCompletionTokens());
-				long totalTokens = tokenCountOrDefault(usage.getTotalTokens(), inputTokens + outputTokens);
-
-				double inputCostUsd = (inputTokens / 1000.0) * INPUT_COST_PER_1K_TOKENS_USD;
-				double outputCostUsd = (outputTokens / 1000.0) * OUTPUT_COST_PER_1K_TOKENS_USD;
-				double totalCostUsd = inputCostUsd + outputCostUsd;
-
-				log.info("Token usage for word '{}': input={}, output={}, total={}", word, inputTokens, outputTokens,
-						totalTokens);
-				log.info("Cost USD for word '{}': total=${}, input=${}, output=${}", word,
-						String.format("%.6f", totalCostUsd), String.format("%.6f", inputCostUsd),
-						String.format("%.6f", outputCostUsd));
+				hasUsage = true;
+				inputTokens = tokenCountOrZero(usage.getPromptTokens());
+				outputTokens = tokenCountOrZero(usage.getCompletionTokens());
+				totalTokens = tokenCountOrDefault(usage.getTotalTokens(), inputTokens + outputTokens);
+				inputCostUsd = (inputTokens / 1000.0) * INPUT_COST_PER_1K_TOKENS_USD;
+				outputCostUsd = (outputTokens / 1000.0) * OUTPUT_COST_PER_1K_TOKENS_USD;
+				totalCostUsd = inputCostUsd + outputCostUsd;
 			}
-
-			// 전체 응답은 debug 레벨로만 출력 (응답이 길어서 info 레벨에서는 제외)
-			log.debug("AI Response for word '{}' (target: {}): {}", word, targetLanguage, response);
 
 			WordAnalysisResult[] results = outputConverter.convert(response);
 
-			// Validation 수행
 			for (WordAnalysisResult result : results) {
 				validateResult(result, word);
 			}
@@ -109,18 +105,24 @@ public class WordAiService {
 			// 같은 originalForm을 가진 결과를 병합 (AI가 잘못 분리한 경우 대비)
 			List<WordAnalysisResult> mergedResults = mergeDuplicateOriginalForms(results, word);
 
-			// 빈 결과 검증 - AI가 무의미한 단어라고 판단한 경우
 			if (mergedResults.isEmpty()) {
-				log.info("AI returned empty result for '{}' (meaningless/gibberish word)", word);
 				throw new WordsException(WordsErrorCode.WORD_IS_MEANINGLESS);
 			}
 
-			// 요약 정보 로깅
 			String summary = mergedResults.stream()
 				.map(r -> r.getOriginalForm() + " ("
 						+ String.join(", ", r.getVariantTypes().stream().map(Enum::name).toArray(String[]::new)) + ")")
 				.collect(Collectors.joining(", "));
-			log.info("AI analysis completed for '{}': {} result(s) - {}", word, mergedResults.size(), summary);
+			if (hasUsage) {
+				log.info(
+						"AI analysis completed for '{}': {} result(s) - {}; tokens input={}, output={}, total={}; costUsd total={}, input={}, output={}",
+						word, mergedResults.size(), summary, inputTokens, outputTokens, totalTokens,
+						String.format("%.6f", totalCostUsd), String.format("%.6f", inputCostUsd),
+						String.format("%.6f", outputCostUsd));
+			}
+			else {
+				log.info("AI analysis completed for '{}': {} result(s) - {}", word, mergedResults.size(), summary);
+			}
 
 			return mergedResults;
 		}
@@ -141,9 +143,6 @@ public class WordAiService {
 		return tokenCount == null ? defaultValue : tokenCount;
 	}
 
-	/**
-	 * AI 응답 결과의 유효성을 검증
-	 */
 	private void validateResult(WordAnalysisResult result, String word) {
 		Set<ConstraintViolation<WordAnalysisResult>> violations = validator.validate(result);
 
@@ -152,11 +151,8 @@ public class WordAiService {
 				.map(v -> v.getPropertyPath() + ": " + v.getMessage())
 				.collect(Collectors.joining(", "));
 
-			log.error("AI response validation failed for word '{}': {}", word, errors);
 			throw new IllegalArgumentException("Invalid AI response for word '" + word + "': " + errors);
 		}
-
-		log.debug("AI response validation passed for word '{}'", word);
 	}
 
 	/**

--- a/src/main/java/com/linglevel/api/word/service/WordAiService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordAiService.java
@@ -29,9 +29,9 @@ public class WordAiService {
 
 	private static final String PROMPT_TEMPLATE_PATH = "prompts/word-analysis.md";
 
-	private static final double LLAMA4_SCOUT_INPUT_COST_PER_1K_TOKENS_USD = 0.00017;
+	private static final double INPUT_COST_PER_1K_TOKENS_USD = 0.00017;
 
-	private static final double LLAMA4_SCOUT_OUTPUT_COST_PER_1K_TOKENS_USD = 0.00066;
+	private static final double OUTPUT_COST_PER_1K_TOKENS_USD = 0.00066;
 
 	private final ChatModel chatModel;
 
@@ -77,8 +77,8 @@ public class WordAiService {
 				long outputTokens = tokenCountOrZero(usage.getCompletionTokens());
 				long totalTokens = tokenCountOrDefault(usage.getTotalTokens(), inputTokens + outputTokens);
 
-				double inputCostUsd = (inputTokens / 1000.0) * LLAMA4_SCOUT_INPUT_COST_PER_1K_TOKENS_USD;
-				double outputCostUsd = (outputTokens / 1000.0) * LLAMA4_SCOUT_OUTPUT_COST_PER_1K_TOKENS_USD;
+				double inputCostUsd = (inputTokens / 1000.0) * INPUT_COST_PER_1K_TOKENS_USD;
+				double outputCostUsd = (outputTokens / 1000.0) * OUTPUT_COST_PER_1K_TOKENS_USD;
 				double totalCostUsd = inputCostUsd + outputCostUsd;
 
 				log.info("📊 Token Usage for word '{}': Input={}, Output={}, Total={}", word, inputTokens, outputTokens,

--- a/src/main/java/com/linglevel/api/word/service/WordAiService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordAiService.java
@@ -15,8 +15,11 @@ import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.chat.prompt.PromptTemplate;
 import org.springframework.ai.converter.BeanOutputConverter;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -24,132 +27,29 @@ import java.util.stream.Collectors;
 @Slf4j
 public class WordAiService {
 
+	private static final String PROMPT_TEMPLATE_PATH = "prompts/word-analysis.md";
+
 	private final ChatModel chatModel;
 
 	private final Validator validator;
+
+	private final String promptTemplate;
 
 	public WordAiService(ChatModel chatModel) {
 		this.chatModel = chatModel;
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		this.validator = factory.getValidator();
+		this.promptTemplate = loadPromptTemplate();
 	}
 
-	private static final String PROMPT_TEMPLATE = """
-			Word: {word} | Target: {targetLanguage}
-
-			**CRITICAL: If '{word}' is nonsensical/gibberish/typo, return []**
-			**CRITICAL: ALL fields (summary, meaning, example, exampleTranslation) MUST have meaningful content. NEVER leave empty strings.**
-			**If you cannot provide meaningful content, return [] instead.**
-
-			HOMOGRAPH CHECK: Same spelling, multiple DISTINCT ORIGINS or DIFFERENT ORIGINAL FORMS?
-			(e.g., "saw"=past of "see" + noun "saw"톱, "left"=past of "leave" + adj "left"왼쪽, "rose"=past of "rise" + noun "rose"장미)
-			**CRITICAL**: If input word IS the original form (e.g., "run", "book"), return SINGLE entry with variantTypes=[ORIGINAL_FORM]
-			- "run" → Single entry: originalForm="run", variantTypes=[ORIGINAL_FORM] (DO NOT split into ORIGINAL_FORM and PAST_PARTICIPLE)
-			- "books" → Single entry: originalForm="book", variantTypes=[PLURAL, THIRD_PERSON]
-			→ YES (different origins): Return array with separate entries | NO: Single-element array
-
-			**CRITICAL MERGING RULE:**
-			- If input word has SAME originalForm but DIFFERENT variantTypes, MERGE into ONE ENTRY with multiple variantTypes
-			- Example "books":
-			  Single entry: originalForm="book", variantTypes=[PLURAL, THIRD_PERSON], meanings include BOTH noun meanings AND verb meanings
-			- Each meaning should specify its partOfSpeech clearly
-
-			STRUCTURE:
-			**CRITICAL: Only variantTypes describes the INPUT word. Everything else (summary, meanings, examples) describes the ORIGINAL FORM.**
-
-			1. sourceLanguageCode/targetLanguageCode: "EN", "KO", etc.
-			2. originalForm: Base form (verbs→infinitive, adj→positive, nouns→singular)
-			   **CRITICAL: For adverbs ending in "-ly":**
-			   - The adverb itself IS the original form
-			   - Do NOT remove "-ly" to get the base adjective
-			   - "carefully" → originalForm="carefully" (NOT "careful")
-			   - "absolutely" → originalForm="absolutely" (NOT "absolute")
-			3. variantTypes: **ARRAY** of relationships between INPUT word and originalForm
-			   variantTypes = ONLY morphological relationship (변형 관계만!)
-			   ✅ VALID VALUES: ORIGINAL_FORM, PAST_TENSE, PAST_PARTICIPLE, PRESENT_PARTICIPLE, THIRD_PERSON, COMPARATIVE, SUPERLATIVE, PLURAL, UNDEFINED
-
-			   **CRITICAL: Special cases**
-			   - Pronouns (them, him, whom, etc.): variantTypes=[ORIGINAL_FORM], partOfSpeech="pronoun"
-			   - Past participles used as adjectives (confused, interested, etc.): variantTypes=[PAST_PARTICIPLE], add BOTH verb and adjective meanings
-			   - Words without inflection (adverbs, prepositions, etc.): variantTypes=[ORIGINAL_FORM]
-
-			4. partOfSpeech = Grammatical category (품사)
-			   - Goes INSIDE meanings array (meanings 배열 안에!)
-			   ✅ VALID VALUES: verb, noun, adjective, adverb, pronoun, preposition, conjunction, interjection, determiner, article, numeral
-
-			   - If input="ran" and originalForm="run", then variantTypes=[PAST_TENSE]
-			   - If input="books" and originalForm="book", then variantTypes=[PLURAL, THIRD_PERSON] (both noun plural AND verb 3rd person)
-			5. summary: Max 3 common translations of the ORIGINAL FORM
-			   - Input "ran" → summary of "run": ["달리다","운영하다"]
-			   - Input "prettiest" → summary of "pretty": ["예쁜","아름다운"]
-			6. meanings: All meanings describe the ORIGINAL FORM (not the input word)
-			   - Max 15 objects (common→rare, omit obscure ones)
-			   - partOfSpeech: verb, noun, adjective, adverb, etc.
-			   - meaning: Detailed explanation in target language
-			   - example: **CRITICAL RULES:**
-			     1. ALWAYS use the ORIGINAL FORM in the example (NOT the input word!)
-			        - If originalForm="book" (input was "books"), use "book" in example
-			        - If originalForm="run" (input was "ran"), use "run" in example
-			     2. **PART OF SPEECH MUST MATCH**: The word in the example MUST be used as the specified partOfSpeech
-			        - If partOfSpeech="noun", the word must function as a noun in the example
-			        - If partOfSpeech="verb", the word must function as a verb in the example
-			        - WRONG: partOfSpeech="noun" but example has "I need to book a flight" (book is verb here)
-			        - CORRECT: partOfSpeech="noun" and example has "I love reading a book" (book is noun here)
-			     3. Grammar: Ensure grammatically correct sentences (e.g., "I/You/We/They run" ✓, "She runs" ✓)
-			     4. QUALITY: Natural, practical sentences used in real-life contexts
-			     5. CLARITY: Sentence must clearly demonstrate the word's meaning
-			     6. LENGTH: 5-12 words (not too short, not too long)
-			     7. AVOID: Generic phrases like "I need...", "This is...", "It is..." - be creative!
-			     GOOD: "I love reading a good book." (book as noun, matches partOfSpeech)
-			     GOOD: "We run a small bakery in downtown." (run as verb, matches partOfSpeech)
-			     BAD: "I need to book a flight." (if partOfSpeech is noun - book is verb here!)
-			   - exampleTranslation: Translation in target language
-			7. conjugations: (verbs only) present, past, pastParticiple, presentParticiple, thirdPerson
-			8. comparatives: (adj only) positive, comparative, superlative
-			9. plural: (nouns only) singular, plural
-
-			EXAMPLE - "saw" homograph:
-			[
-			  {{
-			    "originalForm": "see",
-			    "variantTypes": ["PAST_TENSE"],
-			    "sourceLanguageCode": "EN",
-			    "targetLanguageCode": "KO",
-			    "summary": ["보다", "알다"],
-			    "meanings": [
-			      {{
-			        "partOfSpeech": "verb",
-			        "meaning": "시각적으로 인지하다",
-			        "example": "We see the mountains clearly from our window.",
-			        "exampleTranslation": "우리는 창문에서 산이 선명하게 보입니다."
-			      }}
-			    ],
-			    "conjugations": {{"present": "see", "past": "saw", "pastParticiple": "seen", "presentParticiple": "seeing", "thirdPerson": "sees"}},
-			    "comparatives": null,
-			    "plural": null
-			  }},
-			  {{
-			    "originalForm": "saw",
-			    "variantTypes": ["ORIGINAL_FORM"],
-			    "sourceLanguageCode": "EN",
-			    "targetLanguageCode": "KO",
-			    "summary": ["톱"],
-			    "meanings": [
-			      {{
-			        "partOfSpeech": "noun",
-			        "meaning": "톱 (자르는 도구)",
-			        "example": "The carpenter used a saw to cut the wood.",
-			        "exampleTranslation": "목수는 톱을 사용하여 나무를 잘랐습니다."
-			      }}
-			    ],
-			    "conjugations": null,
-			    "comparatives": null,
-			    "plural": {{"singular": "saw", "plural": "saws"}}
-			  }}
-			]
-
-			{format}
-			""";
+	private String loadPromptTemplate() {
+		try {
+			return new ClassPathResource(PROMPT_TEMPLATE_PATH).getContentAsString(StandardCharsets.UTF_8);
+		}
+		catch (IOException e) {
+			throw new IllegalStateException("Failed to load word analysis prompt template: " + PROMPT_TEMPLATE_PATH, e);
+		}
+	}
 
 	public List<WordAnalysisResult> analyzeWord(String word, String targetLanguage) {
 		try {
@@ -158,7 +58,7 @@ public class WordAiService {
 
 			String format = outputConverter.getFormat();
 
-			PromptTemplate promptTemplate = new PromptTemplate(PROMPT_TEMPLATE);
+			PromptTemplate promptTemplate = new PromptTemplate(this.promptTemplate);
 			Prompt prompt = promptTemplate
 				.create(Map.of("word", word, "targetLanguage", targetLanguage, "format", format));
 

--- a/src/main/java/com/linglevel/api/word/service/WordAiService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordAiService.java
@@ -1,5 +1,6 @@
 package com.linglevel.api.word.service;
 
+import com.linglevel.api.word.dto.VariantType;
 import com.linglevel.api.word.dto.WordAnalysisResult;
 import com.linglevel.api.word.exception.WordsErrorCode;
 import com.linglevel.api.word.exception.WordsException;
@@ -20,7 +21,11 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -81,9 +86,9 @@ public class WordAiService {
 				double outputCostUsd = (outputTokens / 1000.0) * OUTPUT_COST_PER_1K_TOKENS_USD;
 				double totalCostUsd = inputCostUsd + outputCostUsd;
 
-				log.info("📊 Token Usage for word '{}': Input={}, Output={}, Total={}", word, inputTokens, outputTokens,
+				log.info("Token usage for word '{}': input={}, output={}, total={}", word, inputTokens, outputTokens,
 						totalTokens);
-				log.info("💰 Cost USD for word '{}': Total=${}, Input=${}, Output=${}", word,
+				log.info("Cost USD for word '{}': total=${}, input=${}, output=${}", word,
 						String.format("%.6f", totalCostUsd), String.format("%.6f", inputCostUsd),
 						String.format("%.6f", outputCostUsd));
 			}
@@ -115,7 +120,7 @@ public class WordAiService {
 				.map(r -> r.getOriginalForm() + " ("
 						+ String.join(", ", r.getVariantTypes().stream().map(Enum::name).toArray(String[]::new)) + ")")
 				.collect(Collectors.joining(", "));
-			log.info("✅ AI analysis completed for '{}': {} result(s) - {}", word, mergedResults.size(), summary);
+			log.info("AI analysis completed for '{}': {} result(s) - {}", word, mergedResults.size(), summary);
 
 			return mergedResults;
 		}
@@ -199,7 +204,7 @@ public class WordAiService {
 		List<WordAnalysisResult> filteredResults = new ArrayList<>();
 
 		for (WordAnalysisResult result : results) {
-			List<com.linglevel.api.word.dto.VariantType> originalVariantTypes = result.getVariantTypes();
+			List<VariantType> originalVariantTypes = result.getVariantTypes();
 
 			if (originalVariantTypes == null || originalVariantTypes.isEmpty()) {
 				log.warn("Empty variantTypes for word '{}' (originalForm: '{}')", word, result.getOriginalForm());
@@ -207,7 +212,7 @@ public class WordAiService {
 			}
 
 			// 1. 유효한 VariantType만 필터링
-			List<com.linglevel.api.word.dto.VariantType> validVariantTypes = originalVariantTypes.stream()
+			List<VariantType> validVariantTypes = originalVariantTypes.stream()
 				.filter(vt -> vt != null)
 				.collect(Collectors.toList());
 
@@ -281,7 +286,7 @@ public class WordAiService {
 		WordAnalysisResult first = results.get(0);
 
 		// variantTypes 병합 (중복 제거)
-		List<com.linglevel.api.word.dto.VariantType> mergedVariantTypes = results.stream()
+		List<VariantType> mergedVariantTypes = results.stream()
 			.flatMap(r -> r.getVariantTypes().stream())
 			.distinct()
 			.collect(Collectors.toList());

--- a/src/main/java/com/linglevel/api/word/service/WordAiService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordAiService.java
@@ -74,24 +74,7 @@ public class WordAiService {
 			ChatResponse chatResponse = ChatClient.create(chatModel).prompt(prompt).call().chatResponse();
 
 			String response = chatResponse.getResult().getOutput().getText();
-
-			boolean hasUsage = false;
-			long inputTokens = 0;
-			long outputTokens = 0;
-			long totalTokens = 0;
-			double inputCostUsd = 0;
-			double outputCostUsd = 0;
-			double totalCostUsd = 0;
-			if (chatResponse.getMetadata() != null && chatResponse.getMetadata().getUsage() != null) {
-				var usage = chatResponse.getMetadata().getUsage();
-				hasUsage = true;
-				inputTokens = tokenCountOrZero(usage.getPromptTokens());
-				outputTokens = tokenCountOrZero(usage.getCompletionTokens());
-				totalTokens = tokenCountOrDefault(usage.getTotalTokens(), inputTokens + outputTokens);
-				inputCostUsd = (inputTokens / 1000.0) * INPUT_COST_PER_1K_TOKENS_USD;
-				outputCostUsd = (outputTokens / 1000.0) * OUTPUT_COST_PER_1K_TOKENS_USD;
-				totalCostUsd = inputCostUsd + outputCostUsd;
-			}
+			logAiUsage(word, chatResponse);
 
 			WordAnalysisResult[] results = outputConverter.convert(response);
 
@@ -113,16 +96,7 @@ public class WordAiService {
 				.map(r -> r.getOriginalForm() + " ("
 						+ String.join(", ", r.getVariantTypes().stream().map(Enum::name).toArray(String[]::new)) + ")")
 				.collect(Collectors.joining(", "));
-			if (hasUsage) {
-				log.info(
-						"AI analysis completed for '{}': {} result(s) - {}; tokens input={}, output={}, total={}; costUsd total={}, input={}, output={}",
-						word, mergedResults.size(), summary, inputTokens, outputTokens, totalTokens,
-						String.format("%.6f", totalCostUsd), String.format("%.6f", inputCostUsd),
-						String.format("%.6f", outputCostUsd));
-			}
-			else {
-				log.info("AI analysis completed for '{}': {} result(s) - {}", word, mergedResults.size(), summary);
-			}
+			log.info("AI analysis completed for '{}': {} result(s) - {}", word, mergedResults.size(), summary);
 
 			return mergedResults;
 		}
@@ -133,6 +107,24 @@ public class WordAiService {
 			log.error("Failed to analyze word '{}' with AI (target: {})", word, targetLanguage, e);
 			throw new WordsException(WordsErrorCode.WORD_ANALYSIS_FAILED, e);
 		}
+	}
+
+	private void logAiUsage(String word, ChatResponse chatResponse) {
+		if (chatResponse.getMetadata() == null || chatResponse.getMetadata().getUsage() == null) {
+			return;
+		}
+
+		var usage = chatResponse.getMetadata().getUsage();
+		long inputTokens = tokenCountOrZero(usage.getPromptTokens());
+		long outputTokens = tokenCountOrZero(usage.getCompletionTokens());
+		long totalTokens = tokenCountOrDefault(usage.getTotalTokens(), inputTokens + outputTokens);
+		double inputCostUsd = (inputTokens / 1000.0) * INPUT_COST_PER_1K_TOKENS_USD;
+		double outputCostUsd = (outputTokens / 1000.0) * OUTPUT_COST_PER_1K_TOKENS_USD;
+		double totalCostUsd = inputCostUsd + outputCostUsd;
+
+		log.info("AI usage for word '{}': tokens input={}, output={}, total={}; costUsd total={}, input={}, output={}",
+				word, inputTokens, outputTokens, totalTokens, String.format("%.6f", totalCostUsd),
+				String.format("%.6f", inputCostUsd), String.format("%.6f", outputCostUsd));
 	}
 
 	private long tokenCountOrZero(Integer tokenCount) {

--- a/src/main/java/com/linglevel/api/word/service/WordAiService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordAiService.java
@@ -69,9 +69,9 @@ public class WordAiService {
 			// 토큰 사용량 및 비용 로깅
 			if (chatResponse.getMetadata() != null && chatResponse.getMetadata().getUsage() != null) {
 				var usage = chatResponse.getMetadata().getUsage();
-				long inputTokens = usage.getPromptTokens();
-				long outputTokens = usage.getGenerationTokens();
-				long totalTokens = usage.getTotalTokens();
+				long inputTokens = tokenCountOrZero(usage.getPromptTokens());
+				long outputTokens = tokenCountOrZero(usage.getCompletionTokens());
+				long totalTokens = tokenCountOrDefault(usage.getTotalTokens(), inputTokens + outputTokens);
 
 				double inputCostUsd = (inputTokens / 1000.0) * 0.00017;
 				double outputCostUsd = (outputTokens / 1000.0) * 0.000085;
@@ -125,6 +125,14 @@ public class WordAiService {
 			log.error("Failed to analyze word '{}' with AI (target: {})", word, targetLanguage, e);
 			throw new WordsException(WordsErrorCode.WORD_ANALYSIS_FAILED, e);
 		}
+	}
+
+	private long tokenCountOrZero(Integer tokenCount) {
+		return tokenCountOrDefault(tokenCount, 0);
+	}
+
+	private long tokenCountOrDefault(Integer tokenCount, long defaultValue) {
+		return tokenCount == null ? defaultValue : tokenCount;
 	}
 
 	/**

--- a/src/main/java/com/linglevel/api/word/service/WordPersistenceService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordPersistenceService.java
@@ -82,8 +82,6 @@ public class WordPersistenceService {
 			.orElseGet(() -> {
 				Word newWord = convertAnalysisResultToWord(analysisResult);
 				Word savedWord = wordRepository.save(newWord);
-				log.info("Saved new word: {} ({} -> {})", originalForm, sourceLanguageCode, targetLanguageCode);
-
 				saveWordVariants(savedWord);
 
 				return savedWord;
@@ -91,7 +89,6 @@ public class WordPersistenceService {
 
 		Optional<WordVariant> existingVariant = wordVariantRepository.findByWordAndOriginalForm(word, originalForm);
 		if (existingVariant.isPresent()) {
-			log.info("Variant already exists: {} -> {}", word, originalForm);
 			return existingVariant.get();
 		}
 
@@ -101,7 +98,6 @@ public class WordPersistenceService {
 
 		WordVariant inputVariant = createVariant(word, originalForm, variantTypes);
 		wordVariantRepository.save(inputVariant);
-		log.info("Saved input variant: {} -> {} ({})", word, originalForm, variantTypes);
 
 		return inputVariant;
 	}
@@ -176,8 +172,6 @@ public class WordPersistenceService {
 
 			if (!newVariants.isEmpty()) {
 				wordVariantRepository.saveAll(newVariants);
-				newVariants.forEach(variant -> log.info("Saved variant: {} -> {} ({})", variant.getWord(),
-						variant.getOriginalForm(), variant.getVariantTypes()));
 			}
 		}
 	}
@@ -213,7 +207,6 @@ public class WordPersistenceService {
 			String originalForm = variant.getOriginalForm();
 			wordRepository.findByWordAndTargetLanguageCode(originalForm, targetLanguage).ifPresent(wordToDelete -> {
 				wordRepository.delete(wordToDelete);
-				log.info("Deleted Word: {} (targetLanguage={})", originalForm, targetLanguage);
 			});
 		}
 

--- a/src/main/java/com/linglevel/api/word/service/WordService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordService.java
@@ -43,32 +43,42 @@ public class WordService {
 
 	public WordSearchResponse getOrCreateWords(String userId, String word, LanguageCode targetLanguage) {
 		List<WordVariant> wordVariants = getOrCreateWordEntities(word, targetLanguage);
+		List<WordResponse> responses = createResponses(userId, wordVariants, targetLanguage);
 
-		// 각 원형에 대한 WordResponse 생성
-		List<WordResponse> results = new ArrayList<>();
+		return wordResponseMapper.toWordSearchResponse(word, responses);
+	}
+
+	private List<WordResponse> createResponses(String userId, List<WordVariant> wordVariants,
+			LanguageCode targetLanguage) {
+		List<WordResponse> responses = new ArrayList<>();
 
 		for (WordVariant wordVariant : wordVariants) {
-			// 원형 단어를 targetLanguage로 번역된 것 가져오기
-			Word originalWord = wordRepository
-				.findByWordAndTargetLanguageCode(wordVariant.getOriginalForm(), targetLanguage)
-				.orElseGet(() -> {
-					return singleFlightCoordinator.execute(wordVariant.getOriginalForm(), targetLanguage, () -> {
-						List<WordAnalysisResult> analysisResults = wordAiService
-							.analyzeWord(wordVariant.getOriginalForm(), targetLanguage.getCode());
-						return wordPersistenceService.saveWord(analysisResults.get(0));
-					}, () -> wordRepository.findByWordAndTargetLanguageCode(wordVariant.getOriginalForm(),
-							targetLanguage));
-				});
-
-			boolean isBookmarked = wordBookmarkRepository.existsByUserIdAndWord(userId, wordVariant.getOriginalForm());
-
-			WordResponse response = wordResponseMapper.toWordResponse(originalWord, isBookmarked,
-					wordVariant.getVariantTypes(), wordVariant.getOriginalForm());
-
-			results.add(response);
+			responses.add(createResponse(userId, wordVariant, targetLanguage));
 		}
 
-		return wordResponseMapper.toWordSearchResponse(word, results);
+		return responses;
+	}
+
+	private WordResponse createResponse(String userId, WordVariant wordVariant, LanguageCode targetLanguage) {
+		String originalForm = wordVariant.getOriginalForm();
+		Word originalWord = getOrCreateOriginalWord(originalForm, targetLanguage);
+		boolean isBookmarked = wordBookmarkRepository.existsByUserIdAndWord(userId, originalForm);
+
+		return wordResponseMapper.toWordResponse(originalWord, isBookmarked, wordVariant.getVariantTypes(),
+				originalForm);
+	}
+
+	private Word getOrCreateOriginalWord(String originalForm, LanguageCode targetLanguage) {
+		return wordRepository.findByWordAndTargetLanguageCode(originalForm, targetLanguage)
+			.orElseGet(() -> singleFlightCoordinator.execute(originalForm, targetLanguage,
+					() -> analyzeAndSaveOriginalWord(originalForm, targetLanguage),
+					() -> wordRepository.findByWordAndTargetLanguageCode(originalForm, targetLanguage)));
+	}
+
+	private Word analyzeAndSaveOriginalWord(String originalForm, LanguageCode targetLanguage) {
+		List<WordAnalysisResult> analysisResults = wordAiService.analyzeWord(originalForm, targetLanguage.getCode());
+
+		return wordPersistenceService.saveWord(analysisResults.get(0));
 	}
 
 	public List<WordVariant> getOrCreateWordEntities(String word, LanguageCode targetLanguage) {

--- a/src/main/java/com/linglevel/api/word/service/WordService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordService.java
@@ -15,7 +15,6 @@ import com.linglevel.api.word.repository.InvalidWordRepository;
 import com.linglevel.api.word.repository.WordRepository;
 import com.linglevel.api.word.repository.WordVariantRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -24,7 +23,6 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class WordService {
 
 	private final WordRepository wordRepository;
@@ -54,10 +52,6 @@ public class WordService {
 			Word originalWord = wordRepository
 				.findByWordAndTargetLanguageCode(wordVariant.getOriginalForm(), targetLanguage)
 				.orElseGet(() -> {
-					// 해당 언어로 번역된 Word가 없으면 AI로 새로 생성
-					log.info("Word '{}' not found for targetLanguage {}, creating new one...",
-							wordVariant.getOriginalForm(), targetLanguage);
-
 					return singleFlightCoordinator.execute(wordVariant.getOriginalForm(), targetLanguage, () -> {
 						List<WordAnalysisResult> analysisResults = wordAiService
 							.analyzeWord(wordVariant.getOriginalForm(), targetLanguage.getCode());
@@ -81,7 +75,6 @@ public class WordService {
 		// 1. WordVariant에서 검색 (변형 형태인지 확인)
 		List<WordVariant> existingVariants = wordVariantRepository.findAllByWord(word);
 		if (!existingVariants.isEmpty()) {
-			log.info("Found {} existing variants for word '{}'", existingVariants.size(), word);
 			return existingVariants;
 		}
 
@@ -91,15 +84,11 @@ public class WordService {
 		if (cachedInvalidWord.isPresent()) {
 			InvalidWord invalidWord = cachedInvalidWord.get();
 			if (invalidWord.getAttemptCount() >= 3) {
-				log.info("Word '{}' permanently blocked after {} failed attempts", word, invalidWord.getAttemptCount());
 				throw new WordsException(WordsErrorCode.WORD_IS_MEANINGLESS);
 			}
-			log.info("Word '{}' found in cache with {} attempts. Allowing retry (attempt {}/3)", word,
-					invalidWord.getAttemptCount(), invalidWord.getAttemptCount() + 1);
 		}
 
 		// 3. DB에 없으면 AI 호출 (AI 분석 실패 시에만 InvalidWord로 캐싱)
-		log.info("Word '{}' not found in database. Calling AI to analyze...", word);
 		return singleFlightCoordinator.execute(word, targetLanguage, () -> {
 			List<WordAnalysisResult> analysisResults = analyzeWordAndUpdateInvalidCache(word, targetLanguage);
 			return wordPersistenceService.saveAnalysisResults(word, analysisResults, cachedInvalidWord);
@@ -127,7 +116,6 @@ public class WordService {
 
 	private void cacheInvalidWordIfMeaningless(String word, WordsException e) {
 		if (e.getErrorCode() == WordsErrorCode.WORD_IS_MEANINGLESS) {
-			log.warn("AI classified word '{}' as meaningless. Updating invalid-word cache.", word, e);
 			wordPersistenceService.saveInvalidWord(word);
 		}
 	}
@@ -162,19 +150,12 @@ public class WordService {
 	 */
 	public WordSearchResponse forceReanalyzeWord(String word, LanguageCode targetLanguage, boolean overwrite,
 			boolean deleteVariants) {
-		log.info("Force re-analyzing word '{}' with targetLanguage={}, overwrite={}, deleteVariants={}", word,
-				targetLanguage, overwrite, deleteVariants);
-
-		// AI로 재분석
-		log.info("Calling AI to re-analyze word '{}'...", word);
 		List<WordAnalysisResult> analysisResults = wordAiService.analyzeWord(word, targetLanguage.getCode());
 
 		// 분석 결과를 DB에 저장 (빈 결과는 WordAiService에서 예외 발생, overwrite=false면 중복 체크로 인해 새로운 것만
 		// 추가됨)
 		List<WordVariant> savedVariants = wordPersistenceService.forceSaveAnalysisResults(word, targetLanguage,
 				overwrite, deleteVariants, analysisResults);
-
-		log.info("Force re-analysis completed. Saved {} variants", savedVariants.size());
 
 		// 결과를 WordSearchResponse로 변환하여 반환
 		// userId는 null로 전달 (어드민 API이므로 북마크 체크 불필요)

--- a/src/main/java/com/linglevel/api/word/service/WordService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordService.java
@@ -2,7 +2,9 @@ package com.linglevel.api.word.service;
 
 import com.linglevel.api.bookmark.repository.WordBookmarkRepository;
 import com.linglevel.api.i18n.LanguageCode;
-import com.linglevel.api.word.dto.*;
+import com.linglevel.api.word.dto.WordAnalysisResult;
+import com.linglevel.api.word.dto.WordResponse;
+import com.linglevel.api.word.dto.WordSearchResponse;
 import com.linglevel.api.word.entity.InvalidWord;
 import com.linglevel.api.word.entity.Word;
 import com.linglevel.api.word.entity.WordVariant;

--- a/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
+++ b/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
@@ -55,16 +55,18 @@ public class WordSingleFlightRedisCoordinator {
 
 	private final ConcurrentHashMap<String, CopyOnWriteArrayList<CompletableFuture<Void>>> channelWaiters = new ConcurrentHashMap<>();
 
+	private final PatternTopic doneTopic = new PatternTopic(DONE_PATTERN);
+
 	private final MessageListener doneListener = this::onDoneMessage;
 
 	@PostConstruct
 	void initialize() {
-		redisMessageListenerContainer.addMessageListener(doneListener, new PatternTopic(DONE_PATTERN));
+		redisMessageListenerContainer.addMessageListener(doneListener, doneTopic);
 	}
 
 	@PreDestroy
 	void shutdown() {
-
+		redisMessageListenerContainer.removeMessageListener(doneListener, doneTopic);
 	}
 
 	public <T> T execute(String word, LanguageCode targetLanguage, Supplier<T> leaderAction,

--- a/src/main/java/com/linglevel/api/word/service/WordVariantService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordVariantService.java
@@ -3,7 +3,6 @@ package com.linglevel.api.word.service;
 import com.linglevel.api.word.entity.WordVariant;
 import com.linglevel.api.word.repository.WordVariantRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -16,7 +15,6 @@ import java.util.List;
  */
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class WordVariantService {
 
 	private final WordVariantRepository wordVariantRepository;

--- a/src/main/resources/prompts/word-analysis.md
+++ b/src/main/resources/prompts/word-analysis.md
@@ -1,0 +1,114 @@
+Word: {word} | Target: {targetLanguage}
+
+**CRITICAL: If '{word}' is nonsensical/gibberish/typo, return []**
+**CRITICAL: ALL fields (summary, meaning, example, exampleTranslation) MUST have meaningful content. NEVER leave empty strings.**
+**If you cannot provide meaningful content, return [] instead.**
+
+HOMOGRAPH CHECK: Same spelling, multiple DISTINCT ORIGINS or DIFFERENT ORIGINAL FORMS?
+(e.g., "saw"=past of "see" + noun "saw"톱, "left"=past of "leave" + adj "left"왼쪽, "rose"=past of "rise" + noun "rose"장미)
+**CRITICAL**: If input word IS the original form (e.g., "run", "book"), return SINGLE entry with variantTypes=[ORIGINAL_FORM]
+- "run" → Single entry: originalForm="run", variantTypes=[ORIGINAL_FORM] (DO NOT split into ORIGINAL_FORM and PAST_PARTICIPLE)
+- "books" → Single entry: originalForm="book", variantTypes=[PLURAL, THIRD_PERSON]
+→ YES (different origins): Return array with separate entries | NO: Single-element array
+
+**CRITICAL MERGING RULE:**
+- If input word has SAME originalForm but DIFFERENT variantTypes, MERGE into ONE ENTRY with multiple variantTypes
+- Example "books":
+  Single entry: originalForm="book", variantTypes=[PLURAL, THIRD_PERSON], meanings include BOTH noun meanings AND verb meanings
+- Each meaning should specify its partOfSpeech clearly
+
+STRUCTURE:
+**CRITICAL: Only variantTypes describes the INPUT word. Everything else (summary, meanings, examples) describes the ORIGINAL FORM.**
+
+1. sourceLanguageCode/targetLanguageCode: "EN", "KO", etc.
+2. originalForm: Base form (verbs→infinitive, adj→positive, nouns→singular)
+   **CRITICAL: For adverbs ending in "-ly":**
+   - The adverb itself IS the original form
+   - Do NOT remove "-ly" to get the base adjective
+   - "carefully" → originalForm="carefully" (NOT "careful")
+   - "absolutely" → originalForm="absolutely" (NOT "absolute")
+3. variantTypes: **ARRAY** of relationships between INPUT word and originalForm
+   variantTypes = ONLY morphological relationship (변형 관계만!)
+   ✅ VALID VALUES: ORIGINAL_FORM, PAST_TENSE, PAST_PARTICIPLE, PRESENT_PARTICIPLE, THIRD_PERSON, COMPARATIVE, SUPERLATIVE, PLURAL, UNDEFINED
+
+   **CRITICAL: Special cases**
+   - Pronouns (them, him, whom, etc.): variantTypes=[ORIGINAL_FORM], partOfSpeech="pronoun"
+   - Past participles used as adjectives (confused, interested, etc.): variantTypes=[PAST_PARTICIPLE], add BOTH verb and adjective meanings
+   - Words without inflection (adverbs, prepositions, etc.): variantTypes=[ORIGINAL_FORM]
+
+4. partOfSpeech = Grammatical category (품사)
+   - Goes INSIDE meanings array (meanings 배열 안에!)
+   ✅ VALID VALUES: verb, noun, adjective, adverb, pronoun, preposition, conjunction, interjection, determiner, article, numeral
+
+   - If input="ran" and originalForm="run", then variantTypes=[PAST_TENSE]
+   - If input="books" and originalForm="book", then variantTypes=[PLURAL, THIRD_PERSON] (both noun plural AND verb 3rd person)
+5. summary: Max 3 common translations of the ORIGINAL FORM
+   - Input "ran" → summary of "run": ["달리다","운영하다"]
+   - Input "prettiest" → summary of "pretty": ["예쁜","아름다운"]
+6. meanings: All meanings describe the ORIGINAL FORM (not the input word)
+   - Max 15 objects (common→rare, omit obscure ones)
+   - partOfSpeech: verb, noun, adjective, adverb, etc.
+   - meaning: Detailed explanation in target language
+   - example: **CRITICAL RULES:**
+     1. ALWAYS use the ORIGINAL FORM in the example (NOT the input word!)
+        - If originalForm="book" (input was "books"), use "book" in example
+        - If originalForm="run" (input was "ran"), use "run" in example
+     2. **PART OF SPEECH MUST MATCH**: The word in the example MUST be used as the specified partOfSpeech
+        - If partOfSpeech="noun", the word must function as a noun in the example
+        - If partOfSpeech="verb", the word must function as a verb in the example
+        - WRONG: partOfSpeech="noun" but example has "I need to book a flight" (book is verb here)
+        - CORRECT: partOfSpeech="noun" and example has "I love reading a book" (book is noun here)
+     3. Grammar: Ensure grammatically correct sentences (e.g., "I/You/We/They run" ✓, "She runs" ✓)
+     4. QUALITY: Natural, practical sentences used in real-life contexts
+     5. CLARITY: Sentence must clearly demonstrate the word's meaning
+     6. LENGTH: 5-12 words (not too short, not too long)
+     7. AVOID: Generic phrases like "I need...", "This is...", "It is..." - be creative!
+     GOOD: "I love reading a good book." (book as noun, matches partOfSpeech)
+     GOOD: "We run a small bakery in downtown." (run as verb, matches partOfSpeech)
+     BAD: "I need to book a flight." (if partOfSpeech is noun - book is verb here!)
+   - exampleTranslation: Translation in target language
+7. conjugations: (verbs only) present, past, pastParticiple, presentParticiple, thirdPerson
+8. comparatives: (adj only) positive, comparative, superlative
+9. plural: (nouns only) singular, plural
+
+EXAMPLE - "saw" homograph:
+[
+  {{
+    "originalForm": "see",
+    "variantTypes": ["PAST_TENSE"],
+    "sourceLanguageCode": "EN",
+    "targetLanguageCode": "KO",
+    "summary": ["보다", "알다"],
+    "meanings": [
+      {{
+        "partOfSpeech": "verb",
+        "meaning": "시각적으로 인지하다",
+        "example": "We see the mountains clearly from our window.",
+        "exampleTranslation": "우리는 창문에서 산이 선명하게 보입니다."
+      }}
+    ],
+    "conjugations": {{"present": "see", "past": "saw", "pastParticiple": "seen", "presentParticiple": "seeing", "thirdPerson": "sees"}},
+    "comparatives": null,
+    "plural": null
+  }},
+  {{
+    "originalForm": "saw",
+    "variantTypes": ["ORIGINAL_FORM"],
+    "sourceLanguageCode": "EN",
+    "targetLanguageCode": "KO",
+    "summary": ["톱"],
+    "meanings": [
+      {{
+        "partOfSpeech": "noun",
+        "meaning": "톱 (자르는 도구)",
+        "example": "The carpenter used a saw to cut the wood.",
+        "exampleTranslation": "목수는 톱을 사용하여 나무를 잘랐습니다."
+      }}
+    ],
+    "conjugations": null,
+    "comparatives": null,
+    "plural": {{"singular": "saw", "plural": "saws"}}
+  }}
+]
+
+{format}


### PR DESCRIPTION
## Summary
word 생성 경로의 코드 스타일, 프롬프트 관리, 로그 기준, AI 사용량/비용 로깅을 정리했습니다.

## Problem
word 패키지에 프롬프트 문자열과 생성 응답 조립 로직이 길게 섞여 있었고, 일부 로그 레벨과 AI 사용량/비용 로깅 위치가 운영 관측 기준과 맞지 않았습니다.

## Solution
프롬프트를 리소스로 분리하고, word 응답 생성 흐름과 single-flight listener 종료 처리를 정리했습니다. 또한 Spring AI token usage API 변경에 맞춰 사용량 조회 메서드를 교체하고, Bedrock 비용 계산을 달러 기준으로 갱신했습니다.

## Changes
- word analysis prompt를 `src/main/resources/prompts/word-analysis.md`로 분리
- `WordAiService`의 응답 생성/검증/로깅 흐름 정리
- AI usage/cost 로그를 파싱 전에 남기도록 조정
- Bedrock token cost constant와 Spring AI usage API 사용 정리
- word controller/service 계층의 import, 로그 레벨, 불필요한 debug 로그 정리
- Redis listener container shutdown lifecycle 정리

## Example
API 계약 변경 없음. 기존 word 생성 요청/응답 형식은 유지됩니다.

## Related Issues
없음

## Validation
- `./gradlew checkFormat test --tests com.linglevel.api.word.service.WordServiceTest --tests com.linglevel.api.word.service.WordVariantServiceTest --tests com.linglevel.api.word.controller.WordsAdminControllerTest`