### PR TITLE
docs: refine branch naming conventions

### DIFF
--- a/docs/templates/repository-conventions.md
+++ b/docs/templates/repository-conventions.md
@@ -18,7 +18,10 @@
 - `refactor`: 구조 개선 또는 리팩터링
 - `docs`: 문서 변경
 - `hotfix`: 긴급 수정
-- `codex`: AI 에이전트가 분리 작업을 수행하는 임시 작업 브랜치
+
+작성 원칙:
+
+- 작업 성격이 명확하면 `feat`, `fix`, `refactor`, `docs`, `hotfix` 중 하나를 우선 사용한다.
 
 예시:
 
@@ -26,7 +29,6 @@
 docs/readme-update
 refactor/optimize-books-domain
 fix/stabilize-failing-tests
-codex/readme-update
 ```
 
 ## 커밋 메시지


### PR DESCRIPTION
## Summary
브랜치명 컨벤션에서 `codex` 타입을 제거하고, 작업 성격 기반 타입을 우선 사용하도록 정리했습니다.

## Problem
브랜치 타입 목록에 `codex`가 포함되어 있어 작업 성격이 명확한 리팩터링/문서/수정 작업에도 `codex` 브랜치를 기본처럼 사용할 여지가 있었습니다.

## Solution
허용 브랜치 타입을 `feat`, `fix`, `refactor`, `docs`, `hotfix` 중심으로 정리하고, 작업 성격이 명확하면 해당 타입을 우선 사용한다는 원칙을 추가했습니다.

## Changes
- `codex` 브랜치 타입 설명 삭제
- `codex/readme-update` 예시 삭제
- 작업 성격 기반 브랜치 타입 우선 원칙 추가

## Example
문서 변경이라 별도 사용 예시 없음

## Related Issues
없음