### PR TITLE
docs(k6): simplify performance test docs

### DIFF
--- a/k6/README.md
+++ b/k6/README.md
@@ -1,131 +1,39 @@
 # K6 Performance Testing
 
-`k6` 디렉토리는 정량 부하 테스트를 `부하 프로필` 중심으로 관리한다.
-요청 이름보다 `baseline`, `load`, `stress`, `mixed-load` 같은 실험 목적이 먼저 보이도록 두고, 실제 엔드포인트는 환경변수로 주입한다.
+`k6` 디렉토리는 Ling-Level API의 정량 부하 테스트 자산을 관리한다.
+테스트 스크립트는 개별 요청보다 `baseline`, `load`, `stress`, `mixed-load` 같은 부하 프로필을 기준으로 둔다.
 
-## 현재 구조
+## 디렉토리 구조
 
 ```text
 k6/
 ├── docker-compose.yml
 ├── README.md
-├── seed/
-│   └── ...
-└── scripts/
-    ├── baseline.js
-    ├── load.js
-    ├── stress.js
-    ├── mixed-load.js
-    └── common/
-        ├── endpoints.js
-        ├── http.js
-        ├── profiles.js
-        └── summary.js
+├── reports/
+├── scripts/
+│   ├── baseline.js
+│   ├── load.js
+│   ├── stress.js
+│   ├── mixed-load.js
+│   └── common/
+│       ├── endpoints.js
+│       ├── http.js
+│       ├── profiles.js
+│       └── summary.js
+└── seed/
+    └── README.md
 ```
 
-## 전제 조건
+## 역할
 
-- 애플리케이션이 로컬에서 실행 중이어야 한다.
-- rate limit 영향 없이 k6를 실행하려면 앱을 `local,local-k6` 프로필로 실행한다.
-  - 예: `./gradlew bootRun --args='--spring.profiles.active=local,local-k6'`
-- MongoDB 에는 seed 데이터가 들어 있어야 한다.
-- 테스트용 사용자는 `X-Test-Username` 으로 인증 가능해야 한다.
-- 시드 생성은 [README.md](/Users/solfe/Desktop/WORK/llv/llv-api/k6/seed/README.md)를 따른다.
-- 기본 `BASE_URL` 은 `http://host.docker.internal:8080` 이다.
-- 시계열 결과 저장이 필요하면 먼저 `influxdb` 컨테이너를 실행한다.
-
-## 기본 엔드포인트 이름
-
-- `books.default_list`
-- `books.progress_filter`
-- `books.pagination`
-
-새 엔드포인트를 추가할 때는 `k6/scripts/common/endpoints.js` 에 등록한다.
-
-## 실행 예시
-
-```bash
-docker compose -f k6/docker-compose.yml up -d influxdb
-```
-
-### Baseline
-낮은 부하로 기준 응답시간과 기본 안정성을 확인한다.
-
-```bash
-docker compose -f k6/docker-compose.yml run --rm \
-  -e ENDPOINT_NAME=books.default_list \
-  -e TEST_USERNAME=k6seed-user-02 \
-  k6 run /scripts/baseline.js
-```
-
-### Sustained Load
-일반적인 목표 부하를 일정 시간 유지하면서 지속 성능을 본다.
-
-```bash
-docker compose -f k6/docker-compose.yml run --rm \
-  -e ENDPOINT_NAME=books.progress_filter \
-  -e TEST_USERNAME=k6seed-user-02 \
-  -e TARGET_VUS=20 \
-  k6 run /scripts/load.js
-```
-
-### Stress
-일반 부하보다 더 높은 요청량으로 밀어 한계 구간과 급격한 성능 저하 지점을 찾는다.
-
-```bash
-docker compose -f k6/docker-compose.yml run --rm \
-  -e ENDPOINT_NAME=books.pagination \
-  -e TEST_USERNAME=k6seed-user-02 \
-  -e TARGET_VUS=20 \
-  -e STRESS_TARGET_VUS=80 \
-  k6 run /scripts/stress.js
-```
-
-### Mixed Load
-여러 요청을 비율대로 섞어서 실제 사용 패턴에 가까운 혼합 부하를 본다.
-
-```bash
-docker compose -f k6/docker-compose.yml run --rm \
-  -e ENDPOINT_NAMES=books.default_list,books.progress_filter,books.pagination \
-  -e ENDPOINT_WEIGHTS=7,2,1 \
-  -e TEST_USERNAME=k6seed-user-02 \
-  k6 run /scripts/mixed-load.js
-```
-
-### Custom Endpoint
-등록되지 않은 엔드포인트를 직접 지정해서 같은 부하 프로필로 측정한다.
-
-```bash
-docker compose -f k6/docker-compose.yml run --rm \
-  -e ENDPOINT_PATH=/api/v1/books \
-  -e ENDPOINT_TAG=books \
-  -e ENDPOINT_EXPECTS_ARRAY_AT=content \
-  -e TEST_USERNAME=k6seed-user-02 \
-  k6 run /scripts/load.js
-```
-
-## 자주 바꾸는 환경변수
-
-- `BASE_URL`
-- `TEST_USERNAME`
-- `ENDPOINT_NAME`
-- `ENDPOINT_NAMES`
-- `ENDPOINT_WEIGHTS`
-- `TARGET_VUS`
-- `STRESS_TARGET_VUS`
-- `THINK_TIME`
-
-부하 프로필별 세부 duration 은 `baseline.js`, `load.js`, `stress.js` 가 참조하는 `k6/scripts/common/profiles.js` 환경변수로 조정할 수 있다.
+- `docker-compose.yml`: k6 실행과 InfluxDB 결과 저장을 위한 로컬 구성
+- `scripts/`: 부하 프로필별 k6 실행 스크립트
+- `scripts/common/`: 엔드포인트, HTTP 호출, 부하 프로필, 요약 리포트 공통 코드
+- `seed/`: 성능 테스트용 데이터 생성 및 적재 가이드
+- `reports/`: k6 실행 결과와 분석 JSON 보관 위치
 
 ## 관리 원칙
 
-- 테스트 파일은 요청 중심이 아니라 부하 프로필 중심으로 둔다.
-- 엔드포인트는 `ENDPOINT_NAME` 또는 `ENDPOINT_PATH` 로 주입한다.
-- 여러 요청을 묶고 싶을 때는 `mixed-load.js` 에서 엔드포인트 모듈을 조합한다.
-- 대조군 비교 시에는 같은 seed prefix, 같은 사용자, 같은 정렬 기준을 고정한다.
-
-## 결과 확인
-
-- 콘솔 실시간 출력
-- `/reports` 아래 JSON 결과
-- 필요하면 InfluxDB 데이터를 monitoring Grafana에서 조회
+- 테스트 파일은 요청 이름보다 부하 목적이 먼저 보이도록 둔다.
+- 엔드포인트는 `scripts/common/endpoints.js`에서 관리하거나 환경변수로 주입한다.
+- 대조군 비교 시에는 seed, 사용자, 정렬 조건, 부하 프로필을 고정한다.

--- a/k6/seed/README.md
+++ b/k6/seed/README.md
@@ -9,64 +9,9 @@
 - `k6/seed/streak/...`
 - `k6/seed/word/...`
 
-생성 결과물이나 임시 데이터는 `k6/data`에 두고, 버전 관리 대상은 `k6/seed` 아래에 둔다.
+생성 결과물이나 임시 데이터는 `k6/data`에 두고, 버전 관리 대상 스크립트는 `k6/seed` 아래에 둔다.
 
-## 포함된 스크립트
+## 현재 상태
 
-- `content/book/seed-books-content.mongosh.js`
-  - `user`, `books`, `chapters`, `chunks`, `bookProgress` 컬렉션에 재실행 가능한 업서트 시드를 넣는다.
-  - 기본 분포는 `short / medium / long` 책 구성을 섞고, 챕터 수와 청크 수를 현실적인 범위로 퍼뜨린다.
-  - 같은 콘텐츠 그래프를 기준으로 `NOT_STARTED`, `IN_PROGRESS`, `COMPLETED` 상태가 사용자별로 자연스럽게 섞인 `bookProgress`를 함께 생성한다.
-
-## 실행
-
-로컬 MongoDB 컨테이너가 떠 있는 상태에서 실행한다.
-
-```bash
-docker compose exec -T mongo mongosh llv_api_local < k6/seed/content/book/seed-books-content.mongosh.js
-```
-
-환경변수를 조정해서 규모를 바꿀 수 있다.
-
-```bash
-SEED_PREFIX=k6seed \
-BOOK_COUNT=180 \
-USER_COUNT=4 \
-EXTRA_DIFFICULTY_RATIO=0.25 \
-docker compose exec -T mongo mongosh llv_api_local < k6/seed/content/book/seed-books-content.mongosh.js
-```
-
-같은 prefix 데이터만 지우고 다시 만들고 싶으면 `RESET_EXISTING=true` 를 함께 준다.
-
-```bash
-RESET_EXISTING=true \
-docker compose exec -T mongo mongosh llv_api_local < k6/seed/content/book/seed-books-content.mongosh.js
-```
-
-## 기본 특성
-
-- 책 수 기본값: `240`
-- 사용자 수 기본값: `4`
-- 책 길이 분포:
-  - `short`: 20%
-  - `medium`: 60%
-  - `long`: 20%
-- 기본 난이도 기준 챕터당 평균 청크 수는 약 `30개`를 목표로 둔다.
-- 프로필별 청크 범위:
-  - `short`: 18~24
-  - `medium`: 26~34
-  - `long`: 34~42
-- 각 책은 기본 난이도 1개를 갖고, 일부는 인접 난이도 청크를 추가로 가진다.
-- 이미지 청크는 소량만 섞어서 응답 shape 를 단조롭게 만들지 않는다.
-- `bookProgress`는 사용자 프로필별로 분포를 다르게 준다.
-  - `mostly-unread`
-  - `balanced`
-  - `active-reader`
-  - `completion-heavy`
-- `NOT_STARTED`는 progress 문서를 만들지 않는 방식으로 표현한다.
-- `IN_PROGRESS`는 `chapterProgresses`와 `maxReadChunkNumber`를 함께 채워서 현재 필터와 V3 응답 계산이 모두 자연스럽게 동작하게 한다.
-
-## 주의
-
-- 현재 스크립트는 `books` 콘텐츠 그래프와 `bookProgress`를 함께 만든다.
-- 이미 같은 prefix로 넣은 시드를 다시 깔끔하게 만들고 싶으면 `RESET_EXISTING=true`로 재실행한다.
+기존 book/content 시드 스크립트 파일은 보존한다.
+성능 테스트 시나리오를 다시 정의한 뒤, 필요한 도메인별 시드 스크립트 내용을 재구성한다.


### PR DESCRIPTION
## Summary
k6 테스트 환경 재정비를 시작하기 전에 README를 최소 디렉터리 설명 중심으로 정리했습니다.

## Problem
기존 k6 문서는 특정 실행 예시와 오래된 seed 설명이 길게 남아 있어, 테스트 시나리오를 다시 설계하기 전 현재 디렉터리의 역할을 파악하기 어려웠습니다.

## Solution
루트 k6 README는 디렉터리 구조와 역할, 관리 원칙만 남기고 축소했습니다. seed README는 기존 book/content 시드 스크립트 파일은 보존하되, 향후 성능 테스트 시나리오 재정의 후 내용을 재구성한다는 상태만 명시했습니다.

## Changes
- `k6/README.md` 실행 예시와 환경변수 설명 제거
- `k6/README.md` 디렉터리 구조, 역할, 관리 원칙 중심으로 정리
- `k6/seed/README.md` 기존 seed 실행 가이드 제거
- 기존 `mongosh` 시드 스크립트 파일은 유지

## Example
문서 변경이라 예시 없음

## Related Issues
없음
