### PR TITLE
fix(word): use internal error for Oxford CSV load failure

### DIFF
--- a/src/main/java/com/linglevel/api/word/service/Oxford3000Service.java
+++ b/src/main/java/com/linglevel/api/word/service/Oxford3000Service.java
@@ -212,7 +212,7 @@ public class Oxford3000Service {
 		}
 		catch (Exception e) {
 			log.error("Failed to read Oxford 3000 CSV file: {}", e.getMessage(), e);
-			throw new WordsException(WordsErrorCode.WORD_NOT_FOUND);
+			throw new IllegalStateException("Failed to read Oxford 3000 CSV file: " + OXFORD3000_CSV_PATH, e);
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Oxford 3000 CSV 로딩 실패 시 `WORD_NOT_FOUND` 도메인 예외 대신 `IllegalStateException`을 던지도록 변경했습니다.

## Problem
- CSV 파일을 읽지 못하는 서버 리소스/배포 문제도 `WORD_NOT_FOUND`로 매핑되어 404와 `Word not found.` 응답이 내려갈 수 있었습니다.
- 이는 실제 원인과 API 응답 의미가 맞지 않습니다.

## Solution
- CSV 로딩 실패는 내부 서버 오류로 글로벌 예외 핸들러에 위임되도록 `IllegalStateException`으로 변경했습니다.
- 상세 원인은 로그와 cause에 남기고, 클라이언트 응답에는 기본 내부 오류 메시지가 내려가도록 했습니다.

## Changes
- `Oxford3000Service.readOxford3000Words()`의 CSV 로딩 실패 예외 매핑 수정

## Example
- 기존: CSV 로딩 실패 -> `WordsException(WORD_NOT_FOUND)` -> 404 `Word not found.`
- 변경: CSV 로딩 실패 -> `IllegalStateException` -> 글로벌 핸들러의 500 내부 서버 오류

## Related Issues
- 없음

## Validation
- `git diff --check` 통과
- Gradle 테스트는 로컬 샌드박스의 `~/.gradle` 접근 제한으로 실행하지 못했습니다.