### PR TITLE
refactor(k6): organize test structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ monitoring/alertmanager.yml
 
 ### K6 data ###
 k6/reports/**
+!k6/reports/.gitkeep

--- a/k6/README.md
+++ b/k6/README.md
@@ -15,6 +15,8 @@ k6/
 │   ├── load.js
 │   ├── stress.js
 │   ├── mixed-load.js
+│   ├── domains/
+│   │   └── books.js
 │   └── common/
 │       ├── endpoints.js
 │       ├── http.js
@@ -28,12 +30,14 @@ k6/
 
 - `docker-compose.yml`: k6 실행과 InfluxDB 결과 저장을 위한 로컬 구성
 - `scripts/`: 부하 프로필별 k6 실행 스크립트
+- `scripts/domains/`: 도메인별 엔드포인트와 요청 variant 정의
 - `scripts/common/`: 엔드포인트, HTTP 호출, 부하 프로필, 요약 리포트 공통 코드
 - `seed/`: 성능 테스트용 데이터 생성 및 적재 가이드
-- `reports/`: k6 실행 결과와 분석 JSON 보관 위치
+- `reports/`: k6 실행 결과와 분석 JSON 보관 위치. 로컬 산출물이며 `.gitkeep` 외에는 커밋하지 않는다.
 
 ## 관리 원칙
 
 - 테스트 파일은 요청 이름보다 부하 목적이 먼저 보이도록 둔다.
-- 엔드포인트는 `scripts/common/endpoints.js`에서 관리하거나 환경변수로 주입한다.
+- 엔드포인트는 `scripts/domains/<domain>.js`에 정의하고 `scripts/common/endpoints.js`에서 등록한다.
 - 대조군 비교 시에는 seed, 사용자, 정렬 조건, 부하 프로필을 고정한다.
+- 실행 결과 JSON은 `reports/`에 저장하되, PR에는 테스트 로직과 분석에 필요한 요약만 남긴다.

--- a/k6/scripts/common/endpoints.js
+++ b/k6/scripts/common/endpoints.js
@@ -1,3 +1,5 @@
+import { booksEndpoints } from '../domains/books.js';
+
 function splitCsv(value, fallback) {
   return (value || fallback)
     .split(',')
@@ -11,82 +13,8 @@ function splitNumberCsv(value, fallback) {
     .filter((item) => Number.isFinite(item) && item > 0);
 }
 
-function getByPath(target, path) {
-  if (!path) {
-    return target;
-  }
-
-  return path.split('.').reduce((current, key) => current?.[key], target);
-}
-
-function validateArrayResponse(response, path = 'content') {
-  try {
-    const body = response.json();
-    return Array.isArray(getByPath(body, path));
-  } catch (error) {
-    return false;
-  }
-}
-
-const DEFAULT_LIMIT = Number(__ENV.DEFAULT_LIMIT || 20);
-const DEFAULT_LANGUAGE_CODE = __ENV.LANGUAGE_CODE || 'EN';
-const DEFAULT_SORT_BY = __ENV.SORT_BY || 'created_at';
-const DEFAULT_PAGE = Number(__ENV.PAGE || 1);
-const PROGRESS_FILTERS = splitCsv(__ENV.PROGRESS_FILTERS, 'NOT_STARTED,IN_PROGRESS,COMPLETED');
-const PAGINATION_LIMITS = splitNumberCsv(__ENV.PAGINATION_LIMITS, '10,20,50,100');
-
-function buildBooksBaseQuery() {
-  return {
-    languageCode: DEFAULT_LANGUAGE_CODE,
-    sortBy: DEFAULT_SORT_BY,
-    page: DEFAULT_PAGE,
-    limit: DEFAULT_LIMIT,
-  };
-}
-
 const endpointCatalog = {
-  'books.default_list': {
-    name: 'books.default_list',
-    tag: 'books',
-    buildRequest: () => ({
-      path: '/api/v1/books',
-      query: buildBooksBaseQuery(),
-      variant: 'default_list',
-    }),
-    validate: (response) => validateArrayResponse(response, 'data'),
-  },
-  'books.progress_filter': {
-    name: 'books.progress_filter',
-    tag: 'books',
-    buildRequest: ({ iteration }) => {
-      const progress = PROGRESS_FILTERS[iteration % PROGRESS_FILTERS.length];
-      return {
-        path: '/api/v1/books',
-        query: {
-          ...buildBooksBaseQuery(),
-          progress,
-        },
-        variant: `progress_${progress.toLowerCase()}`,
-      };
-    },
-    validate: (response) => validateArrayResponse(response, 'data'),
-  },
-  'books.pagination': {
-    name: 'books.pagination',
-    tag: 'books',
-    buildRequest: ({ iteration }) => {
-      const limit = PAGINATION_LIMITS[iteration % PAGINATION_LIMITS.length];
-      return {
-        path: '/api/v1/books',
-        query: {
-          ...buildBooksBaseQuery(),
-          limit,
-        },
-        variant: `pagination_limit_${limit}`,
-      };
-    },
-    validate: (response) => validateArrayResponse(response, 'data'),
-  },
+  ...booksEndpoints,
 };
 
 function createCustomEndpoint() {
@@ -103,7 +31,19 @@ function createCustomEndpoint() {
       variant,
       query: {},
     }),
-    validate: (response) => (arrayPath ? validateArrayResponse(response, arrayPath) : true),
+    validate: (response) => {
+      if (!arrayPath) {
+        return true;
+      }
+
+      try {
+        const body = response.json();
+        const value = arrayPath.split('.').reduce((current, key) => current?.[key], body);
+        return Array.isArray(value);
+      } catch (error) {
+        return false;
+      }
+    },
   };
 }
 

--- a/k6/scripts/domains/books.js
+++ b/k6/scripts/domains/books.js
@@ -1,0 +1,90 @@
+function splitCsv(value, fallback) {
+  return (value || fallback)
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function splitNumberCsv(value, fallback) {
+  return splitCsv(value, fallback)
+    .map((item) => Number(item))
+    .filter((item) => Number.isFinite(item) && item > 0);
+}
+
+function getByPath(target, path) {
+  if (!path) {
+    return target;
+  }
+
+  return path.split('.').reduce((current, key) => current?.[key], target);
+}
+
+function validateArrayResponse(response, path = 'content') {
+  try {
+    const body = response.json();
+    return Array.isArray(getByPath(body, path));
+  } catch (error) {
+    return false;
+  }
+}
+
+const DEFAULT_LIMIT = Number(__ENV.DEFAULT_LIMIT || 20);
+const DEFAULT_LANGUAGE_CODE = __ENV.LANGUAGE_CODE || 'EN';
+const DEFAULT_SORT_BY = __ENV.SORT_BY || 'created_at';
+const DEFAULT_PAGE = Number(__ENV.PAGE || 1);
+const PROGRESS_FILTERS = splitCsv(__ENV.PROGRESS_FILTERS, 'NOT_STARTED,IN_PROGRESS,COMPLETED');
+const PAGINATION_LIMITS = splitNumberCsv(__ENV.PAGINATION_LIMITS, '10,20,50,100');
+
+function buildBooksBaseQuery() {
+  return {
+    languageCode: DEFAULT_LANGUAGE_CODE,
+    sortBy: DEFAULT_SORT_BY,
+    page: DEFAULT_PAGE,
+    limit: DEFAULT_LIMIT,
+  };
+}
+
+export const booksEndpoints = {
+  'books.default_list': {
+    name: 'books.default_list',
+    tag: 'books',
+    buildRequest: () => ({
+      path: '/api/v1/books',
+      query: buildBooksBaseQuery(),
+      variant: 'default_list',
+    }),
+    validate: (response) => validateArrayResponse(response, 'data'),
+  },
+  'books.progress_filter': {
+    name: 'books.progress_filter',
+    tag: 'books',
+    buildRequest: ({ iteration }) => {
+      const progress = PROGRESS_FILTERS[iteration % PROGRESS_FILTERS.length];
+      return {
+        path: '/api/v1/books',
+        query: {
+          ...buildBooksBaseQuery(),
+          progress,
+        },
+        variant: `progress_${progress.toLowerCase()}`,
+      };
+    },
+    validate: (response) => validateArrayResponse(response, 'data'),
+  },
+  'books.pagination': {
+    name: 'books.pagination',
+    tag: 'books',
+    buildRequest: ({ iteration }) => {
+      const limit = PAGINATION_LIMITS[iteration % PAGINATION_LIMITS.length];
+      return {
+        path: '/api/v1/books',
+        query: {
+          ...buildBooksBaseQuery(),
+          limit,
+        },
+        variant: `pagination_limit_${limit}`,
+      };
+    },
+    validate: (response) => validateArrayResponse(response, 'data'),
+  },
+};


### PR DESCRIPTION
## Summary
k6 성능 테스트 자산의 reports 보관 정책을 정리하고, books endpoint catalog를 도메인 파일로 분리했습니다.

## Problem
기존 `k6/reports/`는 실행 결과 산출물 위치가 명확하지 않았고, `scripts/common/endpoints.js`가 도메인별 요청 정의와 endpoint 선택 로직을 함께 가지고 있었습니다. Word API 등 세부 성능 분석 시나리오를 추가하면 공통 파일이 빠르게 비대해질 수 있었습니다.

## Solution
reports 디렉터리는 `.gitkeep`만 추적하도록 정리하고, books endpoint 정의는 `scripts/domains/books.js`로 이동했습니다. `scripts/common/endpoints.js`는 도메인 endpoint registry, custom endpoint, weight 선택 로직에 집중하도록 역할을 좁혔습니다.

## Changes
- `k6/reports/.gitkeep` 추가 및 report JSON ignore 예외 정리
- `k6/scripts/domains/books.js` 추가
- `k6/scripts/common/endpoints.js`에서 books catalog 분리
- `k6/README.md`에 `scripts/domains/` 역할과 endpoint 등록 원칙 추가

## Example
신규 도메인 endpoint는 `k6/scripts/domains/<domain>.js`에 정의한 뒤 `k6/scripts/common/endpoints.js`의 catalog에 등록합니다.

검증:
- `node --check k6/scripts/domains/books.js`
- `node --check k6/scripts/common/endpoints.js`

## Related Issues
없음
