### PR TITLE
refactor(word): extract bedrock client

### DIFF
--- a/src/main/java/com/linglevel/api/word/service/WordAiService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordAiService.java
@@ -10,8 +10,6 @@ import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.chat.prompt.PromptTemplate;
@@ -38,14 +36,14 @@ public class WordAiService {
 
 	private static final double OUTPUT_COST_PER_1K_TOKENS_USD = 0.00066;
 
-	private final ChatModel chatModel;
+	private final WordBedrockClient wordBedrockClient;
 
 	private final Validator validator;
 
 	private final String promptTemplate;
 
-	public WordAiService(ChatModel chatModel) {
-		this.chatModel = chatModel;
+	public WordAiService(WordBedrockClient wordBedrockClient) {
+		this.wordBedrockClient = wordBedrockClient;
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		this.validator = factory.getValidator();
 		this.promptTemplate = loadPromptTemplate();
@@ -71,7 +69,7 @@ public class WordAiService {
 			Prompt prompt = promptTemplate
 				.create(Map.of("word", word, "targetLanguage", targetLanguage, "format", format));
 
-			ChatResponse chatResponse = ChatClient.create(chatModel).prompt(prompt).call().chatResponse();
+			ChatResponse chatResponse = wordBedrockClient.call(prompt);
 
 			String response = chatResponse.getResult().getOutput().getText();
 			logAiUsage(word, chatResponse);

--- a/src/main/java/com/linglevel/api/word/service/WordBedrockClient.java
+++ b/src/main/java/com/linglevel/api/word/service/WordBedrockClient.java
@@ -1,0 +1,20 @@
+package com.linglevel.api.word.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WordBedrockClient {
+
+	private final ChatModel chatModel;
+
+	public ChatResponse call(Prompt prompt) {
+		return ChatClient.create(chatModel).prompt(prompt).call().chatResponse();
+	}
+
+}


### PR DESCRIPTION
## Summary
Word AI 분석 흐름에서 AWS Bedrock 호출 경계를 `WordBedrockClient`로 분리했습니다.

## Problem
현재 `WordAiService`가 prompt 생성, Bedrock 호출, 응답 파싱/검증을 모두 담당하고 있어 이후 circuit breaker, bulkhead, fallback 같은 외부 의존성 보호 장치를 Bedrock 호출 지점에만 적용하기 어렵습니다.

## Solution
Spring AI `ChatModel` 호출을 `WordBedrockClient`로 이동하고, `WordAiService`는 기존 분석 orchestration과 응답 처리 책임을 유지하도록 분리했습니다.

## Changes
- `WordBedrockClient` 컴포넌트 추가
- `ChatClient.create(chatModel).prompt(prompt).call().chatResponse()` 호출을 새 클라이언트로 이동
- `WordAiService`가 `WordBedrockClient`를 통해 Bedrock 호출을 위임하도록 변경
- circuit breaker 설정이나 fallback 동작은 아직 추가하지 않음

## Example
API 동작 변경 없음. 이후 PR에서 `WordBedrockClient.call()`에 circuit breaker/fallback을 적용할 수 있습니다.

## Related Issues
없음

## Validation
- `./gradlew checkFormat test --tests com.linglevel.api.word.service.WordServiceTest --tests com.linglevel.api.word.service.WordVariantServiceTest --tests com.linglevel.api.word.controller.WordsAdminControllerTest`