### PR TITLE
chore(word): add resilience dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,10 +31,13 @@ repositories {
 
 dependencies {
 	implementation platform('org.springframework.ai:spring-ai-bom:1.0.0-M6')
+	implementation platform('io.github.resilience4j:resilience4j-bom:2.2.0')
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'io.github.resilience4j:resilience4j-spring-boot3'
 	implementation 'org.springframework.session:spring-session-core'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'


### PR DESCRIPTION
## Summary
Resilience4j 기반 서킷 브레이커 도입을 위한 최소 의존성을 추가했습니다.

## Problem
Bedrock 장애/지연 대응을 위해 `WordBedrockClient`에 circuit breaker를 적용하려면 Resilience4j Spring Boot 3 통합과 어노테이션 동작을 위한 AOP 기반이 필요합니다.

## Solution
Resilience4j BOM, Spring AOP starter, Resilience4j Spring Boot 3 의존성을 추가해 후속 PR에서 circuit breaker 설정과 적용 코드를 분리해서 진행할 수 있도록 했습니다.

## Changes
- `io.github.resilience4j:resilience4j-bom:2.2.0` 추가
- `org.springframework.boot:spring-boot-starter-aop` 추가
- `io.github.resilience4j:resilience4j-spring-boot3` 추가

## Example
아직 런타임 동작 변경 없음. 후속 PR에서 `@CircuitBreaker`와 설정을 적용할 예정입니다.

## Related Issues
없음

## Validation
- `./gradlew bootJar`