### PR TITLE
feat(word): add bedrock circuit breaker

### DIFF
--- a/src/main/java/com/linglevel/api/word/exception/WordsErrorCode.java
+++ b/src/main/java/com/linglevel/api/word/exception/WordsErrorCode.java
@@ -12,6 +12,8 @@ public enum WordsErrorCode {
 	WORD_IS_MEANINGLESS(HttpStatus.BAD_REQUEST, "The word is meaningless."),
 	WORD_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "Word already exists."),
 	WORD_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "Word not found with id."),
+	WORD_AI_TEMPORARILY_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE,
+			"Word AI generation is temporarily unavailable. Please try again."),
 	WORD_ANALYSIS_TIMEOUT(HttpStatus.SERVICE_UNAVAILABLE, "Word analysis is temporarily delayed. Please try again."),
 	WORD_ANALYSIS_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "Word analysis failed. Please try again."),
 	INVALID_WORD_FORMAT(HttpStatus.BAD_REQUEST,

--- a/src/main/java/com/linglevel/api/word/service/WordBedrockClient.java
+++ b/src/main/java/com/linglevel/api/word/service/WordBedrockClient.java
@@ -1,5 +1,8 @@
 package com.linglevel.api.word.service;
 
+import com.linglevel.api.word.exception.WordsErrorCode;
+import com.linglevel.api.word.exception.WordsException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatModel;
@@ -13,8 +16,13 @@ public class WordBedrockClient {
 
 	private final ChatModel chatModel;
 
+	@CircuitBreaker(name = "wordBedrock", fallbackMethod = "fallback")
 	public ChatResponse call(Prompt prompt) {
 		return ChatClient.create(chatModel).prompt(prompt).call().chatResponse();
+	}
+
+	private ChatResponse fallback(Prompt prompt, Throwable e) {
+		throw new WordsException(WordsErrorCode.WORD_AI_TEMPORARILY_UNAVAILABLE, e);
 	}
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,7 +27,7 @@ aws.secret-key=${AWS_SECRET_KEY}
 spring.ai.bedrock.aws.region=us-east-1
 spring.ai.bedrock.aws.access-key=${AWS_ACCESS_KEY}
 spring.ai.bedrock.aws.secret-key=${AWS_SECRET_KEY}
-spring.ai.bedrock.aws.timeout=5s
+spring.ai.bedrock.aws.timeout=8s
 spring.ai.bedrock.converse.chat.options.model=us.meta.llama4-scout-17b-instruct-v1:0
 spring.ai.bedrock.converse.chat.options.temperature=0.3
 spring.ai.bedrock.converse.chat.options.max-tokens=2000
@@ -51,7 +51,7 @@ resilience4j.circuitbreaker.instances.wordBedrock.sliding-window-type=COUNT_BASE
 resilience4j.circuitbreaker.instances.wordBedrock.sliding-window-size=20
 resilience4j.circuitbreaker.instances.wordBedrock.minimum-number-of-calls=10
 resilience4j.circuitbreaker.instances.wordBedrock.failure-rate-threshold=50
-resilience4j.circuitbreaker.instances.wordBedrock.slow-call-duration-threshold=4s
+resilience4j.circuitbreaker.instances.wordBedrock.slow-call-duration-threshold=5s
 resilience4j.circuitbreaker.instances.wordBedrock.slow-call-rate-threshold=50
 resilience4j.circuitbreaker.instances.wordBedrock.wait-duration-in-open-state=30s
 resilience4j.circuitbreaker.instances.wordBedrock.permitted-number-of-calls-in-half-open-state=2
@@ -68,7 +68,7 @@ spring.data.redis.ssl.enabled=false
 
 # Word single-flight (Redis lock + Pub/Sub + DB lookup fallback)
 word.single-flight.enabled=true
-word.single-flight.wait-timeout-ms=7000
+word.single-flight.wait-timeout-ms=10000
 word.single-flight.result-schema-version=v2
 
 # AWS S3 (AI Input/Output buckets)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,9 +27,13 @@ aws.secret-key=${AWS_SECRET_KEY}
 spring.ai.bedrock.aws.region=us-east-1
 spring.ai.bedrock.aws.access-key=${AWS_ACCESS_KEY}
 spring.ai.bedrock.aws.secret-key=${AWS_SECRET_KEY}
+spring.ai.bedrock.aws.timeout=5s
 spring.ai.bedrock.converse.chat.options.model=us.meta.llama4-scout-17b-instruct-v1:0
 spring.ai.bedrock.converse.chat.options.temperature=0.3
 spring.ai.bedrock.converse.chat.options.max-tokens=2000
+
+# Spring AI Retry
+spring.ai.retry.max-attempts=1
 
 # AI Import Key
 import.api.key=${IMPORT_API_KEY}
@@ -41,6 +45,19 @@ jwt.refresh-token-expiration=2592000000
 
 # Actuator Health Check Configuration
 management.endpoints.web.exposure.include=health,info,prometheus
+management.health.circuitbreakers.enabled=true
+
+# Resilience4j Circuit Breaker
+resilience4j.circuitbreaker.instances.wordBedrock.register-health-indicator=true
+resilience4j.circuitbreaker.instances.wordBedrock.sliding-window-type=COUNT_BASED
+resilience4j.circuitbreaker.instances.wordBedrock.sliding-window-size=20
+resilience4j.circuitbreaker.instances.wordBedrock.minimum-number-of-calls=10
+resilience4j.circuitbreaker.instances.wordBedrock.failure-rate-threshold=50
+resilience4j.circuitbreaker.instances.wordBedrock.slow-call-duration-threshold=4s
+resilience4j.circuitbreaker.instances.wordBedrock.slow-call-rate-threshold=50
+resilience4j.circuitbreaker.instances.wordBedrock.wait-duration-in-open-state=30s
+resilience4j.circuitbreaker.instances.wordBedrock.permitted-number-of-calls-in-half-open-state=2
+resilience4j.circuitbreaker.instances.wordBedrock.automatic-transition-from-open-to-half-open-enabled=true
 
 # Discord
 discord.webhook.suggestion.url=${DISCORD_SUGGESTION_WEBHOOK}
@@ -53,7 +70,7 @@ spring.data.redis.ssl.enabled=false
 
 # Word single-flight (Redis lock + Pub/Sub + DB lookup fallback)
 word.single-flight.enabled=true
-word.single-flight.wait-timeout-ms=11000
+word.single-flight.wait-timeout-ms=7000
 word.single-flight.result-schema-version=v2
 
 # AWS S3 (AI Input/Output buckets)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -45,10 +45,8 @@ jwt.refresh-token-expiration=2592000000
 
 # Actuator Health Check Configuration
 management.endpoints.web.exposure.include=health,info,prometheus
-management.health.circuitbreakers.enabled=true
 
 # Resilience4j Circuit Breaker
-resilience4j.circuitbreaker.instances.wordBedrock.register-health-indicator=true
 resilience4j.circuitbreaker.instances.wordBedrock.sliding-window-type=COUNT_BASED
 resilience4j.circuitbreaker.instances.wordBedrock.sliding-window-size=20
 resilience4j.circuitbreaker.instances.wordBedrock.minimum-number-of-calls=10

--- a/src/test/java/com/linglevel/api/word/service/WordBedrockClientCircuitBreakerTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordBedrockClientCircuitBreakerTest.java
@@ -1,0 +1,89 @@
+package com.linglevel.api.word.service;
+
+import com.linglevel.api.word.exception.WordsErrorCode;
+import com.linglevel.api.word.exception.WordsException;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.springboot3.circuitbreaker.autoconfigure.CircuitBreakerAutoConfiguration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringJUnitConfig(classes = { WordBedrockClientCircuitBreakerTest.TestConfig.class, WordBedrockClient.class })
+@ImportAutoConfiguration({ AopAutoConfiguration.class, CircuitBreakerAutoConfiguration.class })
+@TestPropertySource(properties = { "resilience4j.circuitbreaker.instances.wordBedrock.sliding-window-type=COUNT_BASED",
+		"resilience4j.circuitbreaker.instances.wordBedrock.sliding-window-size=2",
+		"resilience4j.circuitbreaker.instances.wordBedrock.minimum-number-of-calls=2",
+		"resilience4j.circuitbreaker.instances.wordBedrock.failure-rate-threshold=50",
+		"resilience4j.circuitbreaker.instances.wordBedrock.wait-duration-in-open-state=60s",
+		"resilience4j.circuitbreaker.instances.wordBedrock.permitted-number-of-calls-in-half-open-state=1" })
+class WordBedrockClientCircuitBreakerTest {
+
+	@Autowired
+	private WordBedrockClient client;
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Autowired
+	private AtomicInteger bedrockAttempts;
+
+	@Test
+	@DisplayName("Bedrock 호출 실패가 반복되면 circuit을 열고 이후 호출은 Bedrock까지 보내지 않는다")
+	void call_opensCircuitAndSkipsBedrockAfterRepeatedFailures() {
+		Prompt prompt = new Prompt("Analyze word");
+
+		assertTemporaryUnavailable(client, prompt);
+		assertTemporaryUnavailable(client, prompt);
+
+		CircuitBreakerRegistry circuitBreakerRegistry = applicationContext.getBean(CircuitBreakerRegistry.class);
+		CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("wordBedrock");
+		assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+		assertThat(bedrockAttempts).hasValue(2);
+
+		assertThatThrownBy(() -> client.call(prompt)).isInstanceOfSatisfying(WordsException.class, e -> {
+			assertThat(e.getErrorCode()).isEqualTo(WordsErrorCode.WORD_AI_TEMPORARILY_UNAVAILABLE);
+			assertThat(e.getCause()).isInstanceOf(CallNotPermittedException.class);
+		});
+		assertThat(bedrockAttempts).hasValue(2);
+	}
+
+	private void assertTemporaryUnavailable(WordBedrockClient client, Prompt prompt) {
+		assertThatThrownBy(() -> client.call(prompt)).isInstanceOfSatisfying(WordsException.class,
+				e -> assertThat(e.getErrorCode()).isEqualTo(WordsErrorCode.WORD_AI_TEMPORARILY_UNAVAILABLE));
+	}
+
+	@Configuration
+	static class TestConfig {
+
+		@Bean
+		AtomicInteger bedrockAttempts() {
+			return new AtomicInteger();
+		}
+
+		@Bean
+		ChatModel chatModel(AtomicInteger bedrockAttempts) {
+			return prompt -> {
+				bedrockAttempts.incrementAndGet();
+				throw new IllegalStateException("bedrock unavailable");
+			};
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Summary
Word Bedrock 호출 경로에 circuit breaker를 적용해 외부 AI 장애 시 빠르게 fallback으로 전환합니다.

## Problem
Bedrock 장애나 지연 상황에서 동기 요청이 timeout/retry로 오래 점유될 수 있고, 복구 중인 외부 서비스에 반복 요청이 몰릴 수 있습니다.

## Solution
Resilience4j `@CircuitBreaker`를 `WordBedrockClient`에 적용하고, Bedrock timeout/retry/single-flight 대기 시간을 동기 요청 기준으로 조정했습니다. Circuit breaker 상태는 ECS liveness health check에 영향을 주지 않도록 main `/actuator/health`에는 연결하지 않았습니다.

## Changes
- `WordBedrockClient`에 `wordBedrock` circuit breaker와 fallback 추가
- Bedrock timeout을 `8s`로 설정하고 Spring AI retry를 1회 시도로 제한
- slow call 기준을 `5s`, single-flight follower wait timeout을 `10000ms`로 조정
- circuit breaker 설정 추가
- 반복 실패 시 circuit open 및 이후 Bedrock 호출 차단을 검증하는 테스트 추가

## Example
Bedrock 호출 실패가 반복되면 `WORD_AI_TEMPORARILY_UNAVAILABLE`로 빠르게 fallback 처리되고, circuit open 이후에는 Bedrock까지 호출하지 않습니다.

## Related Issues
없음

## Validation
`./gradlew checkFormat test --tests com.linglevel.api.word.service.WordBedrockClientCircuitBreakerTest --tests com.linglevel.api.word.service.WordServiceTest --tests com.linglevel.api.word.controller.WordsAdminControllerTest`