### PR TITLE
fix(word): configure bedrock retry and fallback policy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ repositories {
 dependencies {
 	implementation platform('org.springframework.ai:spring-ai-bom:1.0.0-M6')
 	implementation platform('io.github.resilience4j:resilience4j-bom:2.2.0')
+	implementation platform('software.amazon.awssdk:bom:2.31.78')
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -50,7 +51,8 @@ dependencies {
 	implementation('org.springframework.ai:spring-ai-bedrock-converse-spring-boot-starter') {
 		exclude group: 'io.swagger.core.v3', module: 'swagger-annotations'
 	}
-	implementation 'software.amazon.awssdk:s3:2.31.78'
+	implementation 'software.amazon.awssdk:s3'
+	implementation 'software.amazon.awssdk:bedrockruntime'
 	implementation 'com.google.firebase:firebase-admin:9.7.0'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	implementation 'com.sksamuel.scrimage:scrimage-core:4.3.5'

--- a/src/main/java/com/linglevel/api/word/config/WordBedrockClientConfig.java
+++ b/src/main/java/com/linglevel/api/word/config/WordBedrockClientConfig.java
@@ -1,0 +1,27 @@
+package com.linglevel.api.word.config;
+
+import org.springframework.ai.autoconfigure.bedrock.BedrockAwsConnectionProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import software.amazon.awssdk.regions.providers.AwsRegionProvider;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+
+@Configuration
+public class WordBedrockClientConfig {
+
+	private static final int MAX_ATTEMPTS = 2;
+
+	@Bean
+	public BedrockRuntimeClient wordBedrockRuntimeClient(AwsCredentialsProvider credentialsProvider,
+			AwsRegionProvider regionProvider, BedrockAwsConnectionProperties connectionProperties) {
+		return BedrockRuntimeClient.builder()
+			.region(regionProvider.getRegion())
+			.credentialsProvider(credentialsProvider)
+			.overrideConfiguration(builder -> builder.apiCallTimeout(connectionProperties.getTimeout())
+				.retryStrategy(AwsRetryStrategy.standardRetryStrategy().toBuilder().maxAttempts(MAX_ATTEMPTS).build()))
+			.build();
+	}
+
+}

--- a/src/main/java/com/linglevel/api/word/service/WordBedrockClient.java
+++ b/src/main/java/com/linglevel/api/word/service/WordBedrockClient.java
@@ -21,7 +21,7 @@ public class WordBedrockClient {
 		return ChatClient.create(chatModel).prompt(prompt).call().chatResponse();
 	}
 
-	private ChatResponse fallback(Prompt prompt, Throwable e) {
+	private ChatResponse fallback(Prompt prompt, Exception e) {
 		throw new WordsException(WordsErrorCode.WORD_AI_TEMPORARILY_UNAVAILABLE, e);
 	}
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,9 +32,6 @@ spring.ai.bedrock.converse.chat.options.model=us.meta.llama4-scout-17b-instruct-
 spring.ai.bedrock.converse.chat.options.temperature=0.3
 spring.ai.bedrock.converse.chat.options.max-tokens=2000
 
-# Spring AI Retry
-spring.ai.retry.max-attempts=1
-
 # AI Import Key
 import.api.key=${IMPORT_API_KEY}
 

--- a/src/test/java/com/linglevel/api/word/config/WordBedrockClientConfigTest.java
+++ b/src/test/java/com/linglevel/api/word/config/WordBedrockClientConfigTest.java
@@ -1,0 +1,37 @@
+package com.linglevel.api.word.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.autoconfigure.bedrock.BedrockAwsConnectionProperties;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WordBedrockClientConfigTest {
+
+	@Test
+	@DisplayName("Bedrock 호출은 한 번 재시도하고 전체 요청 시간을 8초로 제한한다")
+	void wordBedrockRuntimeClient_configuresSingleRetryAndTotalTimeout() {
+		BedrockAwsConnectionProperties connectionProperties = new BedrockAwsConnectionProperties();
+		connectionProperties.setTimeout(Duration.ofSeconds(8));
+
+		WordBedrockClientConfig config = new WordBedrockClientConfig();
+		try (BedrockRuntimeClient client = config.wordBedrockRuntimeClient(
+				StaticCredentialsProvider.create(AwsBasicCredentials.create("access-key", "secret-key")),
+				() -> Region.US_EAST_1, connectionProperties)) {
+			ClientOverrideConfiguration overrideConfiguration = client.serviceClientConfiguration()
+				.overrideConfiguration();
+
+			assertThat(overrideConfiguration.apiCallTimeout()).contains(Duration.ofSeconds(8));
+			assertThat(overrideConfiguration.retryStrategy())
+				.hasValueSatisfying(retryStrategy -> assertThat(retryStrategy.maxAttempts()).isEqualTo(2));
+		}
+	}
+
+}

--- a/src/test/java/com/linglevel/api/word/service/WordBedrockClientCircuitBreakerTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordBedrockClientCircuitBreakerTest.java
@@ -6,6 +6,7 @@ import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.springboot3.circuitbreaker.autoconfigure.CircuitBreakerAutoConfiguration;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.model.ChatModel;
@@ -43,6 +44,12 @@ class WordBedrockClientCircuitBreakerTest {
 	@Autowired
 	private AtomicInteger bedrockAttempts;
 
+	@BeforeEach
+	void resetCircuitBreaker() {
+		applicationContext.getBean(CircuitBreakerRegistry.class).circuitBreaker("wordBedrock").reset();
+		bedrockAttempts.set(0);
+	}
+
 	@Test
 	@DisplayName("Bedrock 호출 실패가 반복되면 circuit을 열고 이후 호출은 Bedrock까지 보내지 않는다")
 	void call_opensCircuitAndSkipsBedrockAfterRepeatedFailures() {
@@ -63,6 +70,13 @@ class WordBedrockClientCircuitBreakerTest {
 		assertThat(bedrockAttempts).hasValue(2);
 	}
 
+	@Test
+	@DisplayName("JVM Error는 fallback으로 변환하지 않고 그대로 전파한다")
+	void call_propagatesErrorWithoutFallback() {
+		assertThatThrownBy(() -> client.call(new Prompt("Trigger error"))).isInstanceOf(AssertionError.class)
+			.hasMessage("fatal error");
+	}
+
 	private void assertTemporaryUnavailable(WordBedrockClient client, Prompt prompt) {
 		assertThatThrownBy(() -> client.call(prompt)).isInstanceOfSatisfying(WordsException.class,
 				e -> assertThat(e.getErrorCode()).isEqualTo(WordsErrorCode.WORD_AI_TEMPORARILY_UNAVAILABLE));
@@ -80,6 +94,9 @@ class WordBedrockClientCircuitBreakerTest {
 		ChatModel chatModel(AtomicInteger bedrockAttempts) {
 			return prompt -> {
 				bedrockAttempts.incrementAndGet();
+				if ("Trigger error".equals(prompt.getContents())) {
+					throw new AssertionError("fatal error");
+				}
 				throw new IllegalStateException("bedrock unavailable");
 			};
 		}


### PR DESCRIPTION
## Summary
Bedrock 호출의 재시도와 전체 시간 제한을 AWS SDK 클라이언트에 명시적으로 적용했습니다.

## Problem
`spring.ai.retry.max-attempts`는 현재 Spring AI Bedrock Converse 호출의 AWS SDK 재시도 횟수를 제어하지 않아, 설정만으로는 의도한 재시도 정책을 보장할 수 없었습니다. 또한 circuit breaker fallback이 `Throwable`을 받아 JVM `Error`까지 서비스 예외로 변환할 수 있었습니다.

## Solution
Spring AI가 주입받아 사용하는 `BedrockRuntimeClient`를 직접 구성하고 AWS SDK 표준 재시도 전략의 최대 시도 횟수를 2회로 제한했습니다. 전체 API 호출 시간은 기존 Bedrock 연결 설정의 8초를 사용하며, fallback 대상은 `Exception`으로 제한했습니다.

## Changes
- AWS SDK BOM 2.31.78로 관련 모듈 버전 정렬
- `bedrockruntime` 직접 의존성 선언
- 최초 호출 포함 최대 2회 시도와 전체 8초 timeout 적용
- 효과가 없던 `spring.ai.retry.max-attempts` 설정 제거
- JVM `Error`를 fallback으로 변환하지 않도록 시그니처 조정
- 재시도 설정 및 circuit breaker fallback 회귀 테스트 추가

## Example
Bedrock 호출은 최초 요청이 재시도 가능한 사유로 빠르게 실패하면 최대 한 번 재시도합니다. 두 시도와 backoff는 전체 8초 안에서 수행되며, 최종 실패는 기존 503 fallback으로 처리됩니다. JVM `Error`는 fallback으로 변환하지 않고 그대로 전파됩니다.

## Related Issues
없음