### PR TITLE
feat: add phase two performance test foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ out/
 
 ### env ###
 .env.local
+infra/performance-test/run/.env.app
 MISSIONS.md
 
 ### firebase key ###

--- a/docs/architecture/performance-test-infrastructure.md
+++ b/docs/architecture/performance-test-infrastructure.md
@@ -12,6 +12,7 @@ flowchart LR
     APP --> MYSQL["MySQL"]
     APP --> ATLAS["MongoDB Atlas"]
     APP --> MOCK["External API mock"]
+    ENV["S3 environment file"] --> APP
 
     PROM["Prometheus"] --> APP
     GRAFANA["Grafana"] --> PROM
@@ -28,10 +29,10 @@ flowchart LR
 | VPC, Subnet, Security Group | 테스트 환경의 네트워크 격리와 통신 제어 |
 | Internal ALB | k6 요청을 API task로 라우팅 |
 | ECS Fargate | API, k6, Redis, MySQL, external API mock, Prometheus, Grafana 컨테이너 실행 |
-| MongoDB Atlas | 테스트 데이터 저장소. 테스트 네트워크의 egress IP만 allowlist에 등록 |
+| MongoDB Atlas | 사용자가 유지하는 테스트 데이터 저장소. 실행 중에만 IP allowlist를 임시로 전체 허용 |
 | External API mock | Bedrock, S3 등 외부 의존성의 응답·지연·오류를 통제 |
 | CloudWatch Logs/Metrics | ECS, ALB 로그와 인프라 메트릭 수집 |
-| S3 | Terraform state와 실행 결과 보관 |
+| S3 | 테스트용 environment file 전달, Terraform state와 실행 결과 보관 |
 | IAM Role | Terraform 프로비저닝 및 ECS task의 최소 권한 부여 |
 
 ## 단계별 범위
@@ -39,8 +40,16 @@ flowchart LR
 | 단계 | 목표 | 포함 구성 | 완료 기준 |
 | --- | --- | --- | --- |
 | 1단계 | Terraform으로 컨테이너를 생성하고 제거한다. | VPC, Internal ALB, ECS Fargate API, CloudWatch Logs | ALB health check 성공 후 `terraform destroy`로 런타임 리소스가 제거된다. |
-| 2단계 | 의존성이 연결된 API에 k6 부하를 전달한다. | 1단계 + k6, Redis, MySQL, MongoDB Atlas, external API mock | k6가 ALB를 통해 API를 호출하고 API가 Redis, MySQL, Atlas, mock 연결을 확인한다. |
+| 2단계 | 의존성이 연결된 API에 k6 부하를 전달한다. | 1단계 + k6, Redis, MySQL, MongoDB Atlas, external API mock | k6가 ALB를 통해 API를 호출하고 API 또는 전용 probe가 각 의존성의 연결을 확인한다. |
 | 3단계 | 부하 결과와 애플리케이션·인프라 상태를 Grafana에서 함께 분석한다. | 2단계 + Prometheus, Grafana, CloudWatch, 결과 S3 | 동일 실행 시간 범위의 지표와 원본 결과를 조회·보관한다. |
+
+## 2단계 운영 경계
+
+- 테스트 task는 public subnet에서 public IP를 사용한다. NAT Gateway와 고정 EIP는 구성하지 않고, inbound는 Security Group으로 제한한다.
+- Atlas는 테스트 전용 cluster와 최소 권한 계정을 사용한다. IP allowlist의 `0.0.0.0/0` 허용은 테스트 중에만 유지하고 종료 직후 제거한다.
+- 비밀값은 서비스별 임시 `.env`를 S3 environment file로 전달한다. Terraform은 bucket, object key, IAM만 관리하고 객체 내용은 관리하지 않아 비밀값이 state에 기록되지 않게 한다.
+- 실행 스크립트가 로컬 `.env`를 S3에 업로드하고, 테스트 종료 시 S3 객체와 로컬 파일을 모두 삭제한다.
+- 2단계는 의존성 연결과 k6 요청 전달까지만 검증한다. exporter, Prometheus, Grafana를 통한 메트릭 수집은 3단계에서 추가한다.
 
 ## 3단계 수집 지표
 

--- a/infra/performance-test/README.md
+++ b/infra/performance-test/README.md
@@ -68,12 +68,16 @@ Terraform과 검증 스크립트는 같은 `AWS_PROFILE`을 사용한다. CI에�
 
 ## 2단계 환경 파일
 
-Terraform 적용 후 `infra/performance-test/run/.env.app`에 테스트 전용 환경 변수를 작성하고 업로드한다. 이 파일은 Git에서 제외되며 객체 내용도 Terraform state에 기록되지 않는다.
+ECS를 포함한 전체 Terraform 적용 전에 `infra/performance-test/run/.env.app`에 테스트 전용 환경 변수를 작성하고 업로드한다. 이 파일은 Git에서 제외되며 객체 내용도 Terraform state에 기록되지 않는다.
+
+업로드 스크립트는 S3 bucket, public access block, 암호화 설정만 먼저 적용한 후 환경 파일을 업로드한다. 업로드가 끝나야 전체 인프라를 적용한다.
 
 ```bash
 cp infra/performance-test/run/.env.app.example infra/performance-test/run/.env.app
 chmod 600 infra/performance-test/run/.env.app
 ./infra/performance-test/run/upload-app-environment.sh
+
+terraform -chdir=infra/performance-test/terraform/platform apply
 ```
 
 테스트 종료 후에는 인프라를 제거하기 전에 환경 파일을 먼저 정리한다. 원격 객체 삭제가 실패하더라도 로컬 `.env.app`은 삭제되며, 실패한 S3 객체는 `terraform destroy`의 `force_destroy`로 다시 정리한다.

--- a/infra/performance-test/README.md
+++ b/infra/performance-test/README.md
@@ -10,6 +10,7 @@
 
 - `terraform/platform`: AWS 리소스 정의
 - `run/verify-phase-one.sh`: ALB target health 확인
+- `run/.env.app.example`: 테스트 앱 환경 변수 양식
 - `run/upload-app-environment.sh`: 앱 환경 파일을 임시 S3 객체로 업로드
 - `run/cleanup-app-environment.sh`: S3 객체와 로컬 환경 파일 삭제
 - `iam/performance-test-provisioner-policy.json`: Terraform 실행 역할의 초기 권한 정책
@@ -70,6 +71,7 @@ Terraform과 검증 스크립트는 같은 `AWS_PROFILE`을 사용한다. CI에�
 Terraform 적용 후 `infra/performance-test/run/.env.app`에 테스트 전용 환경 변수를 작성하고 업로드한다. 이 파일은 Git에서 제외되며 객체 내용도 Terraform state에 기록되지 않는다.
 
 ```bash
+cp infra/performance-test/run/.env.app.example infra/performance-test/run/.env.app
 chmod 600 infra/performance-test/run/.env.app
 ./infra/performance-test/run/upload-app-environment.sh
 ```

--- a/infra/performance-test/README.md
+++ b/infra/performance-test/README.md
@@ -10,6 +10,8 @@
 
 - `terraform/platform`: AWS 리소스 정의
 - `run/verify-phase-one.sh`: ALB target health 확인
+- `run/upload-app-environment.sh`: 앱 환경 파일을 임시 S3 객체로 업로드
+- `run/cleanup-app-environment.sh`: S3 객체와 로컬 환경 파일 삭제
 - `iam/performance-test-provisioner-policy.json`: Terraform 실행 역할의 초기 권한 정책
 
 ## 2단계 계획
@@ -62,3 +64,21 @@ terraform destroy
 `terraform.tfvars`의 `test_run_id`는 실행마다 고유하게 설정한다. 로컬 PC에서는 Internal ALB에 직접 접근하지 않고, 검증 스크립트로 target health를 확인한다.
 
 Terraform과 검증 스크립트는 같은 `AWS_PROFILE`을 사용한다. CI에서는 GitHub OIDC가 `PerformanceTestProvisioner`의 임시 credential을 제공한다.
+
+## 2단계 환경 파일
+
+Terraform 적용 후 `infra/performance-test/run/.env.app`에 테스트 전용 환경 변수를 작성하고 업로드한다. 이 파일은 Git에서 제외되며 객체 내용도 Terraform state에 기록되지 않는다.
+
+```bash
+chmod 600 infra/performance-test/run/.env.app
+./infra/performance-test/run/upload-app-environment.sh
+```
+
+테스트 종료 후에는 인프라를 제거하기 전에 환경 파일을 먼저 정리한다. 원격 객체 삭제가 실패하더라도 로컬 `.env.app`은 삭제되며, 실패한 S3 객체는 `terraform destroy`의 `force_destroy`로 다시 정리한다.
+
+```bash
+./infra/performance-test/run/cleanup-app-environment.sh
+
+cd infra/performance-test/terraform/platform
+terraform destroy
+```

--- a/infra/performance-test/README.md
+++ b/infra/performance-test/README.md
@@ -4,13 +4,21 @@
 
 ## 현재 단계
 
-1단계는 `ECS Fargate API 1대 -> Internal ALB` 배포와 제거만 검증한다. 기본 이미지는 Nginx이며, Redis, MySQL, Atlas, k6, Prometheus, Grafana는 다음 단계에서 추가한다. Word single-flight 실험에서는 API를 2대로 확장한다.
+1단계의 `ECS Fargate API 1대 -> Internal ALB` 배포와 제거 검증을 마쳤다. 2단계에서는 API를 2대로 확장하고 Redis, MySQL, Atlas, external API mock, k6를 연결한다. Prometheus와 Grafana는 3단계에서 추가한다.
 
 ## 구조
 
 - `terraform/platform`: AWS 리소스 정의
 - `run/verify-phase-one.sh`: ALB target health 확인
 - `iam/performance-test-provisioner-policy.json`: Terraform 실행 역할의 초기 권한 정책
+
+## 2단계 계획
+
+- ECS task는 public subnet과 public IP를 사용하며 NAT Gateway와 EIP는 두지 않는다.
+- Atlas는 사용자가 유지하는 테스트 전용 cluster를 사용한다. 테스트 직전에 IP allowlist를 `0.0.0.0/0`으로 열고 종료 직후 닫는다.
+- 비밀값은 서비스별 임시 `.env`를 S3 environment file로 전달한다. Terraform은 객체 내용이 아닌 bucket, object key, IAM만 관리한다.
+- 실행 스크립트가 `.env`를 업로드하며 테스트 종료 시 S3 객체와 로컬 파일을 모두 삭제한다.
+- 이 단계의 완료 기준은 k6가 ALB를 통해 API를 호출하고 API 또는 전용 probe가 각 의존성 연결을 확인하는 것이다.
 
 ## 관측 계획
 
@@ -19,9 +27,9 @@
 - `mysqld_exporter`: connection, query rate, InnoDB, lock, I/O 지표
 - `redis_exporter`: memory, client, command rate, hit/miss, eviction 지표
 
-exporter는 Secrets Manager에서 읽기 전용 DB 계정을 주입받는다. 느린 쿼리 원문과 Redis command 인자는 metric label로 수집하지 않고 DB 로그와 profiler에서 확인한다.
+exporter의 읽기 전용 DB 계정도 서비스별 S3 environment file로 주입한다. 느린 쿼리 원문과 Redis command 인자는 metric label로 수집하지 않고 DB 로그와 profiler에서 확인한다.
 
-## 실행
+## 1단계 실행
 
 먼저 로컬 AWS profile이 `PerformanceTestProvisioner` 역할을 assume하도록 설정한다. 이 설정은 저장소가 아닌 `~/.aws/config`에 둔다.
 

--- a/infra/performance-test/README.md
+++ b/infra/performance-test/README.md
@@ -12,6 +12,15 @@
 - `run/verify-phase-one.sh`: ALB target health 확인
 - `iam/performance-test-provisioner-policy.json`: Terraform 실행 역할의 초기 권한 정책
 
+## 관측 계획
+
+3단계에서 Prometheus가 아래 exporter의 `/metrics`를 수집하고 Grafana에서 API 지표와 함께 조회한다.
+
+- `mysqld_exporter`: connection, query rate, InnoDB, lock, I/O 지표
+- `redis_exporter`: memory, client, command rate, hit/miss, eviction 지표
+
+exporter는 Secrets Manager에서 읽기 전용 DB 계정을 주입받는다. 느린 쿼리 원문과 Redis command 인자는 metric label로 수집하지 않고 DB 로그와 profiler에서 확인한다.
+
 ## 실행
 
 먼저 로컬 AWS profile이 `PerformanceTestProvisioner` 역할을 assume하도록 설정한다. 이 설정은 저장소가 아닌 `~/.aws/config`에 둔다.

--- a/infra/performance-test/iam/performance-test-provisioner-policy.json
+++ b/infra/performance-test/iam/performance-test-provisioner-policy.json
@@ -92,15 +92,60 @@
         "iam:AttachRolePolicy",
         "iam:CreateRole",
         "iam:DeleteRole",
+        "iam:DeleteRolePolicy",
         "iam:DetachRolePolicy",
+        "iam:GetRolePolicy",
         "iam:GetRole",
         "iam:ListAttachedRolePolicies",
+        "iam:ListRolePolicies",
         "iam:ListRoleTags",
         "iam:PassRole",
+        "iam:PutRolePolicy",
         "iam:TagRole",
         "iam:UntagRole"
       ],
       "Resource": "arn:aws:iam::*:role/llvpt-*"
+    },
+    {
+      "Sid": "EnvironmentFileBucketLifecycle",
+      "Effect": "Allow",
+      "Action": [
+        "s3:CreateBucket",
+        "s3:DeleteBucket",
+        "s3:DeleteBucketPolicy",
+        "s3:GetAccelerateConfiguration",
+        "s3:GetBucketAcl",
+        "s3:GetBucketCORS",
+        "s3:GetBucketLogging",
+        "s3:GetBucketLocation",
+        "s3:GetBucketObjectLockConfiguration",
+        "s3:GetBucketPolicy",
+        "s3:GetBucketPublicAccessBlock",
+        "s3:GetBucketRequestPayment",
+        "s3:GetBucketTagging",
+        "s3:GetBucketVersioning",
+        "s3:GetBucketWebsite",
+        "s3:GetEncryptionConfiguration",
+        "s3:GetLifecycleConfiguration",
+        "s3:GetReplicationConfiguration",
+        "s3:ListBucket",
+        "s3:ListBucketVersions",
+        "s3:PutBucketPublicAccessBlock",
+        "s3:PutBucketTagging",
+        "s3:PutEncryptionConfiguration"
+      ],
+      "Resource": "arn:aws:s3:::llvpt-*-env"
+    },
+    {
+      "Sid": "EnvironmentFileObjectCleanup",
+      "Effect": "Allow",
+      "Action": [
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion",
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Resource": "arn:aws:s3:::llvpt-*-env/*"
     },
     {
       "Sid": "CloudWatchLogGroupLifecycle",

--- a/infra/performance-test/run/.env.app.example
+++ b/infra/performance-test/run/.env.app.example
@@ -1,0 +1,32 @@
+# Runtime profile
+SPRING_PROFILES_ACTIVE=prod
+
+# Data stores
+SPRING_DATA_MONGODB_URI=mongodb+srv://replace-me:replace-me@replace-me.mongodb.net/llv_performance_test
+SPRING_DATA_MONGODB_DATABASE=llv_performance_test
+SPRING_DATA_REDIS_HOST=replace-me
+SPRING_DATA_REDIS_PORT=6379
+
+# Test controls
+RATE_LIMIT_ENABLED=false
+WORD_SINGLE_FLIGHT_ENABLED=true
+
+# Application secrets
+JWT_SECRET=replace-with-test-jwt-secret
+IMPORT_API_KEY=replace-with-test-import-api-key
+DISCORD_SUGGESTION_WEBHOOK=replace-with-test-webhook-url
+FIREBASE_CONFIG_BASE64=replace-with-test-firebase-config-base64
+
+# AWS and external service mocks
+AWS_ACCESS_KEY=replace-with-test-access-key
+AWS_SECRET_KEY=replace-with-test-secret-key
+S3_REGION=ap-northeast-2
+S3_AI_INPUT_NAME=replace-with-test-input-bucket
+S3_AI_OUTPUT_NAME=replace-with-test-output-bucket
+CF_R2_ENDPOINT=replace-with-mock-endpoint
+CF_R2_ACCESS_KEY=replace-with-test-r2-access-key
+CF_R2_SECRET_KEY=replace-with-test-r2-secret-key
+CF_R2_STATIC_BUCKET=replace-with-test-static-bucket
+
+# Observability
+SENTRY_DSN=

--- a/infra/performance-test/run/cleanup-app-environment.sh
+++ b/infra/performance-test/run/cleanup-app-environment.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+platform_dir="${1:-infra/performance-test/terraform/platform}"
+environment_file="infra/performance-test/run/.env.app"
+
+trap 'rm -f "$environment_file"' EXIT
+
+region="$(terraform -chdir="$platform_dir" output -raw aws_region)"
+bucket="$(terraform -chdir="$platform_dir" output -raw environment_file_bucket)"
+key="$(terraform -chdir="$platform_dir" output -raw app_environment_file_key)"
+
+if ! aws s3 rm "s3://${bucket}/${key}" --region "$region" --only-show-errors; then
+	echo "Failed to delete s3://${bucket}/${key}; the local environment file was removed." >&2
+	exit 1
+fi
+
+echo "Application environment file removed from S3 and local storage."

--- a/infra/performance-test/run/upload-app-environment.sh
+++ b/infra/performance-test/run/upload-app-environment.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+platform_dir="${1:-infra/performance-test/terraform/platform}"
+environment_file="infra/performance-test/run/.env.app"
+
+if [[ ! -f "$environment_file" ]]; then
+	echo "Application environment file not found: ${environment_file}" >&2
+	exit 1
+fi
+
+region="$(terraform -chdir="$platform_dir" output -raw aws_region)"
+bucket="$(terraform -chdir="$platform_dir" output -raw environment_file_bucket)"
+key="$(terraform -chdir="$platform_dir" output -raw app_environment_file_key)"
+
+aws s3 cp "$environment_file" "s3://${bucket}/${key}" \
+	--region "$region" \
+	--sse AES256 \
+	--only-show-errors
+
+echo "Application environment file uploaded to s3://${bucket}/${key}."

--- a/infra/performance-test/run/upload-app-environment.sh
+++ b/infra/performance-test/run/upload-app-environment.sh
@@ -10,6 +10,11 @@ if [[ ! -f "$environment_file" ]]; then
 	exit 1
 fi
 
+terraform -chdir="$platform_dir" apply \
+	-target=aws_s3_bucket.environment_files \
+	-target=aws_s3_bucket_public_access_block.environment_files \
+	-target=aws_s3_bucket_server_side_encryption_configuration.environment_files
+
 region="$(terraform -chdir="$platform_dir" output -raw aws_region)"
 bucket="$(terraform -chdir="$platform_dir" output -raw environment_file_bucket)"
 key="$(terraform -chdir="$platform_dir" output -raw app_environment_file_key)"

--- a/infra/performance-test/terraform/platform/iam.tf
+++ b/infra/performance-test/terraform/platform/iam.tf
@@ -18,3 +18,21 @@ resource "aws_iam_role_policy_attachment" "task_execution" {
   role       = aws_iam_role.task_execution.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
+
+data "aws_iam_policy_document" "task_execution_environment_file" {
+  statement {
+    actions   = ["s3:GetBucketLocation"]
+    resources = [aws_s3_bucket.environment_files.arn]
+  }
+
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.environment_files.arn}/${local.environment_file_key}"]
+  }
+}
+
+resource "aws_iam_role_policy" "task_execution_environment_file" {
+  name   = "environment-file-read"
+  role   = aws_iam_role.task_execution.id
+  policy = data.aws_iam_policy_document.task_execution_environment_file.json
+}

--- a/infra/performance-test/terraform/platform/main.tf
+++ b/infra/performance-test/terraform/platform/main.tf
@@ -1,6 +1,7 @@
 locals {
-  name_prefix        = "llvpt-${var.test_run_id}"
-  availability_zones = var.availability_zones
+  name_prefix          = "llvpt-${var.test_run_id}"
+  environment_file_key = "environment/app.env"
+  availability_zones   = var.availability_zones
   public_subnets = {
     for index, availability_zone in local.availability_zones :
     availability_zone => cidrsubnet(var.vpc_cidr, 8, index)

--- a/infra/performance-test/terraform/platform/outputs.tf
+++ b/infra/performance-test/terraform/platform/outputs.tf
@@ -7,3 +7,13 @@ output "target_group_arn" {
   description = "Target group inspected by the phase-one verification script."
   value       = aws_lb_target_group.app.arn
 }
+
+output "environment_file_bucket" {
+  description = "Temporary S3 bucket used for ECS environment files."
+  value       = aws_s3_bucket.environment_files.id
+}
+
+output "app_environment_file_key" {
+  description = "Object key reserved for the application environment file."
+  value       = local.environment_file_key
+}

--- a/infra/performance-test/terraform/platform/s3.tf
+++ b/infra/performance-test/terraform/platform/s3.tf
@@ -1,0 +1,25 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket" "environment_files" {
+  bucket        = "${local.name_prefix}-${data.aws_caller_identity.current.account_id}-${var.aws_region}-env"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_public_access_block" "environment_files" {
+  bucket = aws_s3_bucket.environment_files.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "environment_files" {
+  bucket = aws_s3_bucket.environment_files.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
재사용 가능한 부하 테스트 인프라의 2단계 의존성 연결을 준비하기 위해 임시 S3 environment file 기반을 추가했습니다.

## Problem
API가 Atlas, Redis 등 테스트 의존성에 연결하려면 비밀값 주입이 필요하지만 Terraform 리소스에 값을 직접 넣으면 state에 노출될 수 있습니다. 또한 ECS가 환경 파일보다 먼저 시작되면 task가 S3 객체를 읽지 못하고 배포가 실패합니다.

## Solution
Terraform은 암호화된 비공개 S3 bucket, object key와 최소 IAM 권한만 관리합니다. 로컬 스크립트가 S3 저장소를 먼저 bootstrap하고 환경 파일을 업로드한 뒤 전체 Terraform 적용으로 ECS를 시작하도록 순서를 분리했습니다.

## Changes
- 2단계 인프라 범위와 3단계 exporter 메트릭 계획 문서화
- S3 public access block과 SSE-S3 암호화 적용
- ECS 실행 역할에 지정된 환경 파일의 읽기 권한만 부여
- 테스트 전용 `.env.app.example` 양식 추가
- 로컬 환경 파일 업로드 및 S3/로컬 정리 스크립트 추가
- S3 bootstrap -> 환경 파일 업로드 -> 전체 ECS 배포 순서 보장

## Example
```bash
cp infra/performance-test/run/.env.app.example infra/performance-test/run/.env.app
chmod 600 infra/performance-test/run/.env.app
./infra/performance-test/run/upload-app-environment.sh
terraform -chdir=infra/performance-test/terraform/platform apply
```

실제 AWS apply는 이 PR에서 수행하지 않았습니다. Terraform validate, fmt, IAM JSON 문법, 셸 문법을 검증했습니다.

## Related Issues
없음