### PR TITLE
feat(performance-test): complete phase two service integration

### DIFF
--- a/docs/architecture/performance-test-infrastructure.md
+++ b/docs/architecture/performance-test-infrastructure.md
@@ -50,6 +50,7 @@ flowchart LR
 - 병목 분석 대상인 ALB, ECS, Atlas, Redis, MySQL, S3는 실제 환경과 유사한 구성으로 사용한다.
 - Atlas는 테스트 전용 cluster와 최소 권한 계정을 사용한다. IP allowlist의 `0.0.0.0/0` 허용은 테스트 중에만 유지하고 종료 직후 제거한다.
 - S3 AI input/output bucket은 Terraform으로 생성한다. public access 차단, 암호화, ECS task role 최소 권한을 적용하고 테스트 종료 시 제거한다.
+- S3 변경 감지 기반 AI 처리는 현재 범위에서 제외하고, 추후 메시지 큐와 mock worker를 연결하는 방식으로 추가한다.
 - 비밀값은 서비스별 임시 `.env`를 S3 environment file로 전달한다. Terraform은 bucket, object key, IAM만 관리하고 객체 내용은 관리하지 않아 비밀값이 state에 기록되지 않게 한다.
 - 실행 스크립트가 로컬 `.env`를 S3에 업로드하고, 테스트 종료 시 S3 객체와 로컬 파일을 모두 삭제한다.
 - Bedrock과 Discord는 WireMock Standalone으로 성공·지연·오류를 통제한다. mapping은 저장소에서 관리하고 테스트 전에 Admin API로 등록하며 request journal로 실제 호출 횟수를 확인한다.

--- a/docs/architecture/performance-test-infrastructure.md
+++ b/docs/architecture/performance-test-infrastructure.md
@@ -11,7 +11,8 @@ flowchart LR
     APP --> REDIS["Redis"]
     APP --> MYSQL["MySQL"]
     APP --> ATLAS["MongoDB Atlas"]
-    APP --> MOCK["External API mock"]
+    APP --> S3AI["S3 input/output"]
+    APP --> MOCK["WireMock (Bedrock/Discord)"]
     ENV["S3 environment file"] --> APP
 
     PROM["Prometheus"] --> APP
@@ -30,10 +31,10 @@ flowchart LR
 | Internal ALB | k6 요청을 API task로 라우팅 |
 | ECS Fargate | API, k6, Redis, MySQL, external API mock, Prometheus, Grafana 컨테이너 실행 |
 | MongoDB Atlas | 사용자가 유지하는 테스트 데이터 저장소. 실행 중에만 IP allowlist를 임시로 전체 허용 |
-| External API mock (WireMock) | Bedrock, S3 등 외부 의존성의 응답·지연·오류를 통제 |
+| External API mock (WireMock) | Bedrock과 Discord의 성공·지연·오류를 통제 |
 | CloudWatch Logs/Metrics | ECS, ALB 로그와 인프라 메트릭 수집 |
-| S3 | 테스트용 environment file 전달, Terraform state와 실행 결과 보관 |
-| IAM Role | Terraform 프로비저닝 및 ECS task의 최소 권한 부여 |
+| S3 | AI input/output bucket, environment file 전달, Terraform state와 실행 결과 보관 |
+| IAM Role | Terraform 프로비저닝 권한과 ECS task의 S3 접근 권한 부여 |
 
 ## 단계별 범위
 
@@ -46,10 +47,14 @@ flowchart LR
 ## 2단계 운영 경계
 
 - 테스트 task는 public subnet에서 public IP를 사용한다. NAT Gateway와 고정 EIP는 구성하지 않고, inbound는 Security Group으로 제한한다.
+- 병목 분석 대상인 ALB, ECS, Atlas, Redis, MySQL, S3는 실제 환경과 유사한 구성으로 사용한다.
 - Atlas는 테스트 전용 cluster와 최소 권한 계정을 사용한다. IP allowlist의 `0.0.0.0/0` 허용은 테스트 중에만 유지하고 종료 직후 제거한다.
+- S3 AI input/output bucket은 Terraform으로 생성한다. public access 차단, 암호화, ECS task role 최소 권한을 적용하고 테스트 종료 시 제거한다.
 - 비밀값은 서비스별 임시 `.env`를 S3 environment file로 전달한다. Terraform은 bucket, object key, IAM만 관리하고 객체 내용은 관리하지 않아 비밀값이 state에 기록되지 않게 한다.
 - 실행 스크립트가 로컬 `.env`를 S3에 업로드하고, 테스트 종료 시 S3 객체와 로컬 파일을 모두 삭제한다.
-- 외부 API mock은 WireMock Standalone을 사용한다. mapping은 저장소에서 관리하고 테스트 전에 Admin API로 등록하며 request journal로 실제 호출 횟수를 확인한다.
+- Bedrock과 Discord는 WireMock Standalone으로 성공·지연·오류를 통제한다. mapping은 저장소에서 관리하고 테스트 전에 Admin API로 등록하며 request journal로 실제 호출 횟수를 확인한다.
+- Firebase Auth 호출 대신 테스트 JWT를 사용하고 FCM bean은 mock/no-op으로 대체한다. Sentry는 비활성화한다.
+- Bedrock 실제 지연 시간은 부하 테스트와 분리한 소규모 실호출로 측정해 mock 지연 값을 보정한다.
 - 2단계는 의존성 연결과 k6 요청 전달까지만 검증한다. exporter, Prometheus, Grafana를 통한 메트릭 수집은 3단계에서 추가한다.
 
 ## 3단계 수집 지표

--- a/docs/architecture/performance-test-infrastructure.md
+++ b/docs/architecture/performance-test-infrastructure.md
@@ -30,7 +30,7 @@ flowchart LR
 | Internal ALB | k6 요청을 API task로 라우팅 |
 | ECS Fargate | API, k6, Redis, MySQL, external API mock, Prometheus, Grafana 컨테이너 실행 |
 | MongoDB Atlas | 사용자가 유지하는 테스트 데이터 저장소. 실행 중에만 IP allowlist를 임시로 전체 허용 |
-| External API mock | Bedrock, S3 등 외부 의존성의 응답·지연·오류를 통제 |
+| External API mock (WireMock) | Bedrock, S3 등 외부 의존성의 응답·지연·오류를 통제 |
 | CloudWatch Logs/Metrics | ECS, ALB 로그와 인프라 메트릭 수집 |
 | S3 | 테스트용 environment file 전달, Terraform state와 실행 결과 보관 |
 | IAM Role | Terraform 프로비저닝 및 ECS task의 최소 권한 부여 |
@@ -49,6 +49,7 @@ flowchart LR
 - Atlas는 테스트 전용 cluster와 최소 권한 계정을 사용한다. IP allowlist의 `0.0.0.0/0` 허용은 테스트 중에만 유지하고 종료 직후 제거한다.
 - 비밀값은 서비스별 임시 `.env`를 S3 environment file로 전달한다. Terraform은 bucket, object key, IAM만 관리하고 객체 내용은 관리하지 않아 비밀값이 state에 기록되지 않게 한다.
 - 실행 스크립트가 로컬 `.env`를 S3에 업로드하고, 테스트 종료 시 S3 객체와 로컬 파일을 모두 삭제한다.
+- 외부 API mock은 WireMock Standalone을 사용한다. mapping은 저장소에서 관리하고 테스트 전에 Admin API로 등록하며 request journal로 실제 호출 횟수를 확인한다.
 - 2단계는 의존성 연결과 k6 요청 전달까지만 검증한다. exporter, Prometheus, Grafana를 통한 메트릭 수집은 3단계에서 추가한다.
 
 ## 3단계 수집 지표

--- a/infra/performance-test/README.md
+++ b/infra/performance-test/README.md
@@ -14,6 +14,7 @@
 - `run/upload-app-environment.sh`: 앱 환경 파일을 임시 S3 객체로 업로드
 - `run/cleanup-app-environment.sh`: S3 객체와 로컬 환경 파일 삭제
 - `run/run-k6-smoke.sh`: VPC 내부에서 ALB health endpoint 호출
+- `run/verify-phase-two.sh`: ALB, 의존성, k6 연결을 순서대로 검증
 - `k6/smoke.js`: 인프라 연결 확인용 단일 요청 시나리오
 - `wiremock`: Bedrock과 Discord의 성공·지연·오류 mapping
 - `iam/performance-test-provisioner-policy.json`: Terraform 실행 역할의 초기 권한 정책
@@ -67,6 +68,7 @@ terraform -chdir=infra/performance-test/terraform/platform init
 ```
 
 `terraform.tfvars`의 `test_run_id`는 실행마다 고유하게 설정한다. 환경 파일을 업로드하기 전에는 전체 `terraform apply`를 실행하지 않는다.
+2단계 검증에서는 테스트할 commit으로 LLV API 이미지를 빌드·업로드하고 `app_image`를 해당 주소로 교체한다.
 
 Terraform과 검증 스크립트는 같은 `AWS_PROFILE`을 사용한다. CI에서는 GitHub OIDC가 `PerformanceTestProvisioner`의 임시 credential을 제공한다.
 
@@ -84,10 +86,10 @@ chmod 600 infra/performance-test/run/.env.app
 ./infra/performance-test/run/upload-app-environment.sh
 
 terraform -chdir=infra/performance-test/terraform/platform apply
-./infra/performance-test/run/run-k6-smoke.sh
+./infra/performance-test/run/verify-phase-two.sh
 ```
 
-smoke task는 상시 실행되는 ECS service가 아니다. 스크립트를 실행할 때 Fargate task 한 개를 생성하고, ALB 응답과 k6 threshold가 모두 성공한 경우에만 종료 코드 `0`을 반환한다. 실제 Word 부하 시나리오는 이 연결 확인 이후 별도 task 실행 설정으로 추가한다.
+검증 스크립트는 설정된 수의 앱 target health, Redis·MySQL의 내부 DNS/TCP 연결, WireMock mapping 등록, k6의 ALB 요청을 순서대로 확인한다. probe와 smoke task는 상시 실행되는 ECS service가 아니며 검증할 때 각각 한 번 실행된다. 실제 Word 부하 시나리오는 이 연결 확인 이후 별도 task 실행 설정으로 추가한다.
 
 테스트 종료 후에는 인프라를 제거하기 전에 환경 파일을 먼저 정리한다. 원격 객체 삭제가 실패하더라도 로컬 `.env.app`은 삭제되며, 실패한 S3 객체는 `terraform destroy`의 `force_destroy`로 다시 정리한다.
 

--- a/infra/performance-test/README.md
+++ b/infra/performance-test/README.md
@@ -13,6 +13,7 @@
 - `run/.env.app.example`: 테스트 앱 환경 변수 양식
 - `run/upload-app-environment.sh`: 앱 환경 파일을 임시 S3 객체로 업로드
 - `run/cleanup-app-environment.sh`: S3 객체와 로컬 환경 파일 삭제
+- `wiremock`: Bedrock과 Discord의 성공·지연·오류 mapping
 - `iam/performance-test-provisioner-policy.json`: Terraform 실행 역할의 초기 권한 정책
 
 ## 2단계 계획
@@ -29,6 +30,8 @@
 
 Redis, MySQL, WireMock은 각각 `redis`, `mysql`, `mock` 이름으로 Cloud Map에 등록된다. 전체 endpoint는 Terraform의 `dependency_endpoints` output에서 확인한다. MySQL은 비밀번호를 state에 남기지 않기 위해 임시 random root password로 시작하며, 이번 단계에서는 container health와 내부 DNS/TCP 연결만 검증한다.
 
+WireMock은 task 시작 시 초기화 sidecar가 Admin API로 mapping을 등록한다. `terraform.tfvars`의 `mock_scenario`를 `success`, `delay`, `error` 중 하나로 설정해 Bedrock과 Discord 응답을 통제한다. `success`의 기본 지연은 800ms이며 별도 Bedrock 실호출 결과에 맞춰 fixture를 보정한다.
+
 ## 관측 계획
 
 3단계에서 Prometheus가 아래 exporter의 `/metrics`를 수집하고 Grafana에서 API 지표와 함께 조회한다.
@@ -38,7 +41,7 @@ Redis, MySQL, WireMock은 각각 `redis`, `mysql`, `mock` 이름으로 Cloud Map
 
 exporter의 읽기 전용 DB 계정도 서비스별 S3 environment file로 주입한다. 느린 쿼리 원문과 Redis command 인자는 metric label로 수집하지 않고 DB 로그와 profiler에서 확인한다.
 
-## 1단계 실행
+## 실행 준비
 
 먼저 로컬 AWS profile이 `PerformanceTestProvisioner` 역할을 assume하도록 설정한다. 이 설정은 저장소가 아닌 `~/.aws/config`에 둔다.
 
@@ -56,19 +59,12 @@ aws configure sso --profile llv-sso
 aws sso login --profile llv-sso
 export AWS_PROFILE=llv-performance-test
 
-cd infra/performance-test/terraform/platform
-cp terraform.tfvars.example terraform.tfvars
-terraform init
-terraform apply
-
-cd ../../../..
-./infra/performance-test/run/verify-phase-one.sh
-
-cd infra/performance-test/terraform/platform
-terraform destroy
+cp infra/performance-test/terraform/platform/terraform.tfvars.example \
+	infra/performance-test/terraform/platform/terraform.tfvars
+terraform -chdir=infra/performance-test/terraform/platform init
 ```
 
-`terraform.tfvars`의 `test_run_id`는 실행마다 고유하게 설정한다. 로컬 PC에서는 Internal ALB에 직접 접근하지 않고, 검증 스크립트로 target health를 확인한다.
+`terraform.tfvars`의 `test_run_id`는 실행마다 고유하게 설정한다. 환경 파일을 업로드하기 전에는 전체 `terraform apply`를 실행하지 않는다.
 
 Terraform과 검증 스크립트는 같은 `AWS_PROFILE`을 사용한다. CI에서는 GitHub OIDC가 `PerformanceTestProvisioner`의 임시 credential을 제공한다.
 
@@ -93,6 +89,5 @@ terraform -chdir=infra/performance-test/terraform/platform apply
 ```bash
 ./infra/performance-test/run/cleanup-app-environment.sh
 
-cd infra/performance-test/terraform/platform
-terraform destroy
+terraform -chdir=infra/performance-test/terraform/platform destroy
 ```

--- a/infra/performance-test/README.md
+++ b/infra/performance-test/README.md
@@ -23,6 +23,8 @@
 - 실행 스크립트가 `.env`를 업로드하며 테스트 종료 시 S3 객체와 로컬 파일을 모두 삭제한다.
 - 이 단계의 완료 기준은 k6가 ALB를 통해 API를 호출하고 API 또는 전용 probe가 각 의존성 연결을 확인하는 것이다.
 
+Redis, MySQL, WireMock은 각각 `redis`, `mysql`, `mock` 이름으로 Cloud Map에 등록된다. 전체 endpoint는 Terraform의 `dependency_endpoints` output에서 확인한다. MySQL은 비밀번호를 state에 남기지 않기 위해 임시 random root password로 시작하며, 이번 단계에서는 container health와 내부 DNS/TCP 연결만 검증한다.
+
 ## 관측 계획
 
 3단계에서 Prometheus가 아래 exporter의 `/metrics`를 수집하고 Grafana에서 API 지표와 함께 조회한다.

--- a/infra/performance-test/README.md
+++ b/infra/performance-test/README.md
@@ -76,7 +76,7 @@ Terraform과 검증 스크립트는 같은 `AWS_PROFILE`을 사용한다. CI에�
 
 ECS를 포함한 전체 Terraform 적용 전에 `infra/performance-test/run/.env.app`에 테스트 전용 환경 변수를 작성하고 업로드한다. 이 파일은 Git에서 제외되며 객체 내용도 Terraform state에 기록되지 않는다.
 
-사용자가 직접 입력할 값은 Atlas 테스트 계정의 `SPRING_DATA_MONGODB_URI`다. Redis와 WireMock 주소는 `test_run_id`로 결정하고 JWT와 import key는 테스트 전용 값으로 생성한다. S3 input/output bucket 값은 Terraform 리소스 추가 후 output으로 자동 반영한다.
+사용자가 직접 입력할 값은 Atlas 테스트 계정의 `SPRING_DATA_MONGODB_URI`다. JWT와 import key는 테스트 전용 값으로 생성한다. 업로드 스크립트는 Terraform output을 읽어 Redis와 WireMock 주소, S3 input/output bucket 값을 환경 파일에 자동 반영한다.
 
 업로드 스크립트는 S3 bucket, public access block, 암호화 설정만 먼저 적용한 후 환경 파일을 업로드한다. 업로드가 끝나야 전체 인프라를 적용한다.
 

--- a/infra/performance-test/README.md
+++ b/infra/performance-test/README.md
@@ -19,6 +19,10 @@
 
 - ECS task는 public subnet과 public IP를 사용하며 NAT Gateway와 EIP는 두지 않는다.
 - Atlas는 사용자가 유지하는 테스트 전용 cluster를 사용한다. 테스트 직전에 IP allowlist를 `0.0.0.0/0`으로 열고 종료 직후 닫는다.
+- ALB, ECS, Atlas, Redis, MySQL, S3는 실제 환경과 유사하게 사용한다.
+- S3 AI input/output bucket은 Terraform이 생성·암호화하고 ECS task role에 최소 권한을 부여하며 테스트 종료 시 제거한다.
+- Bedrock과 Discord는 WireMock으로 대체하고 실제 Bedrock 지연 시간은 별도의 소규모 호출로 보정한다.
+- Firebase Auth는 테스트 JWT로 대체하고 FCM은 mock/no-op으로 실행한다. Sentry는 비활성화한다.
 - 비밀값은 서비스별 임시 `.env`를 S3 environment file로 전달한다. Terraform은 객체 내용이 아닌 bucket, object key, IAM만 관리한다.
 - 실행 스크립트가 `.env`를 업로드하며 테스트 종료 시 S3 객체와 로컬 파일을 모두 삭제한다.
 - 이 단계의 완료 기준은 k6가 ALB를 통해 API를 호출하고 API 또는 전용 probe가 각 의존성 연결을 확인하는 것이다.
@@ -71,6 +75,8 @@ Terraform과 검증 스크립트는 같은 `AWS_PROFILE`을 사용한다. CI에�
 ## 2단계 환경 파일
 
 ECS를 포함한 전체 Terraform 적용 전에 `infra/performance-test/run/.env.app`에 테스트 전용 환경 변수를 작성하고 업로드한다. 이 파일은 Git에서 제외되며 객체 내용도 Terraform state에 기록되지 않는다.
+
+사용자가 직접 입력할 값은 Atlas 테스트 계정의 `SPRING_DATA_MONGODB_URI`다. Redis와 WireMock 주소는 `test_run_id`로 결정하고 JWT와 import key는 테스트 전용 값으로 생성한다. S3 input/output bucket 값은 Terraform 리소스 추가 후 output으로 자동 반영한다.
 
 업로드 스크립트는 S3 bucket, public access block, 암호화 설정만 먼저 적용한 후 환경 파일을 업로드한다. 업로드가 끝나야 전체 인프라를 적용한다.
 

--- a/infra/performance-test/README.md
+++ b/infra/performance-test/README.md
@@ -11,6 +11,7 @@
 - `terraform/platform`: AWS 리소스 정의
 - `run/verify-phase-one.sh`: ALB target health 확인
 - `run/.env.app.example`: 테스트 앱 환경 변수 양식
+- `run/publish-app-image.sh`: 현재 commit의 LLV API 이미지를 임시 ECR에 업로드
 - `run/upload-app-environment.sh`: 앱 환경 파일을 임시 S3 객체로 업로드
 - `run/cleanup-app-environment.sh`: S3 객체와 로컬 환경 파일 삭제
 - `run/run-k6-smoke.sh`: VPC 내부에서 ALB health endpoint 호출
@@ -67,8 +68,7 @@ cp infra/performance-test/terraform/platform/terraform.tfvars.example \
 terraform -chdir=infra/performance-test/terraform/platform init
 ```
 
-`terraform.tfvars`의 `test_run_id`는 실행마다 고유하게 설정한다. 환경 파일을 업로드하기 전에는 전체 `terraform apply`를 실행하지 않는다.
-2단계 검증에서는 테스트할 commit으로 LLV API 이미지를 빌드·업로드하고 `app_image`를 해당 주소로 교체한다.
+`terraform.tfvars`의 `test_run_id`는 실행마다 고유하게 설정하고 `app_image_tag`에는 commit SHA 기반의 고유 태그를 사용한다. 환경 파일과 앱 이미지를 업로드하기 전에는 전체 `terraform apply`를 실행하지 않는다.
 
 Terraform과 검증 스크립트는 같은 `AWS_PROFILE`을 사용한다. CI에서는 GitHub OIDC가 `PerformanceTestProvisioner`의 임시 credential을 제공한다.
 
@@ -83,6 +83,7 @@ ECS를 포함한 전체 Terraform 적용 전에 `infra/performance-test/run/.env
 ```bash
 cp infra/performance-test/run/.env.app.example infra/performance-test/run/.env.app
 chmod 600 infra/performance-test/run/.env.app
+TF_CLI_ARGS_apply=-auto-approve ./infra/performance-test/run/publish-app-image.sh
 ./infra/performance-test/run/upload-app-environment.sh
 
 terraform -chdir=infra/performance-test/terraform/platform apply

--- a/infra/performance-test/README.md
+++ b/infra/performance-test/README.md
@@ -13,6 +13,8 @@
 - `run/.env.app.example`: 테스트 앱 환경 변수 양식
 - `run/upload-app-environment.sh`: 앱 환경 파일을 임시 S3 객체로 업로드
 - `run/cleanup-app-environment.sh`: S3 객체와 로컬 환경 파일 삭제
+- `run/run-k6-smoke.sh`: VPC 내부에서 ALB health endpoint 호출
+- `k6/smoke.js`: 인프라 연결 확인용 단일 요청 시나리오
 - `wiremock`: Bedrock과 Discord의 성공·지연·오류 mapping
 - `iam/performance-test-provisioner-policy.json`: Terraform 실행 역할의 초기 권한 정책
 
@@ -82,7 +84,10 @@ chmod 600 infra/performance-test/run/.env.app
 ./infra/performance-test/run/upload-app-environment.sh
 
 terraform -chdir=infra/performance-test/terraform/platform apply
+./infra/performance-test/run/run-k6-smoke.sh
 ```
+
+smoke task는 상시 실행되는 ECS service가 아니다. 스크립트를 실행할 때 Fargate task 한 개를 생성하고, ALB 응답과 k6 threshold가 모두 성공한 경우에만 종료 코드 `0`을 반환한다. 실제 Word 부하 시나리오는 이 연결 확인 이후 별도 task 실행 설정으로 추가한다.
 
 테스트 종료 후에는 인프라를 제거하기 전에 환경 파일을 먼저 정리한다. 원격 객체 삭제가 실패하더라도 로컬 `.env.app`은 삭제되며, 실패한 S3 객체는 `terraform destroy`의 `force_destroy`로 다시 정리한다.
 

--- a/infra/performance-test/iam/performance-test-provisioner-policy.json
+++ b/infra/performance-test/iam/performance-test-provisioner-policy.json
@@ -149,6 +149,52 @@
       "Resource": "arn:aws:s3:::llvpt-*-env/*"
     },
     {
+      "Sid": "AiBucketLifecycle",
+      "Effect": "Allow",
+      "Action": [
+        "s3:CreateBucket",
+        "s3:DeleteBucket",
+        "s3:GetAccelerateConfiguration",
+        "s3:GetBucketAcl",
+        "s3:GetBucketCORS",
+        "s3:GetBucketLogging",
+        "s3:GetBucketLocation",
+        "s3:GetBucketObjectLockConfiguration",
+        "s3:GetBucketPolicy",
+        "s3:GetBucketPublicAccessBlock",
+        "s3:GetBucketRequestPayment",
+        "s3:GetBucketTagging",
+        "s3:GetBucketVersioning",
+        "s3:GetBucketWebsite",
+        "s3:GetEncryptionConfiguration",
+        "s3:GetLifecycleConfiguration",
+        "s3:GetReplicationConfiguration",
+        "s3:ListBucket",
+        "s3:ListBucketVersions",
+        "s3:PutBucketPublicAccessBlock",
+        "s3:PutBucketTagging",
+        "s3:PutEncryptionConfiguration"
+      ],
+      "Resource": [
+        "arn:aws:s3:::llvpt-*-ai-in",
+        "arn:aws:s3:::llvpt-*-ai-out"
+      ]
+    },
+    {
+      "Sid": "AiBucketObjectCleanup",
+      "Effect": "Allow",
+      "Action": [
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion",
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::llvpt-*-ai-in/*",
+        "arn:aws:s3:::llvpt-*-ai-out/*"
+      ]
+    },
+    {
       "Sid": "CloudWatchLogGroupLifecycle",
       "Effect": "Allow",
       "Action": [

--- a/infra/performance-test/iam/performance-test-provisioner-policy.json
+++ b/infra/performance-test/iam/performance-test-provisioner-policy.json
@@ -26,6 +26,7 @@
         "ec2:DescribeTags",
         "ec2:DescribeVpcAttribute",
         "ec2:DescribeRouteTables",
+        "ec2:DescribeRegions",
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeVpcs",
@@ -158,6 +159,34 @@
         "logs:PutRetentionPolicy",
         "logs:TagResource",
         "logs:UntagResource"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ServiceDiscoveryLifecycle",
+      "Effect": "Allow",
+      "Action": [
+        "servicediscovery:CreatePrivateDnsNamespace",
+        "servicediscovery:CreateService",
+        "servicediscovery:DeleteNamespace",
+        "servicediscovery:DeleteService",
+        "servicediscovery:GetNamespace",
+        "servicediscovery:GetOperation",
+        "servicediscovery:GetService",
+        "servicediscovery:ListTagsForResource",
+        "servicediscovery:TagResource",
+        "servicediscovery:UntagResource",
+        "servicediscovery:UpdateService"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ServiceDiscoveryPrivateDns",
+      "Effect": "Allow",
+      "Action": [
+        "route53:CreateHostedZone",
+        "route53:GetHostedZone",
+        "route53:ListHostedZonesByName"
       ],
       "Resource": "*"
     }

--- a/infra/performance-test/iam/performance-test-provisioner-policy.json
+++ b/infra/performance-test/iam/performance-test-provisioner-policy.json
@@ -76,10 +76,12 @@
         "ecs:DeregisterTaskDefinition",
         "ecs:DescribeClusters",
         "ecs:DescribeServices",
+        "ecs:DescribeTasks",
         "ecs:DescribeTaskDefinition",
         "ecs:ListTagsForResource",
         "ecs:ListTasks",
         "ecs:RegisterTaskDefinition",
+        "ecs:RunTask",
         "ecs:TagResource",
         "ecs:UntagResource",
         "ecs:UpdateService"

--- a/infra/performance-test/iam/performance-test-provisioner-policy.json
+++ b/infra/performance-test/iam/performance-test-provisioner-policy.json
@@ -211,6 +211,35 @@
       "Resource": "*"
     },
     {
+      "Sid": "AppImageRepositoryLifecycle",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:CompleteLayerUpload",
+        "ecr:CreateRepository",
+        "ecr:DeleteRepository",
+        "ecr:DescribeImages",
+        "ecr:DescribeRepositories",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:InitiateLayerUpload",
+        "ecr:ListImages",
+        "ecr:ListTagsForResource",
+        "ecr:PutImage",
+        "ecr:PutImageScanningConfiguration",
+        "ecr:PutImageTagMutability",
+        "ecr:TagResource",
+        "ecr:UntagResource",
+        "ecr:UploadLayerPart"
+      ],
+      "Resource": "arn:aws:ecr:*:*:repository/llvpt-*"
+    },
+    {
+      "Sid": "AppImageRepositoryLogin",
+      "Effect": "Allow",
+      "Action": "ecr:GetAuthorizationToken",
+      "Resource": "*"
+    },
+    {
       "Sid": "ServiceDiscoveryLifecycle",
       "Effect": "Allow",
       "Action": [

--- a/infra/performance-test/k6/smoke.js
+++ b/infra/performance-test/k6/smoke.js
@@ -1,0 +1,24 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+const baseUrl = (__ENV.BASE_URL || '').replace(/\/$/, '');
+const healthPath = __ENV.HEALTH_PATH || '/actuator/health';
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+  thresholds: {
+    checks: ['rate==1'],
+    http_req_failed: ['rate==0'],
+  },
+};
+
+export default function () {
+  const response = http.get(`${baseUrl}${healthPath}`, {
+    tags: { endpoint: 'health' },
+  });
+
+  check(response, {
+    'ALB target responds successfully': (result) => result.status >= 200 && result.status < 400,
+  });
+}

--- a/infra/performance-test/run/.env.app.example
+++ b/infra/performance-test/run/.env.app.example
@@ -25,7 +25,6 @@ BEDROCK_ENDPOINT=http://mock.replace-with-test-run-id.llvpt.local:8080
 DISCORD_SUGGESTION_WEBHOOK=http://mock.replace-with-test-run-id.llvpt.local:8080/discord/webhook
 
 # Disabled integrations
-FIREBASE_ENABLED=false
 FCM_ENABLED=false
 SENTRY_ENABLED=false
 

--- a/infra/performance-test/run/.env.app.example
+++ b/infra/performance-test/run/.env.app.example
@@ -1,32 +1,33 @@
-# Runtime profile
-SPRING_PROFILES_ACTIVE=prod
-
-# Data stores
+# User input: Atlas test account
 SPRING_DATA_MONGODB_URI=mongodb+srv://replace-me:replace-me@replace-me.mongodb.net/llv_performance_test
+
+# Runtime profile and data stores
+SPRING_PROFILES_ACTIVE=performance-test
 SPRING_DATA_MONGODB_DATABASE=llv_performance_test
-SPRING_DATA_REDIS_HOST=replace-me
+SPRING_DATA_REDIS_HOST=redis.replace-with-test-run-id.llvpt.local
 SPRING_DATA_REDIS_PORT=6379
 
 # Test controls
 RATE_LIMIT_ENABLED=false
 WORD_SINGLE_FLIGHT_ENABLED=true
 
-# Application secrets
-JWT_SECRET=replace-with-test-jwt-secret
-IMPORT_API_KEY=replace-with-test-import-api-key
-DISCORD_SUGGESTION_WEBHOOK=replace-with-test-webhook-url
-FIREBASE_CONFIG_BASE64=replace-with-test-firebase-config-base64
+# Test authentication
+JWT_SECRET=replace-with-generated-test-jwt-secret
+IMPORT_API_KEY=replace-with-generated-test-import-api-key
 
-# AWS and external service mocks
-AWS_ACCESS_KEY=replace-with-test-access-key
-AWS_SECRET_KEY=replace-with-test-secret-key
+# Terraform-managed S3 resources
 S3_REGION=ap-northeast-2
-S3_AI_INPUT_NAME=replace-with-test-input-bucket
-S3_AI_OUTPUT_NAME=replace-with-test-output-bucket
-CF_R2_ENDPOINT=replace-with-mock-endpoint
-CF_R2_ACCESS_KEY=replace-with-test-r2-access-key
-CF_R2_SECRET_KEY=replace-with-test-r2-secret-key
-CF_R2_STATIC_BUCKET=replace-with-test-static-bucket
+S3_AI_INPUT_NAME=replace-with-terraform-output
+S3_AI_OUTPUT_NAME=replace-with-terraform-output
+
+# WireMock integrations
+BEDROCK_ENDPOINT=http://mock.replace-with-test-run-id.llvpt.local:8080
+DISCORD_SUGGESTION_WEBHOOK=http://mock.replace-with-test-run-id.llvpt.local:8080/discord/webhook
+
+# Disabled integrations
+FIREBASE_ENABLED=false
+FCM_ENABLED=false
+SENTRY_ENABLED=false
 
 # Observability
 SENTRY_DSN=

--- a/infra/performance-test/run/publish-app-image.sh
+++ b/infra/performance-test/run/publish-app-image.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+platform_dir="${1:-infra/performance-test/terraform/platform}"
+
+read_terraform_value() {
+	local expression="$1"
+	local value
+	value="$(printf '%s\n' "$expression" | terraform -chdir="$platform_dir" console)"
+	value="${value#\"}"
+	value="${value%\"}"
+	printf '%s' "$value"
+}
+
+terraform -chdir="$platform_dir" apply -target=aws_ecr_repository.app
+
+region="$(read_terraform_value 'var.aws_region')"
+image_tag="$(read_terraform_value 'var.app_image_tag')"
+repository_url="$(terraform -chdir="$platform_dir" output -raw app_ecr_repository_url)"
+registry="${repository_url%%/*}"
+repository_name="${repository_url#*/}"
+
+existing_tag="$(aws ecr list-images \
+	--region "$region" \
+	--repository-name "$repository_name" \
+	--filter tagStatus=TAGGED \
+	--query "imageIds[?imageTag == '${image_tag}'].imageTag | [0]" \
+	--output text)"
+
+if [[ "$existing_tag" == "$image_tag" ]]; then
+	echo "Application image already exists at ${repository_url}:${image_tag}; reusing it."
+	exit 0
+fi
+
+./gradlew bootJar
+aws ecr get-login-password --region "$region" | \
+	docker login --username AWS --password-stdin "$registry"
+docker buildx build \
+	--platform linux/amd64 \
+	--tag "${repository_url}:${image_tag}" \
+	--push \
+	.
+
+echo "Application image pushed to ${repository_url}:${image_tag}."

--- a/infra/performance-test/run/run-k6-smoke.sh
+++ b/infra/performance-test/run/run-k6-smoke.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+platform_dir="${1:-infra/performance-test/terraform/platform}"
+region="$(terraform -chdir="$platform_dir" output -raw aws_region)"
+cluster_arn="$(terraform -chdir="$platform_dir" output -raw ecs_cluster_arn)"
+task_definition_arn="$(terraform -chdir="$platform_dir" output -raw k6_task_definition_arn)"
+subnet_id="$(terraform -chdir="$platform_dir" output -raw k6_subnet_id)"
+security_group_id="$(terraform -chdir="$platform_dir" output -raw k6_security_group_id)"
+
+task_arn="$(aws ecs run-task \
+	--region "$region" \
+	--cluster "$cluster_arn" \
+	--task-definition "$task_definition_arn" \
+	--launch-type FARGATE \
+	--network-configuration \
+	"awsvpcConfiguration={subnets=[${subnet_id}],securityGroups=[${security_group_id}],assignPublicIp=ENABLED}" \
+	--query 'tasks[0].taskArn' \
+	--output text)"
+
+if [[ -z "$task_arn" || "$task_arn" == "None" ]]; then
+	echo "Failed to start the k6 smoke task." >&2
+	exit 1
+fi
+
+echo "Waiting for k6 smoke task: ${task_arn}"
+aws ecs wait tasks-stopped --region "$region" --cluster "$cluster_arn" --tasks "$task_arn"
+
+exit_code="$(aws ecs describe-tasks \
+	--region "$region" \
+	--cluster "$cluster_arn" \
+	--tasks "$task_arn" \
+	--query 'tasks[0].containers[?name==`k6`].exitCode | [0]' \
+	--output text)"
+
+if [[ "$exit_code" != "0" ]]; then
+	stop_reason="$(aws ecs describe-tasks \
+		--region "$region" \
+		--cluster "$cluster_arn" \
+		--tasks "$task_arn" \
+		--query 'tasks[0].stoppedReason' \
+		--output text)"
+	echo "k6 smoke task failed with exit code ${exit_code}: ${stop_reason}" >&2
+	exit 1
+fi
+
+echo "k6 smoke task passed."

--- a/infra/performance-test/run/upload-app-environment.sh
+++ b/infra/performance-test/run/upload-app-environment.sh
@@ -5,6 +5,15 @@ set -euo pipefail
 platform_dir="${1:-infra/performance-test/terraform/platform}"
 environment_file="infra/performance-test/run/.env.app"
 
+read_terraform_value() {
+	local expression="$1"
+	local value
+	value="$(printf '%s\n' "$expression" | terraform -chdir="$platform_dir" console)"
+	value="${value#\"}"
+	value="${value%\"}"
+	printf '%s' "$value"
+}
+
 if [[ ! -f "$environment_file" ]]; then
 	echo "Application environment file not found: ${environment_file}" >&2
 	exit 1
@@ -18,10 +27,10 @@ terraform -chdir="$platform_dir" apply \
 	-target=aws_s3_bucket_public_access_block.ai \
 	-target=aws_s3_bucket_server_side_encryption_configuration.ai
 
-region="$(terraform -chdir="$platform_dir" output -raw aws_region)"
-test_run_id="$(terraform -chdir="$platform_dir" output -raw test_run_id)"
+region="$(read_terraform_value 'var.aws_region')"
+test_run_id="$(read_terraform_value 'var.test_run_id')"
 bucket="$(terraform -chdir="$platform_dir" output -raw environment_file_bucket)"
-key="$(terraform -chdir="$platform_dir" output -raw app_environment_file_key)"
+key="$(read_terraform_value 'local.environment_file_key')"
 ai_input_bucket="$(terraform -chdir="$platform_dir" output -raw ai_input_bucket)"
 ai_output_bucket="$(terraform -chdir="$platform_dir" output -raw ai_output_bucket)"
 

--- a/infra/performance-test/run/upload-app-environment.sh
+++ b/infra/performance-test/run/upload-app-environment.sh
@@ -13,11 +13,40 @@ fi
 terraform -chdir="$platform_dir" apply \
 	-target=aws_s3_bucket.environment_files \
 	-target=aws_s3_bucket_public_access_block.environment_files \
-	-target=aws_s3_bucket_server_side_encryption_configuration.environment_files
+	-target=aws_s3_bucket_server_side_encryption_configuration.environment_files \
+	-target=aws_s3_bucket.ai \
+	-target=aws_s3_bucket_public_access_block.ai \
+	-target=aws_s3_bucket_server_side_encryption_configuration.ai
 
 region="$(terraform -chdir="$platform_dir" output -raw aws_region)"
+test_run_id="$(terraform -chdir="$platform_dir" output -raw test_run_id)"
 bucket="$(terraform -chdir="$platform_dir" output -raw environment_file_bucket)"
 key="$(terraform -chdir="$platform_dir" output -raw app_environment_file_key)"
+ai_input_bucket="$(terraform -chdir="$platform_dir" output -raw ai_input_bucket)"
+ai_output_bucket="$(terraform -chdir="$platform_dir" output -raw ai_output_bucket)"
+
+replace_environment_value() {
+	local name="$1"
+	local value="$2"
+	local temporary_file
+	temporary_file="$(mktemp)"
+
+	awk -v name="$name" -v value="$value" '
+		index($0, name "=") == 1 { print name "=" value; found = 1; next }
+		{ print }
+		END { if (!found) print name "=" value }
+	' "$environment_file" >"$temporary_file"
+
+	mv "$temporary_file" "$environment_file"
+	chmod 600 "$environment_file"
+}
+
+replace_environment_value "S3_AI_INPUT_NAME" "$ai_input_bucket"
+replace_environment_value "S3_AI_OUTPUT_NAME" "$ai_output_bucket"
+replace_environment_value "SPRING_DATA_REDIS_HOST" "redis.${test_run_id}.llvpt.local"
+replace_environment_value "BEDROCK_ENDPOINT" "http://mock.${test_run_id}.llvpt.local:8080"
+replace_environment_value "DISCORD_SUGGESTION_WEBHOOK" \
+	"http://mock.${test_run_id}.llvpt.local:8080/discord/webhook"
 
 aws s3 cp "$environment_file" "s3://${bucket}/${key}" \
 	--region "$region" \

--- a/infra/performance-test/run/verify-phase-one.sh
+++ b/infra/performance-test/run/verify-phase-one.sh
@@ -5,22 +5,23 @@ set -euo pipefail
 platform_dir="${1:-infra/performance-test/terraform/platform}"
 region="$(terraform -chdir="$platform_dir" output -raw aws_region)"
 target_group_arn="$(terraform -chdir="$platform_dir" output -raw target_group_arn)"
+expected_target_count="$(terraform -chdir="$platform_dir" output -raw app_desired_count)"
 
 for attempt in $(seq 1 30); do
-	state="$(aws elbv2 describe-target-health \
+	healthy_target_count="$(aws elbv2 describe-target-health \
 		--region "$region" \
 		--target-group-arn "$target_group_arn" \
-		--query 'TargetHealthDescriptions[0].TargetHealth.State' \
+		--query "length(TargetHealthDescriptions[?TargetHealth.State=='healthy'])" \
 		--output text)"
 
-	if [[ "$state" == "healthy" ]]; then
-		echo "Phase one verification passed: ALB target is healthy."
+	if [[ "$healthy_target_count" == "$expected_target_count" ]]; then
+		echo "ALB verification passed: ${healthy_target_count}/${expected_target_count} targets are healthy."
 		exit 0
 	fi
 
-	echo "Waiting for healthy ALB target (attempt ${attempt}/30, state: ${state})..."
+	echo "Waiting for healthy ALB targets (attempt ${attempt}/30, healthy: ${healthy_target_count}/${expected_target_count})..."
 	sleep 10
 done
 
-echo "Phase one verification failed: ALB target did not become healthy." >&2
+echo "ALB verification failed: expected ${expected_target_count} healthy targets." >&2
 exit 1

--- a/infra/performance-test/run/verify-phase-two.sh
+++ b/infra/performance-test/run/verify-phase-two.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+platform_dir="${1:-infra/performance-test/terraform/platform}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+region="$(terraform -chdir="$platform_dir" output -raw aws_region)"
+cluster_arn="$(terraform -chdir="$platform_dir" output -raw ecs_cluster_arn)"
+task_definition_arn="$(terraform -chdir="$platform_dir" output -raw dependency_probe_task_definition_arn)"
+subnet_id="$(terraform -chdir="$platform_dir" output -raw k6_subnet_id)"
+security_group_id="$(terraform -chdir="$platform_dir" output -raw app_security_group_id)"
+
+"${script_dir}/verify-phase-one.sh" "$platform_dir"
+
+task_arn="$(aws ecs run-task \
+	--region "$region" \
+	--cluster "$cluster_arn" \
+	--task-definition "$task_definition_arn" \
+	--launch-type FARGATE \
+	--network-configuration \
+	"awsvpcConfiguration={subnets=[${subnet_id}],securityGroups=[${security_group_id}],assignPublicIp=ENABLED}" \
+	--query 'tasks[0].taskArn' \
+	--output text)"
+
+if [[ -z "$task_arn" || "$task_arn" == "None" ]]; then
+	echo "Failed to start the dependency probe task." >&2
+	exit 1
+fi
+
+echo "Waiting for dependency probe task: ${task_arn}"
+aws ecs wait tasks-stopped --region "$region" --cluster "$cluster_arn" --tasks "$task_arn"
+
+exit_code="$(aws ecs describe-tasks \
+	--region "$region" \
+	--cluster "$cluster_arn" \
+	--tasks "$task_arn" \
+	--query 'tasks[0].containers[?name==`dependency-probe`].exitCode | [0]' \
+	--output text)"
+
+if [[ "$exit_code" != "0" ]]; then
+	echo "Dependency probe failed with exit code ${exit_code}." >&2
+	exit 1
+fi
+
+"${script_dir}/run-k6-smoke.sh" "$platform_dir"
+echo "Phase two verification passed."

--- a/infra/performance-test/terraform/platform/alb.tf
+++ b/infra/performance-test/terraform/platform/alb.tf
@@ -7,11 +7,12 @@ resource "aws_lb" "app" {
 }
 
 resource "aws_lb_target_group" "app" {
-  name        = "${local.name_prefix}-tg"
-  port        = var.container_port
-  protocol    = "HTTP"
-  target_type = "ip"
-  vpc_id      = aws_vpc.this.id
+  name                 = "${local.name_prefix}-tg"
+  port                 = var.container_port
+  protocol             = "HTTP"
+  target_type          = "ip"
+  vpc_id               = aws_vpc.this.id
+  deregistration_delay = 30
 
   health_check {
     enabled             = true

--- a/infra/performance-test/terraform/platform/dependencies.tf
+++ b/infra/performance-test/terraform/platform/dependencies.tf
@@ -41,32 +41,65 @@ resource "aws_ecs_task_definition" "dependency" {
   memory                   = each.value.memory
   execution_role_arn       = aws_iam_role.task_execution.arn
 
-  container_definitions = jsonencode([
-    merge(
-      {
-        name        = each.key
-        image       = each.value.image
-        essential   = true
-        environment = each.value.environment
-        portMappings = [
-          {
-            containerPort = each.value.port
-            hostPort      = each.value.port
-            protocol      = "tcp"
+  container_definitions = jsonencode(concat(
+    [
+      merge(
+        {
+          name        = each.key
+          image       = each.value.image
+          essential   = true
+          environment = each.value.environment
+          portMappings = [
+            {
+              containerPort = each.value.port
+              hostPort      = each.value.port
+              protocol      = "tcp"
+            }
+          ]
+          logConfiguration = {
+            logDriver = "awslogs"
+            options = {
+              awslogs-group         = aws_cloudwatch_log_group.dependency[each.key].name
+              awslogs-region        = var.aws_region
+              awslogs-stream-prefix = "ecs"
+            }
           }
+        },
+        each.value.health_check == null ? {} : { healthCheck = each.value.health_check }
+      )
+    ],
+    each.key == "mock" ? [
+      {
+        name      = "mock-init"
+        image     = var.mock_init_image
+        essential = false
+        dependsOn = [
+          {
+            containerName = "mock"
+            condition     = "START"
+          }
+        ]
+        environment = [
+          {
+            name  = "WIREMOCK_MAPPINGS_BASE64"
+            value = base64encode(local.wiremock_mappings)
+          }
+        ]
+        entryPoint = ["/bin/sh", "-c"]
+        command = [
+          "until curl --fail --silent http://localhost:8080/__admin/mappings >/dev/null; do sleep 1; done; printf '%s' \"$WIREMOCK_MAPPINGS_BASE64\" | base64 -d | curl --fail --silent --show-error --header 'Content-Type: application/json' --data-binary @- http://localhost:8080/__admin/mappings/import"
         ]
         logConfiguration = {
           logDriver = "awslogs"
           options = {
             awslogs-group         = aws_cloudwatch_log_group.dependency[each.key].name
             awslogs-region        = var.aws_region
-            awslogs-stream-prefix = "ecs"
+            awslogs-stream-prefix = "mock-init"
           }
         }
-      },
-      each.value.health_check == null ? {} : { healthCheck = each.value.health_check }
-    )
-  ])
+      }
+    ] : []
+  ))
 
   depends_on = [aws_iam_role_policy_attachment.task_execution]
 }

--- a/infra/performance-test/terraform/platform/dependencies.tf
+++ b/infra/performance-test/terraform/platform/dependencies.tf
@@ -1,0 +1,95 @@
+resource "aws_service_discovery_private_dns_namespace" "this" {
+  name        = "${var.test_run_id}.llvpt.local"
+  description = "Private service discovery namespace for one performance test run."
+  vpc         = aws_vpc.this.id
+}
+
+resource "aws_service_discovery_service" "dependency" {
+  for_each = local.dependency_services
+
+  name = each.key
+
+  dns_config {
+    namespace_id   = aws_service_discovery_private_dns_namespace.this.id
+    routing_policy = "MULTIVALUE"
+
+    dns_records {
+      ttl  = 10
+      type = "A"
+    }
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}
+
+resource "aws_cloudwatch_log_group" "dependency" {
+  for_each = local.dependency_services
+
+  name              = "/llv/performance-test/${var.test_run_id}/${each.key}"
+  retention_in_days = var.log_retention_days
+}
+
+resource "aws_ecs_task_definition" "dependency" {
+  for_each = local.dependency_services
+
+  family                   = "${local.name_prefix}-${each.key}"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = each.value.cpu
+  memory                   = each.value.memory
+  execution_role_arn       = aws_iam_role.task_execution.arn
+
+  container_definitions = jsonencode([
+    merge(
+      {
+        name        = each.key
+        image       = each.value.image
+        essential   = true
+        environment = each.value.environment
+        portMappings = [
+          {
+            containerPort = each.value.port
+            hostPort      = each.value.port
+            protocol      = "tcp"
+          }
+        ]
+        logConfiguration = {
+          logDriver = "awslogs"
+          options = {
+            awslogs-group         = aws_cloudwatch_log_group.dependency[each.key].name
+            awslogs-region        = var.aws_region
+            awslogs-stream-prefix = "ecs"
+          }
+        }
+      },
+      each.value.health_check == null ? {} : { healthCheck = each.value.health_check }
+    )
+  ])
+
+  depends_on = [aws_iam_role_policy_attachment.task_execution]
+}
+
+resource "aws_ecs_service" "dependency" {
+  for_each = local.dependency_services
+
+  name                               = "${local.name_prefix}-${each.key}"
+  cluster                            = aws_ecs_cluster.this.id
+  task_definition                    = aws_ecs_task_definition.dependency[each.key].arn
+  desired_count                      = 1
+  launch_type                        = "FARGATE"
+  wait_for_steady_state              = true
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 100
+
+  network_configuration {
+    subnets          = [for subnet in aws_subnet.public : subnet.id]
+    security_groups  = [aws_security_group.dependencies.id]
+    assign_public_ip = true
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.dependency[each.key].arn
+  }
+}

--- a/infra/performance-test/terraform/platform/ecr.tf
+++ b/infra/performance-test/terraform/platform/ecr.tf
@@ -1,0 +1,13 @@
+resource "aws_ecr_repository" "app" {
+  name                 = "${local.name_prefix}-app"
+  image_tag_mutability = "IMMUTABLE"
+  force_delete         = true
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}

--- a/infra/performance-test/terraform/platform/ecs.tf
+++ b/infra/performance-test/terraform/platform/ecs.tf
@@ -19,7 +19,7 @@ resource "aws_ecs_task_definition" "app" {
   container_definitions = jsonencode([
     {
       name      = "phase-one-app"
-      image     = var.app_image
+      image     = "${aws_ecr_repository.app.repository_url}:${var.app_image_tag}"
       essential = true
       environmentFiles = [
         {
@@ -57,7 +57,7 @@ resource "aws_ecs_service" "app" {
   task_definition                    = aws_ecs_task_definition.app.arn
   desired_count                      = var.app_desired_count
   launch_type                        = "FARGATE"
-  health_check_grace_period_seconds  = 30
+  health_check_grace_period_seconds  = var.health_check_grace_period_seconds
   wait_for_steady_state              = true
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200

--- a/infra/performance-test/terraform/platform/ecs.tf
+++ b/infra/performance-test/terraform/platform/ecs.tf
@@ -14,12 +14,19 @@ resource "aws_ecs_task_definition" "app" {
   cpu                      = var.task_cpu
   memory                   = var.task_memory
   execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.app_task.arn
 
   container_definitions = jsonencode([
     {
       name      = "phase-one-app"
       image     = var.app_image
       essential = true
+      environmentFiles = [
+        {
+          type  = "s3"
+          value = "${aws_s3_bucket.environment_files.arn}/${local.environment_file_key}"
+        }
+      ]
       portMappings = [
         {
           containerPort = var.container_port
@@ -38,14 +45,17 @@ resource "aws_ecs_task_definition" "app" {
     }
   ])
 
-  depends_on = [aws_iam_role_policy_attachment.task_execution]
+  depends_on = [
+    aws_iam_role_policy_attachment.task_execution,
+    aws_iam_role_policy.task_execution_environment_file,
+  ]
 }
 
 resource "aws_ecs_service" "app" {
   name                               = "${local.name_prefix}-app"
   cluster                            = aws_ecs_cluster.this.id
   task_definition                    = aws_ecs_task_definition.app.arn
-  desired_count                      = 1
+  desired_count                      = var.app_desired_count
   launch_type                        = "FARGATE"
   health_check_grace_period_seconds  = 30
   wait_for_steady_state              = true

--- a/infra/performance-test/terraform/platform/iam.tf
+++ b/infra/performance-test/terraform/platform/iam.tf
@@ -36,3 +36,36 @@ resource "aws_iam_role_policy" "task_execution_environment_file" {
   role   = aws_iam_role.task_execution.id
   policy = data.aws_iam_policy_document.task_execution_environment_file.json
 }
+
+resource "aws_iam_role" "app_task" {
+  name_prefix        = "${local.name_prefix}-app-"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role.json
+}
+
+data "aws_iam_policy_document" "app_task_ai_buckets" {
+  statement {
+    actions   = ["s3:GetBucketLocation"]
+    resources = [for bucket in aws_s3_bucket.ai : bucket.arn]
+  }
+
+  statement {
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.ai["input"].arn}/*"]
+  }
+
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.ai["output"].arn]
+  }
+
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.ai["output"].arn}/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "app_task_ai_buckets" {
+  name   = "ai-bucket-access"
+  role   = aws_iam_role.app_task.id
+  policy = data.aws_iam_policy_document.app_task_ai_buckets.json
+}

--- a/infra/performance-test/terraform/platform/k6.tf
+++ b/infra/performance-test/terraform/platform/k6.tf
@@ -1,0 +1,49 @@
+resource "aws_cloudwatch_log_group" "k6" {
+  name              = "/llv/performance-test/${var.test_run_id}/k6"
+  retention_in_days = var.log_retention_days
+}
+
+resource "aws_ecs_task_definition" "k6" {
+  family                   = "${local.name_prefix}-k6"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.k6_task_cpu
+  memory                   = var.k6_task_memory
+  execution_role_arn       = aws_iam_role.task_execution.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "k6"
+      image     = var.k6_image
+      essential = true
+      environment = [
+        {
+          name  = "BASE_URL"
+          value = "http://${aws_lb.app.dns_name}"
+        },
+        {
+          name  = "HEALTH_PATH"
+          value = var.health_check_path
+        },
+        {
+          name  = "K6_SCRIPT_BASE64"
+          value = base64encode(local.k6_smoke_script)
+        }
+      ]
+      entryPoint = ["/bin/sh", "-c"]
+      command = [
+        "set -eu; printf '%s' \"$K6_SCRIPT_BASE64\" | base64 -d > /tmp/smoke.js; exec k6 run /tmp/smoke.js"
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.k6.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+    }
+  ])
+
+  depends_on = [aws_iam_role_policy_attachment.task_execution]
+}

--- a/infra/performance-test/terraform/platform/main.tf
+++ b/infra/performance-test/terraform/platform/main.tf
@@ -6,6 +6,7 @@ locals {
     for index, availability_zone in local.availability_zones :
     availability_zone => cidrsubnet(var.vpc_cidr, 8, index)
   }
+  wiremock_mappings = file("${path.module}/../../wiremock/${var.mock_scenario}.json")
   dependency_services = {
     redis = {
       image       = var.redis_image

--- a/infra/performance-test/terraform/platform/main.tf
+++ b/infra/performance-test/terraform/platform/main.tf
@@ -7,6 +7,7 @@ locals {
     availability_zone => cidrsubnet(var.vpc_cidr, 8, index)
   }
   wiremock_mappings = file("${path.module}/../../wiremock/${var.mock_scenario}.json")
+  k6_smoke_script   = file("${path.module}/../../k6/smoke.js")
   dependency_services = {
     redis = {
       image       = var.redis_image

--- a/infra/performance-test/terraform/platform/main.tf
+++ b/infra/performance-test/terraform/platform/main.tf
@@ -6,4 +6,51 @@ locals {
     for index, availability_zone in local.availability_zones :
     availability_zone => cidrsubnet(var.vpc_cidr, 8, index)
   }
+  dependency_services = {
+    redis = {
+      image       = var.redis_image
+      port        = 6379
+      cpu         = 256
+      memory      = 512
+      environment = []
+      health_check = {
+        command     = ["CMD-SHELL", "redis-cli ping | grep PONG"]
+        interval    = 10
+        timeout     = 5
+        retries     = 5
+        startPeriod = 10
+      }
+    }
+    mysql = {
+      image  = var.mysql_image
+      port   = 3306
+      cpu    = 512
+      memory = 1024
+      environment = [
+        {
+          name  = "MYSQL_RANDOM_ROOT_PASSWORD"
+          value = "yes"
+        },
+        {
+          name  = "MYSQL_DATABASE"
+          value = "llv_performance_test"
+        }
+      ]
+      health_check = {
+        command     = ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 --silent"]
+        interval    = 10
+        timeout     = 5
+        retries     = 10
+        startPeriod = 60
+      }
+    }
+    mock = {
+      image        = var.mock_image
+      port         = 8080
+      cpu          = 256
+      memory       = 512
+      environment  = []
+      health_check = null
+    }
+  }
 }

--- a/infra/performance-test/terraform/platform/outputs.tf
+++ b/infra/performance-test/terraform/platform/outputs.tf
@@ -23,6 +23,11 @@ output "app_environment_file_key" {
   value       = local.environment_file_key
 }
 
+output "app_ecr_repository_url" {
+  description = "Temporary ECR repository receiving the LLV API image under test."
+  value       = aws_ecr_repository.app.repository_url
+}
+
 output "ai_input_bucket" {
   description = "Temporary S3 bucket receiving AI input objects."
   value       = aws_s3_bucket.ai["input"].id

--- a/infra/performance-test/terraform/platform/outputs.tf
+++ b/infra/performance-test/terraform/platform/outputs.tf
@@ -40,3 +40,23 @@ output "dependency_endpoints" {
     name => "${name}.${aws_service_discovery_private_dns_namespace.this.name}:${service.port}"
   }
 }
+
+output "ecs_cluster_arn" {
+  description = "ECS cluster used to run the one-off k6 task."
+  value       = aws_ecs_cluster.this.arn
+}
+
+output "k6_task_definition_arn" {
+  description = "Task definition used by the k6 smoke runner."
+  value       = aws_ecs_task_definition.k6.arn
+}
+
+output "k6_security_group_id" {
+  description = "Security group assigned to the one-off k6 task."
+  value       = aws_security_group.k6.id
+}
+
+output "k6_subnet_id" {
+  description = "Public subnet used by the one-off k6 task."
+  value       = values(aws_subnet.public)[0].id
+}

--- a/infra/performance-test/terraform/platform/outputs.tf
+++ b/infra/performance-test/terraform/platform/outputs.tf
@@ -60,3 +60,18 @@ output "k6_subnet_id" {
   description = "Public subnet used by the one-off k6 task."
   value       = values(aws_subnet.public)[0].id
 }
+
+output "app_desired_count" {
+  description = "Expected number of healthy application targets."
+  value       = var.app_desired_count
+}
+
+output "app_security_group_id" {
+  description = "Security group reused by the dependency probe."
+  value       = aws_security_group.app.id
+}
+
+output "dependency_probe_task_definition_arn" {
+  description = "Task definition that verifies private dependency connectivity."
+  value       = aws_ecs_task_definition.dependency_probe.arn
+}

--- a/infra/performance-test/terraform/platform/outputs.tf
+++ b/infra/performance-test/terraform/platform/outputs.tf
@@ -17,3 +17,11 @@ output "app_environment_file_key" {
   description = "Object key reserved for the application environment file."
   value       = local.environment_file_key
 }
+
+output "dependency_endpoints" {
+  description = "Private DNS endpoints exposed by Cloud Map."
+  value = {
+    for name, service in local.dependency_services :
+    name => "${name}.${aws_service_discovery_private_dns_namespace.this.name}:${service.port}"
+  }
+}

--- a/infra/performance-test/terraform/platform/outputs.tf
+++ b/infra/performance-test/terraform/platform/outputs.tf
@@ -3,6 +3,11 @@ output "aws_region" {
   value       = var.aws_region
 }
 
+output "test_run_id" {
+  description = "Identifier shared by resources in this test run."
+  value       = var.test_run_id
+}
+
 output "target_group_arn" {
   description = "Target group inspected by the phase-one verification script."
   value       = aws_lb_target_group.app.arn
@@ -16,6 +21,16 @@ output "environment_file_bucket" {
 output "app_environment_file_key" {
   description = "Object key reserved for the application environment file."
   value       = local.environment_file_key
+}
+
+output "ai_input_bucket" {
+  description = "Temporary S3 bucket receiving AI input objects."
+  value       = aws_s3_bucket.ai["input"].id
+}
+
+output "ai_output_bucket" {
+  description = "Temporary S3 bucket containing AI output objects."
+  value       = aws_s3_bucket.ai["output"].id
 }
 
 output "dependency_endpoints" {

--- a/infra/performance-test/terraform/platform/probe.tf
+++ b/infra/performance-test/terraform/platform/probe.tf
@@ -1,0 +1,67 @@
+resource "aws_cloudwatch_log_group" "dependency_probe" {
+  name              = "/llv/performance-test/${var.test_run_id}/dependency-probe"
+  retention_in_days = var.log_retention_days
+}
+
+resource "aws_ecs_task_definition" "dependency_probe" {
+  family                   = "${local.name_prefix}-dependency-probe"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 256
+  memory                   = 512
+  execution_role_arn       = aws_iam_role.task_execution.arn
+
+  container_definitions = jsonencode([
+    {
+      name       = "dependency-probe"
+      image      = var.dependency_probe_image
+      essential  = true
+      entryPoint = ["/bin/sh", "-c"]
+      command = [
+        <<-EOT
+          set -eu
+          probe_tcp() {
+            name="$1"
+            host="$2"
+            port="$3"
+            for attempt in $(seq 1 30); do
+              if nc -z -w 2 "$host" "$port"; then
+                echo "$name connection passed: $host:$port"
+                return 0
+              fi
+              sleep 2
+            done
+            echo "$name connection failed: $host:$port" >&2
+            return 1
+          }
+
+          probe_tcp "Redis" "redis.${aws_service_discovery_private_dns_namespace.this.name}" 6379
+          probe_tcp "MySQL" "mysql.${aws_service_discovery_private_dns_namespace.this.name}" 3306
+
+          mock_url="http://mock.${aws_service_discovery_private_dns_namespace.this.name}:8080/__admin/mappings"
+          for attempt in $(seq 1 30); do
+            if wget -qO /tmp/mappings.json "$mock_url" && \
+                grep -q 'bedrock-converse' /tmp/mappings.json && \
+                grep -q 'discord-' /tmp/mappings.json; then
+              echo "WireMock mappings passed: $mock_url"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "WireMock mappings failed: $mock_url" >&2
+          exit 1
+        EOT
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.dependency_probe.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+    }
+  ])
+
+  depends_on = [aws_iam_role_policy_attachment.task_execution]
+}

--- a/infra/performance-test/terraform/platform/s3.tf
+++ b/infra/performance-test/terraform/platform/s3.tf
@@ -1,5 +1,12 @@
 data "aws_caller_identity" "current" {}
 
+locals {
+  ai_bucket_names = {
+    input  = "${local.name_prefix}-${data.aws_caller_identity.current.account_id}-${substr(md5(var.aws_region), 0, 6)}-ai-in"
+    output = "${local.name_prefix}-${data.aws_caller_identity.current.account_id}-${substr(md5(var.aws_region), 0, 6)}-ai-out"
+  }
+}
+
 resource "aws_s3_bucket" "environment_files" {
   bucket        = "${local.name_prefix}-${data.aws_caller_identity.current.account_id}-${var.aws_region}-env"
   force_destroy = true
@@ -16,6 +23,36 @@ resource "aws_s3_bucket_public_access_block" "environment_files" {
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "environment_files" {
   bucket = aws_s3_bucket.environment_files.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "ai" {
+  for_each = local.ai_bucket_names
+
+  bucket        = each.value
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_public_access_block" "ai" {
+  for_each = aws_s3_bucket.ai
+
+  bucket = each.value.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "ai" {
+  for_each = aws_s3_bucket.ai
+
+  bucket = each.value.id
 
   rule {
     apply_server_side_encryption_by_default {

--- a/infra/performance-test/terraform/platform/security.tf
+++ b/infra/performance-test/terraform/platform/security.tf
@@ -46,6 +46,14 @@ resource "aws_security_group" "app" {
   }
 
   egress {
+    description = "MongoDB Atlas database traffic"
+    from_port   = 27015
+    to_port     = 27017
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
     description = "DNS to the VPC resolver"
     from_port   = 53
     to_port     = 53

--- a/infra/performance-test/terraform/platform/security.tf
+++ b/infra/performance-test/terraform/platform/security.tf
@@ -61,7 +61,65 @@ resource "aws_security_group" "app" {
     cidr_blocks = [var.vpc_cidr]
   }
 
+  dynamic "egress" {
+    for_each = local.dependency_services
+
+    content {
+      description = "${egress.key} dependency traffic"
+      from_port   = egress.value.port
+      to_port     = egress.value.port
+      protocol    = "tcp"
+      cidr_blocks = [var.vpc_cidr]
+    }
+  }
+
   tags = {
     Name = "${local.name_prefix}-app"
+  }
+}
+
+resource "aws_security_group" "dependencies" {
+  name_prefix = "${local.name_prefix}-dependencies-"
+  description = "Allow only application tasks to reach temporary dependency services."
+  vpc_id      = aws_vpc.this.id
+
+  dynamic "ingress" {
+    for_each = local.dependency_services
+
+    content {
+      description     = "${ingress.key} from application tasks"
+      from_port       = ingress.value.port
+      to_port         = ingress.value.port
+      protocol        = "tcp"
+      security_groups = [aws_security_group.app.id]
+    }
+  }
+
+  egress {
+    description = "HTTPS for image pulls and AWS APIs"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "DNS to the VPC resolver"
+    from_port   = 53
+    to_port     = 53
+    protocol    = "udp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  egress {
+    description = "TCP DNS fallback to the VPC resolver"
+    from_port   = 53
+    to_port     = 53
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-dependencies"
   }
 }

--- a/infra/performance-test/terraform/platform/security.tf
+++ b/infra/performance-test/terraform/platform/security.tf
@@ -131,3 +131,45 @@ resource "aws_security_group" "dependencies" {
     Name = "${local.name_prefix}-dependencies"
   }
 }
+
+resource "aws_security_group" "k6" {
+  name_prefix = "${local.name_prefix}-k6-"
+  description = "Allow the one-off k6 task to reach the internal ALB."
+  vpc_id      = aws_vpc.this.id
+
+  egress {
+    description = "HTTP to the internal ALB"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  egress {
+    description = "HTTPS for image pulls and AWS APIs"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "DNS to the VPC resolver"
+    from_port   = 53
+    to_port     = 53
+    protocol    = "udp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  egress {
+    description = "TCP DNS fallback to the VPC resolver"
+    from_port   = 53
+    to_port     = 53
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-k6"
+  }
+}

--- a/infra/performance-test/terraform/platform/terraform.tfvars.example
+++ b/infra/performance-test/terraform/platform/terraform.tfvars.example
@@ -12,3 +12,4 @@ app_image         = "public.ecr.aws/docker/library/nginx:1.27-alpine"
 container_port    = 80
 health_check_path = "/"
 app_desired_count = 2
+mock_scenario      = "success"

--- a/infra/performance-test/terraform/platform/terraform.tfvars.example
+++ b/infra/performance-test/terraform/platform/terraform.tfvars.example
@@ -1,15 +1,14 @@
 # Copy this file to terraform.tfvars. terraform.tfvars is ignored by Git.
 aws_region  = "ap-northeast-2"
-test_run_id = "phase-one"
+test_run_id = "phase-two"
 availability_zones = [
   "ap-northeast-2a",
   "ap-northeast-2b",
 ]
 
-# Phase one deliberately uses a public image. Replace it with the LLV API image
-# only after its health endpoint can start without Redis, MongoDB, and AWS credentials.
-app_image         = "public.ecr.aws/docker/library/nginx:1.27-alpine"
-container_port    = 80
-health_check_path = "/"
+# Build and push the LLV API image for the commit under test before applying.
+app_image         = "replace-with-llv-performance-test-image"
+container_port    = 8080
+health_check_path = "/actuator/health"
 app_desired_count = 2
 mock_scenario      = "success"

--- a/infra/performance-test/terraform/platform/terraform.tfvars.example
+++ b/infra/performance-test/terraform/platform/terraform.tfvars.example
@@ -11,3 +11,4 @@ availability_zones = [
 app_image         = "public.ecr.aws/docker/library/nginx:1.27-alpine"
 container_port    = 80
 health_check_path = "/"
+app_desired_count = 2

--- a/infra/performance-test/terraform/platform/terraform.tfvars.example
+++ b/infra/performance-test/terraform/platform/terraform.tfvars.example
@@ -6,9 +6,10 @@ availability_zones = [
   "ap-northeast-2b",
 ]
 
-# Build and push the LLV API image for the commit under test before applying.
-app_image         = "replace-with-llv-performance-test-image"
-container_port    = 8080
-health_check_path = "/actuator/health"
-app_desired_count = 2
-mock_scenario      = "success"
+# Use a unique immutable tag for the commit under test.
+app_image_tag                    = "replace-with-git-sha"
+container_port                   = 8080
+health_check_path                = "/actuator/health"
+health_check_grace_period_seconds = 180
+app_desired_count                = 2
+mock_scenario                     = "success"

--- a/infra/performance-test/terraform/platform/variables.tf
+++ b/infra/performance-test/terraform/platform/variables.tf
@@ -19,6 +19,24 @@ variable "app_image" {
   default     = "public.ecr.aws/docker/library/nginx:1.27-alpine"
 }
 
+variable "redis_image" {
+  description = "Redis image used by the temporary dependency service."
+  type        = string
+  default     = "redis:7.4.9-alpine"
+}
+
+variable "mysql_image" {
+  description = "MySQL image used by the temporary dependency service."
+  type        = string
+  default     = "mysql:8.4.10"
+}
+
+variable "mock_image" {
+  description = "WireMock image used to control external API responses."
+  type        = string
+  default     = "wiremock/wiremock:3.13.2"
+}
+
 variable "container_port" {
   description = "TCP port exposed by the phase-one container."
   type        = number

--- a/infra/performance-test/terraform/platform/variables.tf
+++ b/infra/performance-test/terraform/platform/variables.tf
@@ -37,6 +37,23 @@ variable "mock_image" {
   default     = "wiremock/wiremock:3.13.2"
 }
 
+variable "mock_init_image" {
+  description = "Container image that registers WireMock mappings through the Admin API."
+  type        = string
+  default     = "curlimages/curl:8.12.1"
+}
+
+variable "mock_scenario" {
+  description = "WireMock response profile loaded when the mock service starts."
+  type        = string
+  default     = "success"
+
+  validation {
+    condition     = contains(["success", "delay", "error"], var.mock_scenario)
+    error_message = "mock_scenario must be one of success, delay, or error."
+  }
+}
+
 variable "container_port" {
   description = "TCP port exposed by the phase-one container."
   type        = number

--- a/infra/performance-test/terraform/platform/variables.tf
+++ b/infra/performance-test/terraform/platform/variables.tf
@@ -61,6 +61,17 @@ variable "task_memory" {
   default     = 512
 }
 
+variable "app_desired_count" {
+  description = "Number of application tasks behind the internal ALB."
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.app_desired_count >= 1
+    error_message = "app_desired_count must be at least 1."
+  }
+}
+
 variable "vpc_cidr" {
   description = "CIDR block reserved for the temporary phase-one VPC."
   type        = string

--- a/infra/performance-test/terraform/platform/variables.tf
+++ b/infra/performance-test/terraform/platform/variables.tf
@@ -72,6 +72,12 @@ variable "k6_task_memory" {
   default     = 512
 }
 
+variable "dependency_probe_image" {
+  description = "Alpine image used by the one-off dependency connectivity probe."
+  type        = string
+  default     = "public.ecr.aws/docker/library/alpine:3.22.2"
+}
+
 variable "container_port" {
   description = "TCP port exposed by the phase-one container."
   type        = number

--- a/infra/performance-test/terraform/platform/variables.tf
+++ b/infra/performance-test/terraform/platform/variables.tf
@@ -54,6 +54,24 @@ variable "mock_scenario" {
   }
 }
 
+variable "k6_image" {
+  description = "k6 image used by the one-off smoke task."
+  type        = string
+  default     = "grafana/k6:2.0.0"
+}
+
+variable "k6_task_cpu" {
+  description = "Fargate CPU units assigned to the one-off k6 task."
+  type        = number
+  default     = 256
+}
+
+variable "k6_task_memory" {
+  description = "Memory in MiB assigned to the one-off k6 task."
+  type        = number
+  default     = 512
+}
+
 variable "container_port" {
   description = "TCP port exposed by the phase-one container."
   type        = number

--- a/infra/performance-test/terraform/platform/variables.tf
+++ b/infra/performance-test/terraform/platform/variables.tf
@@ -13,10 +13,14 @@ variable "test_run_id" {
   }
 }
 
-variable "app_image" {
-  description = "Container image used to verify the ECS and ALB deployment path."
+variable "app_image_tag" {
+  description = "Immutable ECR tag assigned to the LLV API image under test."
   type        = string
-  default     = "public.ecr.aws/docker/library/nginx:1.27-alpine"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$", var.app_image_tag))
+    error_message = "app_image_tag must be a valid non-empty container image tag."
+  }
 }
 
 variable "redis_image" {
@@ -88,6 +92,12 @@ variable "health_check_path" {
   description = "HTTP path used by the ALB target group health check."
   type        = string
   default     = "/"
+}
+
+variable "health_check_grace_period_seconds" {
+  description = "Time allowed for the Spring application to start before ALB health failures count."
+  type        = number
+  default     = 180
 }
 
 variable "task_cpu" {

--- a/infra/performance-test/wiremock/delay.json
+++ b/infra/performance-test/wiremock/delay.json
@@ -1,0 +1,49 @@
+{
+  "mappings": [
+    {
+      "name": "bedrock-converse-delay",
+      "request": {
+        "method": "POST",
+        "urlPathPattern": "/model/.+/converse"
+      },
+      "response": {
+        "status": 200,
+        "fixedDelayMilliseconds": 6000,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "output": {
+            "message": {
+              "role": "assistant",
+              "content": [
+                {
+                  "text": "[{\"originalForm\":\"benchmark\",\"variantTypes\":[\"ORIGINAL_FORM\"],\"sourceLanguageCode\":\"EN\",\"targetLanguageCode\":\"KO\",\"summary\":[\"기준점\"],\"meanings\":[{\"partOfSpeech\":\"noun\",\"meaning\":\"성능이나 품질을 비교하기 위한 기준점\",\"example\":\"The benchmark helps us compare system performance.\",\"exampleTranslation\":\"그 기준점은 시스템 성능을 비교하는 데 도움이 됩니다.\"}],\"conjugations\":null,\"comparatives\":null,\"plural\":{\"singular\":\"benchmark\",\"plural\":\"benchmarks\"}}]"
+                }
+              ]
+            }
+          },
+          "stopReason": "end_turn",
+          "usage": {
+            "inputTokens": 500,
+            "outputTokens": 120,
+            "totalTokens": 620
+          },
+          "metrics": {
+            "latencyMs": 6000
+          }
+        }
+      }
+    },
+    {
+      "name": "discord-delay-profile-success",
+      "request": {
+        "method": "POST",
+        "urlPath": "/discord/webhook"
+      },
+      "response": {
+        "status": 204
+      }
+    }
+  ]
+}

--- a/infra/performance-test/wiremock/error.json
+++ b/infra/performance-test/wiremock/error.json
@@ -1,0 +1,34 @@
+{
+  "mappings": [
+    {
+      "name": "bedrock-converse-error",
+      "request": {
+        "method": "POST",
+        "urlPathPattern": "/model/.+/converse"
+      },
+      "response": {
+        "status": 503,
+        "headers": {
+          "Content-Type": "application/json",
+          "x-amzn-errortype": "ServiceUnavailableException"
+        },
+        "jsonBody": {
+          "message": "Bedrock is temporarily unavailable in the performance test scenario."
+        }
+      }
+    },
+    {
+      "name": "discord-error",
+      "request": {
+        "method": "POST",
+        "urlPath": "/discord/webhook"
+      },
+      "response": {
+        "status": 500,
+        "jsonBody": {
+          "message": "Discord webhook failure in the performance test scenario."
+        }
+      }
+    }
+  ]
+}

--- a/infra/performance-test/wiremock/success.json
+++ b/infra/performance-test/wiremock/success.json
@@ -1,0 +1,49 @@
+{
+  "mappings": [
+    {
+      "name": "bedrock-converse-success",
+      "request": {
+        "method": "POST",
+        "urlPathPattern": "/model/.+/converse"
+      },
+      "response": {
+        "status": 200,
+        "fixedDelayMilliseconds": 800,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "output": {
+            "message": {
+              "role": "assistant",
+              "content": [
+                {
+                  "text": "[{\"originalForm\":\"benchmark\",\"variantTypes\":[\"ORIGINAL_FORM\"],\"sourceLanguageCode\":\"EN\",\"targetLanguageCode\":\"KO\",\"summary\":[\"기준점\"],\"meanings\":[{\"partOfSpeech\":\"noun\",\"meaning\":\"성능이나 품질을 비교하기 위한 기준점\",\"example\":\"The benchmark helps us compare system performance.\",\"exampleTranslation\":\"그 기준점은 시스템 성능을 비교하는 데 도움이 됩니다.\"}],\"conjugations\":null,\"comparatives\":null,\"plural\":{\"singular\":\"benchmark\",\"plural\":\"benchmarks\"}}]"
+                }
+              ]
+            }
+          },
+          "stopReason": "end_turn",
+          "usage": {
+            "inputTokens": 500,
+            "outputTokens": 120,
+            "totalTokens": 620
+          },
+          "metrics": {
+            "latencyMs": 800
+          }
+        }
+      }
+    },
+    {
+      "name": "discord-success",
+      "request": {
+        "method": "POST",
+        "urlPath": "/discord/webhook"
+      },
+      "response": {
+        "status": 204
+      }
+    }
+  ]
+}

--- a/src/main/java/com/linglevel/api/ApiApplication.java
+++ b/src/main/java/com/linglevel/api/ApiApplication.java
@@ -3,10 +3,8 @@ package com.linglevel.api;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableScheduling
 @EnableAsync
 public class ApiApplication {
 

--- a/src/main/java/com/linglevel/api/auth/controller/AuthController.java
+++ b/src/main/java/com/linglevel/api/auth/controller/AuthController.java
@@ -17,9 +17,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@Profile("!performance-test")
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 @Slf4j

--- a/src/main/java/com/linglevel/api/common/config/FirebaseConfig.java
+++ b/src/main/java/com/linglevel/api/common/config/FirebaseConfig.java
@@ -8,12 +8,14 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Base64;
 
 @Configuration
+@Profile("!performance-test")
 public class FirebaseConfig {
 
 	@Value("${firebase.config}")

--- a/src/main/java/com/linglevel/api/common/config/PerformanceTestFirebaseConfig.java
+++ b/src/main/java/com/linglevel/api/common/config/PerformanceTestFirebaseConfig.java
@@ -1,0 +1,40 @@
+package com.linglevel.api.common.config;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.messaging.FirebaseMessaging;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import java.util.Date;
+
+@Configuration
+@Profile("performance-test")
+public class PerformanceTestFirebaseConfig {
+
+	@Bean(destroyMethod = "delete")
+	public FirebaseApp performanceTestFirebaseApp() {
+		GoogleCredentials credentials = GoogleCredentials
+			.create(new AccessToken("performance-test", new Date(Long.MAX_VALUE)));
+		FirebaseOptions options = FirebaseOptions.builder()
+			.setCredentials(credentials)
+			.setProjectId("llv-performance-test")
+			.build();
+		return FirebaseApp.initializeApp(options, "performance-test");
+	}
+
+	@Bean
+	public FirebaseAuth firebaseAuth(FirebaseApp firebaseApp) {
+		return FirebaseAuth.getInstance(firebaseApp);
+	}
+
+	@Bean
+	public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
+		return FirebaseMessaging.getInstance(firebaseApp);
+	}
+
+}

--- a/src/main/java/com/linglevel/api/common/config/SchedulingConfig.java
+++ b/src/main/java/com/linglevel/api/common/config/SchedulingConfig.java
@@ -1,0 +1,12 @@
+package com.linglevel.api.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@Profile("!performance-test")
+public class SchedulingConfig {
+
+}

--- a/src/main/java/com/linglevel/api/fcm/service/FcmMessagingService.java
+++ b/src/main/java/com/linglevel/api/fcm/service/FcmMessagingService.java
@@ -11,6 +11,7 @@ import com.linglevel.api.fcm.repository.PushLogRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -24,6 +25,9 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Slf4j
 public class FcmMessagingService {
+
+	@Value("${fcm.enabled:true}")
+	private boolean fcmEnabled;
 
 	private final FirebaseMessaging firebaseMessaging;
 
@@ -39,9 +43,13 @@ public class FcmMessagingService {
 	 * 단일 사용자에게 알림 전송
 	 */
 	public String sendMessage(String fcmToken, FcmMessageRequest messageRequest) {
+		String pushId = UUID.randomUUID().toString();
+		if (!fcmEnabled) {
+			log.debug("FCM send skipped because FCM is disabled - pushId: {}", pushId);
+			return pushId;
+		}
 		String userId = getUserIdFromToken(fcmToken);
 		String campaignGroup = messageRequest.getCampaignId(); // 원래의 campaignId를 그룹으로 사용
-		String pushId = UUID.randomUUID().toString();
 
 		try {
 			Map<String, String> data = buildDataWithUserId(messageRequest, userId);
@@ -89,6 +97,11 @@ public class FcmMessagingService {
 	 */
 	public BatchResponse sendMulticastMessage(List<String> fcmTokens, FcmMessageRequest messageRequest) {
 		String campaignGroup = messageRequest.getCampaignId(); // 원래의 campaignId를 그룹으로 사용
+		if (!fcmEnabled) {
+			int messageCount = fcmTokens == null ? 0 : fcmTokens.size();
+			log.debug("FCM multicast skipped because FCM is disabled - messages: {}", messageCount);
+			return new DisabledBatchResponse(messageCount);
+		}
 
 		try {
 			if (fcmTokens == null || fcmTokens.isEmpty()) {
@@ -152,6 +165,25 @@ public class FcmMessagingService {
 
 			throw new FcmException(FcmErrorCode.MESSAGE_SEND_FAILED);
 		}
+	}
+
+	private record DisabledBatchResponse(int successCount) implements BatchResponse {
+
+		@Override
+		public List<SendResponse> getResponses() {
+			return List.of();
+		}
+
+		@Override
+		public int getSuccessCount() {
+			return successCount;
+		}
+
+		@Override
+		public int getFailureCount() {
+			return 0;
+		}
+
 	}
 
 	/**

--- a/src/main/java/com/linglevel/api/fcm/service/FcmTokenService.java
+++ b/src/main/java/com/linglevel/api/fcm/service/FcmTokenService.java
@@ -14,6 +14,7 @@ import com.linglevel.api.i18n.CountryCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -24,6 +25,9 @@ import java.util.Optional;
 @Slf4j
 public class FcmTokenService {
 
+	@Value("${fcm.enabled:true}")
+	private boolean fcmEnabled;
+
 	private final FcmTokenRepository fcmTokenRepository;
 
 	private final FirebaseMessaging firebaseMessaging;
@@ -32,6 +36,10 @@ public class FcmTokenService {
 	 * FCM 토큰 유효성 검증
 	 */
 	private boolean validateFcmToken(String fcmToken) {
+		if (!fcmEnabled) {
+			return true;
+		}
+
 		try {
 			Message testMessage = Message.builder()
 				.setToken(fcmToken)

--- a/src/main/java/com/linglevel/api/s3/config/PerformanceTestS3Config.java
+++ b/src/main/java/com/linglevel/api/s3/config/PerformanceTestS3Config.java
@@ -1,0 +1,44 @@
+package com.linglevel.api.s3.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@Profile("performance-test")
+public class PerformanceTestS3Config {
+
+	@Bean("s3AiClient")
+	public S3Client s3AiClient(@Value("${aws.s3.region}") String region) {
+		return S3Client.builder()
+			.region(Region.of(region))
+			.credentialsProvider(DefaultCredentialsProvider.builder().build())
+			.build();
+	}
+
+	@Bean(value = "s3StaticClient", destroyMethod = "")
+	public S3Client s3StaticClient(@Qualifier("s3AiClient") S3Client s3AiClient) {
+		return s3AiClient;
+	}
+
+	@Bean("aiInputBucketName")
+	public String aiInputBucketName(@Value("${aws.s3.ai.input.bucket}") String bucketName) {
+		return bucketName;
+	}
+
+	@Bean("aiOutputBucketName")
+	public String aiOutputBucketName(@Value("${aws.s3.ai.output.bucket}") String bucketName) {
+		return bucketName;
+	}
+
+	@Bean("staticBucketName")
+	public String staticBucketName(@Qualifier("aiOutputBucketName") String aiOutputBucketName) {
+		return aiOutputBucketName;
+	}
+
+}

--- a/src/main/java/com/linglevel/api/s3/config/S3Config.java
+++ b/src/main/java/com/linglevel/api/s3/config/S3Config.java
@@ -3,6 +3,7 @@ package com.linglevel.api.s3.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -12,6 +13,7 @@ import software.amazon.awssdk.services.s3.S3Configuration;
 import java.net.URI;
 
 @Configuration
+@Profile("!performance-test")
 public class S3Config {
 
 	// AWS S3 Configuration (for AI buckets)

--- a/src/main/java/com/linglevel/api/word/config/WordBedrockClientConfig.java
+++ b/src/main/java/com/linglevel/api/word/config/WordBedrockClientConfig.java
@@ -1,12 +1,17 @@
 package com.linglevel.api.word.config;
 
 import org.springframework.ai.autoconfigure.bedrock.BedrockAwsConnectionProperties;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
 import software.amazon.awssdk.regions.providers.AwsRegionProvider;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClientBuilder;
+
+import java.net.URI;
 
 @Configuration
 public class WordBedrockClientConfig {
@@ -15,13 +20,19 @@ public class WordBedrockClientConfig {
 
 	@Bean
 	public BedrockRuntimeClient wordBedrockRuntimeClient(AwsCredentialsProvider credentialsProvider,
-			AwsRegionProvider regionProvider, BedrockAwsConnectionProperties connectionProperties) {
-		return BedrockRuntimeClient.builder()
+			AwsRegionProvider regionProvider, BedrockAwsConnectionProperties connectionProperties,
+			@Value("${word.bedrock.endpoint:}") String endpoint) {
+		BedrockRuntimeClientBuilder builder = BedrockRuntimeClient.builder()
 			.region(regionProvider.getRegion())
 			.credentialsProvider(credentialsProvider)
-			.overrideConfiguration(builder -> builder.apiCallTimeout(connectionProperties.getTimeout())
-				.retryStrategy(AwsRetryStrategy.standardRetryStrategy().toBuilder().maxAttempts(MAX_ATTEMPTS).build()))
-			.build();
+			.overrideConfiguration(configuration -> configuration.apiCallTimeout(connectionProperties.getTimeout())
+				.retryStrategy(AwsRetryStrategy.standardRetryStrategy().toBuilder().maxAttempts(MAX_ATTEMPTS).build()));
+
+		if (StringUtils.hasText(endpoint)) {
+			builder.endpointOverride(URI.create(endpoint));
+		}
+
+		return builder.build();
 	}
 
 }

--- a/src/main/resources/application-performance-test.properties
+++ b/src/main/resources/application-performance-test.properties
@@ -7,6 +7,7 @@ spring.data.redis.port=${SPRING_DATA_REDIS_PORT:6379}
 # ECS task role credentials
 spring.ai.bedrock.aws.access-key=
 spring.ai.bedrock.aws.secret-key=
+word.bedrock.endpoint=${BEDROCK_ENDPOINT}
 
 # S3 test buckets
 aws.s3.region=${S3_REGION}

--- a/src/main/resources/application-performance-test.properties
+++ b/src/main/resources/application-performance-test.properties
@@ -1,0 +1,30 @@
+# Data stores
+spring.data.mongodb.uri=${SPRING_DATA_MONGODB_URI}
+spring.data.mongodb.database=${SPRING_DATA_MONGODB_DATABASE}
+spring.data.redis.host=${SPRING_DATA_REDIS_HOST}
+spring.data.redis.port=${SPRING_DATA_REDIS_PORT:6379}
+
+# ECS task role credentials
+spring.ai.bedrock.aws.access-key=
+spring.ai.bedrock.aws.secret-key=
+
+# S3 test buckets
+aws.s3.region=${S3_REGION}
+aws.s3.ai.input.bucket=${S3_AI_INPUT_NAME}
+aws.s3.ai.output.bucket=${S3_AI_OUTPUT_NAME}
+
+# Disabled integrations and background jobs
+fcm.enabled=${FCM_ENABLED:false}
+sentry.enabled=${SENTRY_ENABLED:false}
+sentry.dsn=
+sentry.traces-sample-rate=0.0
+
+# API documentation
+springdoc.swagger-ui.enabled=false
+springdoc.api-docs.enabled=false
+swagger.servers=http://localhost:8080
+
+# Logging
+logging.level.com.linglevel.api=INFO
+logging.level.org.springframework.data.mongodb=WARN
+logging.level.root=INFO

--- a/src/test/java/com/linglevel/api/common/config/PerformanceTestExternalServiceConfigTest.java
+++ b/src/test/java/com/linglevel/api/common/config/PerformanceTestExternalServiceConfigTest.java
@@ -1,0 +1,43 @@
+package com.linglevel.api.common.config;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.linglevel.api.auth.controller.AuthController;
+import com.linglevel.api.s3.config.PerformanceTestS3Config;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PerformanceTestExternalServiceConfigTest {
+
+	@Test
+	void performanceTestProfileUsesInertFirebaseClientsAndTaskRoleS3Client() {
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+			context.getEnvironment().setActiveProfiles("performance-test");
+			context.getEnvironment()
+				.getPropertySources()
+				.addFirst(new MapPropertySource("test", Map.of("aws.s3.region", "ap-northeast-2",
+						"aws.s3.ai.input.bucket", "test-input", "aws.s3.ai.output.bucket", "test-output")));
+			context.register(PerformanceTestFirebaseConfig.class, PerformanceTestS3Config.class, AuthController.class);
+			context.refresh();
+
+			FirebaseApp firebaseApp = context.getBean(FirebaseApp.class);
+			assertThat(firebaseApp.getOptions().getProjectId()).isEqualTo("llv-performance-test");
+			assertThat(context.getBean(FirebaseAuth.class)).isNotNull();
+			assertThat(context.getBean(FirebaseMessaging.class)).isNotNull();
+			assertThat(context.getBeansOfType(AuthController.class)).isEmpty();
+
+			S3Client aiClient = context.getBean("s3AiClient", S3Client.class);
+			assertThat(context.getBean("s3StaticClient", S3Client.class)).isSameAs(aiClient);
+			assertThat(context.getBean("aiInputBucketName")).isEqualTo("test-input");
+			assertThat(context.getBean("aiOutputBucketName")).isEqualTo("test-output");
+		}
+	}
+
+}

--- a/src/test/java/com/linglevel/api/fcm/service/FcmMessagingServiceTest.java
+++ b/src/test/java/com/linglevel/api/fcm/service/FcmMessagingServiceTest.java
@@ -1,0 +1,67 @@
+package com.linglevel.api.fcm.service;
+
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.linglevel.api.fcm.dto.FcmMessageRequest;
+import com.linglevel.api.fcm.repository.FcmTokenRepository;
+import com.linglevel.api.fcm.repository.PushLogRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class FcmMessagingServiceTest {
+
+	@Mock
+	private FirebaseMessaging firebaseMessaging;
+
+	@Mock
+	private FcmTokenRepository fcmTokenRepository;
+
+	@Mock
+	private PushLogRepository pushLogRepository;
+
+	@Mock
+	private PushLogService pushLogService;
+
+	@InjectMocks
+	private FcmMessagingService fcmMessagingService;
+
+	@BeforeEach
+	void disableFcm() {
+		ReflectionTestUtils.setField(fcmMessagingService, "fcmEnabled", false);
+	}
+
+	@Test
+	void disabledFcmSkipsSingleMessageDelivery() {
+		String pushId = fcmMessagingService.sendMessage("test-token", messageRequest());
+
+		assertThat(pushId).isNotBlank();
+		verifyNoInteractions(firebaseMessaging, fcmTokenRepository, pushLogRepository, pushLogService);
+	}
+
+	@Test
+	void disabledFcmTreatsMulticastAsSuccessfulWithoutDelivery() {
+		BatchResponse response = fcmMessagingService.sendMulticastMessage(List.of("token-1", "token-2"),
+				messageRequest());
+
+		assertThat(response.getSuccessCount()).isEqualTo(2);
+		assertThat(response.getFailureCount()).isZero();
+		assertThat(response.getResponses()).isEmpty();
+		verifyNoInteractions(firebaseMessaging, fcmTokenRepository, pushLogRepository, pushLogService);
+	}
+
+	private FcmMessageRequest messageRequest() {
+		return FcmMessageRequest.builder().title("title").body("body").campaignId("test").build();
+	}
+
+}

--- a/src/test/java/com/linglevel/api/word/config/WordBedrockClientConfigTest.java
+++ b/src/test/java/com/linglevel/api/word/config/WordBedrockClientConfigTest.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 
 import java.time.Duration;
+import java.net.URI;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -24,13 +25,28 @@ class WordBedrockClientConfigTest {
 		WordBedrockClientConfig config = new WordBedrockClientConfig();
 		try (BedrockRuntimeClient client = config.wordBedrockRuntimeClient(
 				StaticCredentialsProvider.create(AwsBasicCredentials.create("access-key", "secret-key")),
-				() -> Region.US_EAST_1, connectionProperties)) {
+				() -> Region.US_EAST_1, connectionProperties, "")) {
 			ClientOverrideConfiguration overrideConfiguration = client.serviceClientConfiguration()
 				.overrideConfiguration();
 
 			assertThat(overrideConfiguration.apiCallTimeout()).contains(Duration.ofSeconds(8));
 			assertThat(overrideConfiguration.retryStrategy())
 				.hasValueSatisfying(retryStrategy -> assertThat(retryStrategy.maxAttempts()).isEqualTo(2));
+		}
+	}
+
+	@Test
+	@DisplayName("설정된 endpoint가 있으면 Bedrock 대신 해당 endpoint를 호출한다")
+	void wordBedrockRuntimeClient_overridesEndpointWhenConfigured() {
+		BedrockAwsConnectionProperties connectionProperties = new BedrockAwsConnectionProperties();
+		connectionProperties.setTimeout(Duration.ofSeconds(8));
+		URI mockEndpoint = URI.create("http://mock.test.llvpt.local:8080");
+
+		WordBedrockClientConfig config = new WordBedrockClientConfig();
+		try (BedrockRuntimeClient client = config.wordBedrockRuntimeClient(
+				StaticCredentialsProvider.create(AwsBasicCredentials.create("access-key", "secret-key")),
+				() -> Region.US_EAST_1, connectionProperties, mockEndpoint.toString())) {
+			assertThat(client.serviceClientConfiguration().endpointOverride()).contains(mockEndpoint);
 		}
 	}
 


### PR DESCRIPTION
## Summary
재사용 가능한 부하 테스트 인프라의 2단계로 애플리케이션과 Redis, MySQL, MongoDB Atlas, WireMock, S3, k6를 AWS 환경에서 연결하고 검증할 수 있도록 구성했습니다.

## Problem
1단계 인프라는 ALB와 ECS 컨테이너 기동만 확인할 수 있어 실제 애플리케이션의 데이터 저장소 및 외부 서비스 의존성을 포함한 부하 테스트를 실행할 수 없었습니다. 또한 비공개 애플리케이션 이미지 배포와 테스트 전용 비밀값 주입 경로가 필요했습니다.

## Solution
테스트 실행마다 생성하고 제거할 수 있는 ECS 의존 서비스와 임시 S3/ECR 리소스를 Terraform으로 정의했습니다. Bedrock과 Discord는 WireMock으로 통제하고, Firebase와 Sentry 등 부하 테스트에 불필요한 외부 호출은 전용 Spring profile에서 격리했습니다.

## Changes
- Redis, MySQL, WireMock ECS 서비스와 Cloud Map 내부 DNS 구성
- MongoDB Atlas, Redis, MySQL, S3 연결을 위한 테스트 전용 애플리케이션 profile 추가
- 테스트 환경 파일을 S3 environment file로 주입하고 종료 시 삭제
- 임시 ECR 생성 및 commit 기반 이미지 게시·재사용 스크립트 추가
- ALB를 호출하는 일회성 k6 smoke task와 2단계 연결 검증 스크립트 추가
- ECS task role, 보안 그룹, S3 bucket 및 IAM 권한 구성
- Spring 기동 시간을 고려한 health check grace period와 테스트 종료 대기 조정
- 인프라 계획 문서와 실행 README 갱신

## Example
```bash
TF_CLI_ARGS_apply=-auto-approve ./infra/performance-test/run/publish-app-image.sh
./infra/performance-test/run/upload-app-environment.sh
terraform -chdir=infra/performance-test/terraform/platform apply
./infra/performance-test/run/verify-phase-two.sh
```

실제 AWS 검증에서 애플리케이션 target 2/2, Redis, MySQL, Atlas, WireMock 연결과 k6 ALB 요청이 성공했습니다. 검증 후 Terraform으로 임시 리소스 50개를 모두 제거했습니다.

검증:
- `./gradlew bootJar`
- `terraform validate`
- 셸 스크립트 문법 및 IAM JSON 검사
- 실제 AWS apply, phase-two verification, destroy

## Related Issues
없음