### PR TITLE
feat(performance-test): add lifecycle runner

### DIFF
--- a/infra/performance-test/README.md
+++ b/infra/performance-test/README.md
@@ -9,6 +9,7 @@
 ## 구조
 
 - `terraform/platform`: AWS 리소스 정의
+- `run/performance-test.sh`: 생성, 검증, 상태 확인, 제거를 담당하는 단일 실행 진입점
 - `run/verify-phase-one.sh`: ALB target health 확인
 - `run/.env.app.example`: 테스트 앱 환경 변수 양식
 - `run/publish-app-image.sh`: 현재 commit의 LLV API 이미지를 임시 ECR에 업로드
@@ -56,19 +57,19 @@ source_profile = llv-sso
 region = ap-northeast-2
 ```
 
+SSO를 source profile로 사용한다면 최초 한 번 설정하고, credential이 만료됐을 때 다시 로그인한다.
+
 ```bash
-# 최초 1회
+# 최초 한 번
 aws configure sso --profile llv-sso
 
+# SSO credential이 만료된 경우
 aws sso login --profile llv-sso
-export AWS_PROFILE=llv-performance-test
-
-cp infra/performance-test/terraform/platform/terraform.tfvars.example \
-	infra/performance-test/terraform/platform/terraform.tfvars
-terraform -chdir=infra/performance-test/terraform/platform init
 ```
 
-`terraform.tfvars`의 `test_run_id`는 실행마다 고유하게 설정하고 `app_image_tag`에는 commit SHA 기반의 고유 태그를 사용한다. 환경 파일과 앱 이미지를 업로드하기 전에는 전체 `terraform apply`를 실행하지 않는다.
+runner에 `--profile`을 전달하면 별도로 `AWS_PROFILE`을 export할 필요가 없다. 이미 필요한 권한을 가진 다른 profile이 있다면 `llv-performance-test` 대신 해당 이름을 전달할 수 있다.
+
+`terraform.tfvars`의 `test_run_id`는 실행마다 고유하게 설정한다. runner는 `app_image_tag`를 현재 commit SHA로 갱신한다. 환경 파일과 앱 이미지를 업로드하기 전에는 전체 `terraform apply`를 실행하지 않는다.
 
 Terraform과 검증 스크립트는 같은 `AWS_PROFILE`을 사용한다. CI에서는 GitHub OIDC가 `PerformanceTestProvisioner`의 임시 credential을 제공한다.
 
@@ -81,13 +82,16 @@ ECS를 포함한 전체 Terraform 적용 전에 `infra/performance-test/run/.env
 업로드 스크립트는 S3 bucket, public access block, 암호화 설정만 먼저 적용한 후 환경 파일을 업로드한다. 업로드가 끝나야 전체 인프라를 적용한다.
 
 ```bash
-cp infra/performance-test/run/.env.app.example infra/performance-test/run/.env.app
-chmod 600 infra/performance-test/run/.env.app
-TF_CLI_ARGS_apply=-auto-approve ./infra/performance-test/run/publish-app-image.sh
-./infra/performance-test/run/upload-app-environment.sh
+./infra/performance-test/run/performance-test.sh up --profile llv-performance-test
+```
 
-terraform -chdir=infra/performance-test/terraform/platform apply
-./infra/performance-test/run/verify-phase-two.sh
+runner는 필요한 로컬 설정 파일이 없으면 example을 복사하고 입력할 값만 안내한 뒤 종료한다. 값을 작성하고 같은 명령을 다시 실행하면 Terraform 초기화, 이미지 게시, 환경 파일 업로드, 전체 apply와 연결 검증을 순서대로 수행한다. `--yes`를 추가한 경우에만 Terraform 승인 질문을 생략한다.
+
+실행 중인 환경은 다음 명령으로 다시 검증하거나 상태를 확인한다.
+
+```bash
+./infra/performance-test/run/performance-test.sh verify --profile llv-performance-test
+./infra/performance-test/run/performance-test.sh status --profile llv-performance-test
 ```
 
 검증 스크립트는 설정된 수의 앱 target health, Redis·MySQL의 내부 DNS/TCP 연결, WireMock mapping 등록, k6의 ALB 요청을 순서대로 확인한다. probe와 smoke task는 상시 실행되는 ECS service가 아니며 검증할 때 각각 한 번 실행된다. 실제 Word 부하 시나리오는 이 연결 확인 이후 별도 task 실행 설정으로 추가한다.
@@ -95,7 +99,7 @@ terraform -chdir=infra/performance-test/terraform/platform apply
 테스트 종료 후에는 인프라를 제거하기 전에 환경 파일을 먼저 정리한다. 원격 객체 삭제가 실패하더라도 로컬 `.env.app`은 삭제되며, 실패한 S3 객체는 `terraform destroy`의 `force_destroy`로 다시 정리한다.
 
 ```bash
-./infra/performance-test/run/cleanup-app-environment.sh
-
-terraform -chdir=infra/performance-test/terraform/platform destroy
+./infra/performance-test/run/performance-test.sh down --profile llv-performance-test
 ```
+
+`down`은 환경 파일 정리 후 Terraform 리소스를 제거하고 state가 비었는지 확인한다. `--yes`를 추가한 경우에만 destroy 승인 질문을 생략한다. Atlas IP allowlist는 runner가 관리하지 않으므로 테스트 직전에 열고 종료 후 직접 닫는다.

--- a/infra/performance-test/README.md
+++ b/infra/performance-test/README.md
@@ -77,7 +77,7 @@ Terraform과 검증 스크립트는 같은 `AWS_PROFILE`을 사용한다. CI에�
 
 ECS를 포함한 전체 Terraform 적용 전에 `infra/performance-test/run/.env.app`에 테스트 전용 환경 변수를 작성하고 업로드한다. 이 파일은 Git에서 제외되며 객체 내용도 Terraform state에 기록되지 않는다.
 
-사용자가 직접 입력할 값은 Atlas 테스트 계정의 `SPRING_DATA_MONGODB_URI`다. JWT와 import key는 테스트 전용 값으로 생성한다. 업로드 스크립트는 Terraform output을 읽어 Redis와 WireMock 주소, S3 input/output bucket 값을 환경 파일에 자동 반영한다.
+사용자가 직접 입력할 값은 Atlas 테스트 계정의 `SPRING_DATA_MONGODB_URI`다. JWT와 import key는 테스트 전용 값으로 생성한다. `JWT_SECRET`은 `openssl rand -base64 32`처럼 32바이트 이상의 키를 Base64로 인코딩해 사용한다. 업로드 스크립트는 Terraform output을 읽어 Redis와 WireMock 주소, S3 input/output bucket 값을 환경 파일에 자동 반영한다.
 
 업로드 스크립트는 S3 bucket, public access block, 암호화 설정만 먼저 적용한 후 환경 파일을 업로드한다. 업로드가 끝나야 전체 인프라를 적용한다.
 

--- a/infra/performance-test/run/.env.app.example
+++ b/infra/performance-test/run/.env.app.example
@@ -12,6 +12,7 @@ RATE_LIMIT_ENABLED=false
 WORD_SINGLE_FLIGHT_ENABLED=true
 
 # Test authentication
+# Generate JWT_SECRET with: openssl rand -base64 32
 JWT_SECRET=replace-with-generated-test-jwt-secret
 IMPORT_API_KEY=replace-with-generated-test-import-api-key
 

--- a/infra/performance-test/run/performance-test.sh
+++ b/infra/performance-test/run/performance-test.sh
@@ -1,0 +1,336 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(cd "${script_dir}/../../.." && pwd)"
+platform_dir="${repository_root}/infra/performance-test/terraform/platform"
+environment_file="${repository_root}/infra/performance-test/run/.env.app"
+environment_example="${environment_file}.example"
+terraform_vars="${platform_dir}/terraform.tfvars"
+terraform_vars_example="${terraform_vars}.example"
+current_step="startup"
+auto_approve=false
+created_local_files=false
+
+usage() {
+	cat <<'EOF'
+Usage: performance-test.sh <command> [options]
+
+Commands:
+  up       Create the phase-two environment and verify connectivity.
+  verify   Verify an existing phase-two environment.
+  status   Show Terraform resources, outputs, and ALB target health.
+  down     Remove the environment and confirm Terraform state is empty.
+
+Options:
+  --profile <name>  Use the named AWS CLI profile.
+  --yes             Skip Terraform approval prompts for up or down.
+  -h, --help        Show this help message.
+EOF
+}
+
+fail() {
+	echo "Error: $*" >&2
+	exit 1
+}
+
+on_error() {
+	local exit_code=$?
+	trap - ERR
+	echo "Failed during: ${current_step}" >&2
+	echo "Inspect the environment with: ${BASH_SOURCE[0]} status${AWS_PROFILE:+ --profile ${AWS_PROFILE}}" >&2
+	echo "Remove it with: ${BASH_SOURCE[0]} down${AWS_PROFILE:+ --profile ${AWS_PROFILE}}" >&2
+	exit "$exit_code"
+}
+
+trap on_error ERR
+
+require_command() {
+	local command_name="$1"
+	command -v "$command_name" >/dev/null 2>&1 || fail "Required command is not installed: ${command_name}"
+}
+
+run_step() {
+	current_step="$1"
+	shift
+	echo
+	echo "==> ${current_step}"
+	"$@"
+}
+
+read_environment_value() {
+	local name="$1"
+	local line
+	line="$(grep -E "^${name}=" "$environment_file" | tail -n 1 || true)"
+	printf '%s' "${line#*=}"
+}
+
+prepare_local_files() {
+	if [[ ! -f "$terraform_vars" ]]; then
+		cp "$terraform_vars_example" "$terraform_vars"
+		echo "Created ${terraform_vars#${repository_root}/}."
+		created_local_files=true
+	fi
+
+	if [[ ! -f "$environment_file" ]]; then
+		cp "$environment_example" "$environment_file"
+		chmod 600 "$environment_file"
+		echo "Created ${environment_file#${repository_root}/}."
+		created_local_files=true
+	fi
+}
+
+verify_clean_worktree() {
+	local changes
+	changes="$(git -C "$repository_root" status --porcelain --untracked-files=normal)"
+	if [[ -n "$changes" ]]; then
+		echo "Uncommitted files:" >&2
+		echo "$changes" >&2
+		fail "Commit or remove local changes before publishing a commit-tagged image."
+	fi
+}
+
+set_application_image_tag() {
+	local image_tag
+	local temporary_file
+	image_tag="$(git -C "$repository_root" rev-parse --short=12 HEAD)"
+	temporary_file="$(mktemp)"
+
+	awk -v image_tag="$image_tag" '
+		/^app_image_tag[[:space:]]*=/ { print "app_image_tag = \"" image_tag "\""; found = 1; next }
+		{ print }
+		END { if (!found) print "app_image_tag = \"" image_tag "\"" }
+	' "$terraform_vars" >"$temporary_file"
+
+	mv "$temporary_file" "$terraform_vars"
+	echo "Application image tag: ${image_tag}"
+}
+
+
+explain_created_local_files() {
+	if [[ "$created_local_files" == true ]]; then
+		cat <<EOF
+Fill the generated files and run the command again.
+- terraform.tfvars: use a unique test_run_id if the default can conflict
+- .env.app: SPRING_DATA_MONGODB_URI, JWT_SECRET, and IMPORT_API_KEY
+EOF
+		exit 2
+	fi
+}
+
+validate_local_files() {
+	local name
+	local value
+	for name in SPRING_DATA_MONGODB_URI JWT_SECRET IMPORT_API_KEY; do
+		value="$(read_environment_value "$name")"
+		if [[ -z "$value" || "$value" == *replace-me* || "$value" == replace-with-generated-* ]]; then
+			fail "Set ${name} in ${environment_file#${repository_root}/}."
+		fi
+	done
+}
+
+configure_aws_profile() {
+	local requested_profile="$1"
+
+	if [[ -n "$requested_profile" ]]; then
+		if ! aws configure list-profiles | grep -Fxq "$requested_profile"; then
+			echo "Available AWS profiles:" >&2
+			aws configure list-profiles >&2
+			fail "AWS profile does not exist: ${requested_profile}"
+		fi
+		export AWS_PROFILE="$requested_profile"
+	fi
+}
+
+verify_aws_identity() {
+	local identity
+	if ! identity="$(aws sts get-caller-identity --query '[Account,Arn]' --output text 2>&1)"; then
+		fail "AWS authentication failed${AWS_PROFILE:+ for profile ${AWS_PROFILE}}: ${identity}"
+	fi
+	echo "AWS identity: ${identity}"
+}
+
+initialize_terraform() {
+	terraform -chdir="$platform_dir" init
+	terraform -chdir="$platform_dir" validate
+}
+
+preflight() {
+	local command="$1"
+	current_step="Validate local tools and AWS authentication"
+	require_command aws
+	require_command terraform
+	configure_aws_profile "$profile"
+	verify_aws_identity
+
+	if [[ "$command" == "up" ]]; then
+		require_command docker
+		require_command git
+		[[ -x "${repository_root}/gradlew" ]] || fail "Gradle wrapper is not executable."
+		if ! docker info >/dev/null 2>&1; then
+			fail "Docker is not running."
+		fi
+		verify_clean_worktree
+		prepare_local_files
+		set_application_image_tag
+		explain_created_local_files
+		validate_local_files
+	elif [[ "$command" == "down" && ! -f "$terraform_vars" ]]; then
+		fail "Terraform variables not found: ${terraform_vars#${repository_root}/}"
+	fi
+
+	initialize_terraform
+}
+
+terraform_state_exists() {
+	local state
+	if ! state="$(terraform -chdir="$platform_dir" state list)"; then
+		fail "Failed to read Terraform state."
+	fi
+	[[ -n "$state" ]]
+}
+
+run_up() {
+	preflight up
+	echo
+	echo "Terraform will use targeted applies only to bootstrap ECR and S3 before the full apply."
+	echo "Ensure the Atlas test allowlist is open for this temporary public-IP environment."
+
+	if [[ "$auto_approve" == true ]]; then
+		export TF_CLI_ARGS_apply="${TF_CLI_ARGS_apply:+${TF_CLI_ARGS_apply} }-auto-approve"
+	fi
+
+	run_step "Publish application image" "${script_dir}/publish-app-image.sh" "$platform_dir"
+	run_step "Upload application environment" "${script_dir}/upload-app-environment.sh" "$platform_dir"
+	run_step "Create phase-two infrastructure" terraform -chdir="$platform_dir" apply
+	run_step "Verify phase-two connectivity" "${script_dir}/verify-phase-two.sh" "$platform_dir"
+
+	echo
+	echo "Phase-two environment is ready."
+}
+
+run_verify() {
+	preflight verify
+	terraform_state_exists || fail "No Terraform-managed performance-test environment exists."
+	run_step "Verify phase-two connectivity" "${script_dir}/verify-phase-two.sh" "$platform_dir"
+}
+
+run_status() {
+	preflight status
+
+	if ! terraform_state_exists; then
+		echo "No Terraform-managed performance-test resources exist."
+		return
+	fi
+
+	echo
+	echo "Managed resources:"
+	terraform -chdir="$platform_dir" state list
+
+	echo
+	echo "Outputs:"
+	terraform -chdir="$platform_dir" output
+
+	local target_group_arn
+	if target_group_arn="$(terraform -chdir="$platform_dir" output -raw target_group_arn 2>/dev/null)" && \
+		[[ -n "$target_group_arn" ]]; then
+		local region
+		region="$(terraform -chdir="$platform_dir" output -raw aws_region)"
+		echo
+		echo "ALB target health:"
+		aws elbv2 describe-target-health \
+			--region "$region" \
+			--target-group-arn "$target_group_arn" \
+			--query 'TargetHealthDescriptions[].{target:Target.Id,state:TargetHealth.State,reason:TargetHealth.Reason}' \
+			--output table
+	else
+		echo
+		echo "ALB target group has not been created yet."
+	fi
+}
+
+run_down() {
+	preflight down
+
+	if ! terraform_state_exists; then
+		rm -f "$environment_file"
+		echo "No Terraform-managed performance-test resources exist."
+		return
+	fi
+
+	current_step="Remove application environment file"
+	if ! "${script_dir}/cleanup-app-environment.sh" "$platform_dir"; then
+		echo "Environment-file cleanup failed; Terraform destroy will continue." >&2
+	fi
+
+	current_step="Destroy phase-two infrastructure"
+	if [[ "$auto_approve" == true ]]; then
+		terraform -chdir="$platform_dir" destroy -auto-approve
+	else
+		terraform -chdir="$platform_dir" destroy
+	fi
+
+	current_step="Confirm Terraform state is empty"
+	if terraform_state_exists; then
+		echo "Resources remain in Terraform state:" >&2
+		terraform -chdir="$platform_dir" state list >&2
+		return 1
+	fi
+
+	echo
+	echo "Phase-two environment was removed. Close the temporary Atlas IP allowlist."
+}
+
+command_name="${1:-}"
+if [[ -z "$command_name" ]]; then
+	usage
+	exit 1
+fi
+shift
+
+profile=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--profile)
+			[[ $# -ge 2 ]] || fail "--profile requires a value."
+			profile="$2"
+			shift 2
+			;;
+		--yes)
+			auto_approve=true
+			shift
+			;;
+		-h | --help)
+			usage
+			exit 0
+			;;
+		*)
+			fail "Unknown option: $1"
+			;;
+	esac
+done
+
+cd "$repository_root"
+
+case "$command_name" in
+	up)
+		run_up
+		;;
+	verify)
+		run_verify
+		;;
+	status)
+		run_status
+		;;
+	down)
+		run_down
+		;;
+	-h | --help | help)
+		usage
+		;;
+	*)
+		usage >&2
+		fail "Unknown command: ${command_name}"
+		;;
+esac

--- a/infra/performance-test/run/performance-test.sh
+++ b/infra/performance-test/run/performance-test.sh
@@ -66,6 +66,29 @@ read_environment_value() {
 	printf '%s' "${line#*=}"
 }
 
+validate_jwt_secret() {
+	local secret="$1"
+	local unpadded_secret
+	local padding_length
+	local decoded_length
+
+	if [[ ! "$secret" =~ ^[A-Za-z0-9+/]+={0,2}$ ]]; then
+		fail "JWT_SECRET must be a Base64-encoded HMAC key."
+	fi
+
+	unpadded_secret="${secret%%=*}"
+	padding_length=$(( ${#secret} - ${#unpadded_secret} ))
+	if (( ${#unpadded_secret} % 4 == 1 )) || \
+		(( padding_length > 0 && ${#secret} % 4 != 0 )); then
+		fail "JWT_SECRET must be valid Base64."
+	fi
+
+	decoded_length=$(( ${#unpadded_secret} * 6 / 8 ))
+	if (( decoded_length < 32 )); then
+		fail "JWT_SECRET must decode to at least 32 bytes for HMAC-SHA."
+	fi
+}
+
 prepare_local_files() {
 	if [[ ! -f "$terraform_vars" ]]; then
 		cp "$terraform_vars_example" "$terraform_vars"
@@ -128,6 +151,8 @@ validate_local_files() {
 			fail "Set ${name} in ${environment_file#${repository_root}/}."
 		fi
 	done
+
+	validate_jwt_secret "$(read_environment_value JWT_SECRET)"
 }
 
 configure_aws_profile() {
@@ -165,9 +190,13 @@ preflight() {
 	verify_aws_identity
 
 	if [[ "$command" == "up" ]]; then
+		local gradle_output
 		require_command docker
 		require_command git
 		[[ -x "${repository_root}/gradlew" ]] || fail "Gradle wrapper is not executable."
+		if ! gradle_output="$("${repository_root}/gradlew" --version 2>&1)"; then
+			fail "Gradle wrapper cannot run: ${gradle_output}"
+		fi
 		if ! docker info >/dev/null 2>&1; then
 			fail "Docker is not running."
 		fi


### PR DESCRIPTION
## Summary
성능 테스트 환경의 생성, 검증, 상태 확인, 제거 절차를 하나의 lifecycle runner로 통합했습니다.

## Problem
기존에는 이미지 게시, 환경 파일 업로드, Terraform 적용, 연결 검증과 제거 명령을 사용자가 순서대로 직접 실행해야 했습니다. 첫 명령이 실패해도 다음 명령이 계속 실행되어 원인과 무관한 연쇄 오류가 발생할 수 있었고, 존재하지 않는 AWS profile이나 누락된 환경 파일도 Terraform 실행 이후에 발견됐습니다.

## Solution
`performance-test.sh`를 단일 진입점으로 추가하고 `up`, `verify`, `status`, `down` 명령으로 전체 수명주기를 관리합니다. 실행 전에 AWS 인증, Docker, Terraform, Git, Gradle과 로컬 설정을 검증하며 한 단계가 실패하면 즉시 중단합니다.

## Changes
- `up`: ECR 이미지 게시, S3 환경 파일 업로드, Terraform apply, 2단계 연결 검증 실행
- `verify`: 기존 환경의 ALB, Redis, MySQL, WireMock, k6 연결 재검증
- `status`: Terraform state, output, ALB target health 확인
- `down`: 환경 파일과 인프라 제거 후 state가 비었는지 확인
- `--profile`과 `--yes` 옵션 지원
- 누락된 로컬 설정 파일 자동 생성과 필수 값 검사
- 현재 commit SHA를 이미지 태그에 자동 반영
- dirty worktree에서 commit 태그 이미지 게시 차단
- AWS SSO source profile 설정 및 단일 실행 흐름 문서화

## Example
```bash
./infra/performance-test/run/performance-test.sh up --profile solfe-api
./infra/performance-test/run/performance-test.sh status --profile solfe-api
./infra/performance-test/run/performance-test.sh down --profile solfe-api
```

검증:
- `bash -n infra/performance-test/run/performance-test.sh`
- `terraform validate`
- 잘못된 AWS profile의 조기 실패 확인
- 실제 `solfe-api` 인증 및 빈 state의 `status`, `down` 확인
- 저장소 외부 작업 디렉터리에서 `--help` 실행 확인

Atlas 테스트 URI와 AWS 비용이 필요한 전체 `up` 실행은 수행하지 않았습니다.

## Related Issues
없음