### PR TITLE
feat(word): cache single-flight results

### DIFF
--- a/src/main/java/com/linglevel/api/word/config/WordSingleFlightProperties.java
+++ b/src/main/java/com/linglevel/api/word/config/WordSingleFlightProperties.java
@@ -15,6 +15,8 @@ public class WordSingleFlightProperties {
 
 	private long waitTimeoutMs = 5_000;
 
+	private long resultCacheTtlMs = 30_000;
+
 	private String resultSchemaVersion = "v2";
 
 }

--- a/src/main/java/com/linglevel/api/word/service/WordService.java
+++ b/src/main/java/com/linglevel/api/word/service/WordService.java
@@ -1,5 +1,6 @@
 package com.linglevel.api.word.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.linglevel.api.bookmark.repository.WordBookmarkRepository;
 import com.linglevel.api.i18n.LanguageCode;
 import com.linglevel.api.word.dto.WordAnalysisResult;
@@ -24,6 +25,12 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class WordService {
+
+	private static final TypeReference<Word> WORD_RESULT_TYPE = new TypeReference<>() {
+	};
+
+	private static final TypeReference<List<WordVariant>> WORD_VARIANT_RESULT_TYPE = new TypeReference<>() {
+	};
 
 	private final WordRepository wordRepository;
 
@@ -74,7 +81,8 @@ public class WordService {
 		return wordRepository.findByWordAndTargetLanguageCode(originalForm, targetLanguage)
 			.orElseGet(() -> singleFlightCoordinator.execute(originalForm, targetLanguage,
 					() -> analyzeAndSaveOriginalWord(originalForm, targetLanguage),
-					() -> wordRepository.findByWordAndTargetLanguageCode(originalForm, targetLanguage)));
+					() -> wordRepository.findByWordAndTargetLanguageCode(originalForm, targetLanguage),
+					WORD_RESULT_TYPE));
 	}
 
 	private Word analyzeAndSaveOriginalWord(String originalForm, LanguageCode targetLanguage) {
@@ -105,7 +113,8 @@ public class WordService {
 		return singleFlightCoordinator.execute(word, targetLanguage, () -> {
 			List<WordAnalysisResult> analysisResults = analyzeWordAndUpdateInvalidCache(word, targetLanguage);
 			return wordPersistenceService.saveAnalysisResults(word, analysisResults, cachedInvalidWord);
-		}, () -> findWordVariantsAfterSingleFlight(word, invalidAttemptCountBeforeSingleFlight));
+		}, () -> findWordVariantsAfterSingleFlight(word, invalidAttemptCountBeforeSingleFlight),
+				WORD_VARIANT_RESULT_TYPE);
 	}
 
 	private Optional<List<WordVariant>> findWordVariantsAfterSingleFlight(String word,

--- a/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
+++ b/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
@@ -2,7 +2,6 @@ package com.linglevel.api.word.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linglevel.api.i18n.LanguageCode;
 import com.linglevel.api.word.config.WordSingleFlightProperties;
@@ -29,7 +28,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -50,6 +48,8 @@ public class WordSingleFlightRedisCoordinator {
 
 	private static final String DONE_PREFIX = "sf:word:done";
 
+	private static final String RESULT_PREFIX = "sf:word:result";
+
 	private static final String DONE_PATTERN = DONE_PREFIX + ":*";
 
 	private final StringRedisTemplate stringRedisTemplate;
@@ -64,7 +64,7 @@ public class WordSingleFlightRedisCoordinator {
 
 	private final WordGenerationMetrics metrics;
 
-	private final ConcurrentHashMap<String, CopyOnWriteArrayList<CompletableFuture<CompletionSignal>>> channelWaiters = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<String, CopyOnWriteArrayList<CompletableFuture<Void>>> channelWaiters = new ConcurrentHashMap<>();
 
 	private final PatternTopic doneTopic = new PatternTopic(DONE_PATTERN);
 
@@ -122,7 +122,7 @@ public class WordSingleFlightRedisCoordinator {
 
 		if (existing.isPresent()) {
 			metrics.recordSingleFlightRequest("lookup", "existing");
-			releaseThenPublishDone(keys, lock, existing.get());
+			cacheThenPublishDoneAndRelease(keys, lock, existing.get());
 			return existing.get();
 		}
 
@@ -164,23 +164,29 @@ public class WordSingleFlightRedisCoordinator {
 
 	private <T> T waitAsFollower(KeySet keys, RLock lock, Supplier<T> leaderAction,
 			Supplier<Optional<T>> followerResultLookup, TypeReference<T> resultType) {
-		CompletableFuture<CompletionSignal> signal = new CompletableFuture<>();
+		CompletableFuture<Void> signal = new CompletableFuture<>();
 		Timer.Sample waitSample = metrics.startFollowerWait();
 		registerWaiter(keys.channel(), signal);
 
 		try {
+			T cachedResult = findCachedResult(keys, resultType);
+			if (cachedResult != null) {
+				metrics.recordSingleFlightRequest("follower", "success");
+				return cachedResult;
+			}
+
 			boolean lockAcquiredAfterRegister = tryAcquireLeaderLock(lock);
 			if (lockAcquiredAfterRegister) {
 				metrics.recordFollowerWait(waitSample, "promoted");
 				return executeWithLeaderLock(keys, lock, leaderAction, followerResultLookup, resultType);
 			}
 
-			CompletionSignal completionSignal = signal.get(properties.getWaitTimeoutMs(), TimeUnit.MILLISECONDS);
+			signal.get(properties.getWaitTimeoutMs(), TimeUnit.MILLISECONDS);
 			metrics.recordFollowerWait(waitSample, "signaled");
-			T sharedResult = deserializeSharedResult(completionSignal, resultType);
-			if (sharedResult != null) {
+			T cachedResultAfterSignal = findCachedResult(keys, resultType);
+			if (cachedResultAfterSignal != null) {
 				metrics.recordSingleFlightRequest("follower", "success");
-				return sharedResult;
+				return cachedResultAfterSignal;
 			}
 		}
 		catch (TimeoutException e) {
@@ -219,14 +225,14 @@ public class WordSingleFlightRedisCoordinator {
 
 	private void completeLeaderAfterCommit(KeySet keys, RLock lock, Object result) {
 		if (!TransactionSynchronizationManager.isSynchronizationActive()) {
-			releaseThenPublishDone(keys, lock, result);
+			cacheThenPublishDoneAndRelease(keys, lock, result);
 			return;
 		}
 
 		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
 			@Override
 			public void afterCommit() {
-				releaseThenPublishDone(keys, lock, result);
+				cacheThenPublishDoneAndRelease(keys, lock, result);
 			}
 
 			@Override
@@ -240,25 +246,37 @@ public class WordSingleFlightRedisCoordinator {
 
 	private void completeLeaderAfterCompletion(KeySet keys, RLock lock) {
 		if (!TransactionSynchronizationManager.isSynchronizationActive()) {
-			releaseThenPublishDone(keys, lock, null);
+			publishDoneAndRelease(keys, lock);
 			return;
 		}
 
 		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
 			@Override
 			public void afterCompletion(int status) {
-				releaseThenPublishDone(keys, lock, null);
+				publishDoneAndRelease(keys, lock);
 			}
 		});
 	}
 
-	private void releaseThenPublishDone(KeySet keys, RLock lock, Object result) {
-		releaseLock(lock, keys.lockKey());
-		publishDone(keys.channel(), result);
+	private void cacheThenPublishDoneAndRelease(KeySet keys, RLock lock, Object result) {
+		try {
+			cacheResult(keys.resultKey(), result);
+		}
+		catch (RuntimeException e) {
+			log.warn("Failed to cache single-flight result key={}. Followers will fall back to DB lookup.",
+					keys.resultKey(), e);
+		}
+
+		publishDoneAndRelease(keys, lock);
 	}
 
-	private void publishDone(String channel, Object result) {
-		stringRedisTemplate.convertAndSend(channel, createCompletionMessage(result));
+	private void publishDoneAndRelease(KeySet keys, RLock lock) {
+		try {
+			stringRedisTemplate.convertAndSend(keys.channel(), "{\"status\":\"done\"}");
+		}
+		finally {
+			releaseLock(lock, keys.lockKey());
+		}
 	}
 
 	private void releaseLock(RLock lock, String lockKey) {
@@ -279,16 +297,16 @@ public class WordSingleFlightRedisCoordinator {
 		return redissonClient.getLock(lockKey);
 	}
 
-	private void registerWaiter(String channel, CompletableFuture<CompletionSignal> signal) {
+	private void registerWaiter(String channel, CompletableFuture<Void> signal) {
 		channelWaiters.compute(channel, (key, waiters) -> {
-			CopyOnWriteArrayList<CompletableFuture<CompletionSignal>> values = waiters == null
-					? new CopyOnWriteArrayList<>() : waiters;
+			CopyOnWriteArrayList<CompletableFuture<Void>> values = waiters == null ? new CopyOnWriteArrayList<>()
+					: waiters;
 			values.add(signal);
 			return values;
 		});
 	}
 
-	private void unregisterWaiter(String channel, CompletableFuture<CompletionSignal> signal) {
+	private void unregisterWaiter(String channel, CompletableFuture<Void> signal) {
 		channelWaiters.computeIfPresent(channel, (key, waiters) -> {
 			waiters.remove(signal);
 			return waiters.isEmpty() ? null : waiters;
@@ -297,54 +315,39 @@ public class WordSingleFlightRedisCoordinator {
 
 	private void onDoneMessage(Message message, byte[] pattern) {
 		String channel = new String(message.getChannel(), StandardCharsets.UTF_8);
-		List<CompletableFuture<CompletionSignal>> waiters = channelWaiters.remove(channel);
+		List<CompletableFuture<Void>> waiters = channelWaiters.remove(channel);
 		if (waiters == null || waiters.isEmpty()) {
 			return;
 		}
 
-		CompletionSignal completionSignal = parseCompletionSignal(message);
-		for (CompletableFuture<CompletionSignal> waiter : waiters) {
-			waiter.complete(completionSignal);
+		for (CompletableFuture<Void> waiter : waiters) {
+			waiter.complete(null);
 		}
 	}
 
-	private String createCompletionMessage(Object result) {
-		if (result == null) {
-			return "{\"status\":\"done\"}";
-		}
-
+	private void cacheResult(String resultKey, Object result) {
 		try {
-			return objectMapper.writeValueAsString(Map.of("status", "success", "result", result));
+			String serializedResult = objectMapper.writeValueAsString(result);
+			stringRedisTemplate.opsForValue()
+				.set(resultKey, serializedResult, properties.getResultCacheTtlMs(), TimeUnit.MILLISECONDS);
 		}
 		catch (JsonProcessingException e) {
-			log.warn("Failed to serialize single-flight completion result. Falling back to DB lookup.", e);
-			return "{\"status\":\"done\"}";
+			throw new IllegalStateException("Failed to serialize single-flight result", e);
 		}
 	}
 
-	private CompletionSignal parseCompletionSignal(Message message) {
-		try {
-			JsonNode root = objectMapper.readTree(new String(message.getBody(), StandardCharsets.UTF_8));
-			JsonNode result = root.path("result");
-			return result.isMissingNode() || result.isNull() ? CompletionSignal.withoutResult()
-					: CompletionSignal.withResult(result);
-		}
-		catch (JsonProcessingException e) {
-			log.warn("Failed to parse single-flight completion message. Falling back to DB lookup.", e);
-			return CompletionSignal.withoutResult();
-		}
-	}
-
-	private <T> T deserializeSharedResult(CompletionSignal completionSignal, TypeReference<T> resultType) {
-		if (!completionSignal.hasResult() || resultType == null) {
+	private <T> T findCachedResult(KeySet keys, TypeReference<T> resultType) {
+		if (resultType == null) {
 			return null;
 		}
 
 		try {
-			return objectMapper.convertValue(completionSignal.result(), resultType);
+			String serializedResult = stringRedisTemplate.opsForValue().get(keys.resultKey());
+			return serializedResult == null ? null : objectMapper.readValue(serializedResult, resultType);
 		}
-		catch (IllegalArgumentException e) {
-			log.warn("Failed to deserialize single-flight completion result. Falling back to DB lookup.", e);
+		catch (RuntimeException | JsonProcessingException e) {
+			log.warn("Failed to read single-flight result cache key={}. Falling back to DB lookup.", keys.resultKey(),
+					e);
 			return null;
 		}
 	}
@@ -357,7 +360,7 @@ public class WordSingleFlightRedisCoordinator {
 		String digest = sha256(canonicalKey);
 		String suffix = properties.getResultSchemaVersion() + ":" + digest;
 
-		return new KeySet(LOCK_PREFIX + ":" + suffix, DONE_PREFIX + ":" + suffix, digest);
+		return new KeySet(LOCK_PREFIX + ":" + suffix, DONE_PREFIX + ":" + suffix, RESULT_PREFIX + ":" + suffix, digest);
 	}
 
 	private String sha256(String value) {
@@ -371,22 +374,7 @@ public class WordSingleFlightRedisCoordinator {
 		}
 	}
 
-	private record KeySet(String lockKey, String channel, String digest) {
-	}
-
-	private record CompletionSignal(JsonNode result) {
-
-		static CompletionSignal withResult(JsonNode result) {
-			return new CompletionSignal(result);
-		}
-
-		static CompletionSignal withoutResult() {
-			return new CompletionSignal(null);
-		}
-
-		boolean hasResult() {
-			return result != null;
-		}
+	private record KeySet(String lockKey, String channel, String resultKey, String digest) {
 	}
 
 }

--- a/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
+++ b/src/main/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinator.java
@@ -1,5 +1,9 @@
 package com.linglevel.api.word.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linglevel.api.i18n.LanguageCode;
 import com.linglevel.api.word.config.WordSingleFlightProperties;
 import com.linglevel.api.word.exception.WordsErrorCode;
@@ -25,6 +29,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -49,6 +54,8 @@ public class WordSingleFlightRedisCoordinator {
 
 	private final StringRedisTemplate stringRedisTemplate;
 
+	private final ObjectMapper objectMapper;
+
 	private final RedisMessageListenerContainer redisMessageListenerContainer;
 
 	private final RedissonClient redissonClient;
@@ -57,7 +64,7 @@ public class WordSingleFlightRedisCoordinator {
 
 	private final WordGenerationMetrics metrics;
 
-	private final ConcurrentHashMap<String, CopyOnWriteArrayList<CompletableFuture<Void>>> channelWaiters = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<String, CopyOnWriteArrayList<CompletableFuture<CompletionSignal>>> channelWaiters = new ConcurrentHashMap<>();
 
 	private final PatternTopic doneTopic = new PatternTopic(DONE_PATTERN);
 
@@ -75,6 +82,11 @@ public class WordSingleFlightRedisCoordinator {
 
 	public <T> T execute(String word, LanguageCode targetLanguage, Supplier<T> leaderAction,
 			Supplier<Optional<T>> followerResultLookup) {
+		return execute(word, targetLanguage, leaderAction, followerResultLookup, null);
+	}
+
+	public <T> T execute(String word, LanguageCode targetLanguage, Supplier<T> leaderAction,
+			Supplier<Optional<T>> followerResultLookup, TypeReference<T> resultType) {
 		if (!properties.isEnabled()) {
 			try {
 				T result = leaderAction.get();
@@ -91,14 +103,14 @@ public class WordSingleFlightRedisCoordinator {
 		RLock lock = createLock(keys.lockKey());
 		boolean lockAcquired = tryAcquireLeaderLock(lock);
 		if (lockAcquired) {
-			return executeWithLeaderLock(keys, lock, leaderAction, followerResultLookup);
+			return executeWithLeaderLock(keys, lock, leaderAction, followerResultLookup, resultType);
 		}
 
-		return waitAsFollower(keys, lock, leaderAction, followerResultLookup);
+		return waitAsFollower(keys, lock, leaderAction, followerResultLookup, resultType);
 	}
 
 	private <T> T executeWithLeaderLock(KeySet keys, RLock lock, Supplier<T> leaderAction,
-			Supplier<Optional<T>> followerResultLookup) {
+			Supplier<Optional<T>> followerResultLookup, TypeReference<T> resultType) {
 		Optional<T> existing;
 		try {
 			existing = followerResultLookup.get();
@@ -110,7 +122,7 @@ public class WordSingleFlightRedisCoordinator {
 
 		if (existing.isPresent()) {
 			metrics.recordSingleFlightRequest("lookup", "existing");
-			releaseThenPublishDone(keys, lock);
+			releaseThenPublishDone(keys, lock, existing.get());
 			return existing.get();
 		}
 
@@ -129,7 +141,7 @@ public class WordSingleFlightRedisCoordinator {
 			throw e;
 		}
 
-		completeLeaderAfterCommit(keys, lock);
+		completeLeaderAfterCommit(keys, lock, result);
 		return result;
 	}
 
@@ -151,8 +163,8 @@ public class WordSingleFlightRedisCoordinator {
 	}
 
 	private <T> T waitAsFollower(KeySet keys, RLock lock, Supplier<T> leaderAction,
-			Supplier<Optional<T>> followerResultLookup) {
-		CompletableFuture<Void> signal = new CompletableFuture<>();
+			Supplier<Optional<T>> followerResultLookup, TypeReference<T> resultType) {
+		CompletableFuture<CompletionSignal> signal = new CompletableFuture<>();
 		Timer.Sample waitSample = metrics.startFollowerWait();
 		registerWaiter(keys.channel(), signal);
 
@@ -160,11 +172,16 @@ public class WordSingleFlightRedisCoordinator {
 			boolean lockAcquiredAfterRegister = tryAcquireLeaderLock(lock);
 			if (lockAcquiredAfterRegister) {
 				metrics.recordFollowerWait(waitSample, "promoted");
-				return executeWithLeaderLock(keys, lock, leaderAction, followerResultLookup);
+				return executeWithLeaderLock(keys, lock, leaderAction, followerResultLookup, resultType);
 			}
 
-			signal.get(properties.getWaitTimeoutMs(), TimeUnit.MILLISECONDS);
+			CompletionSignal completionSignal = signal.get(properties.getWaitTimeoutMs(), TimeUnit.MILLISECONDS);
 			metrics.recordFollowerWait(waitSample, "signaled");
+			T sharedResult = deserializeSharedResult(completionSignal, resultType);
+			if (sharedResult != null) {
+				metrics.recordSingleFlightRequest("follower", "success");
+				return sharedResult;
+			}
 		}
 		catch (TimeoutException e) {
 			metrics.recordFollowerWait(waitSample, "timeout");
@@ -200,16 +217,16 @@ public class WordSingleFlightRedisCoordinator {
 		throw new WordsException(WordsErrorCode.WORD_ANALYSIS_TIMEOUT);
 	}
 
-	private void completeLeaderAfterCommit(KeySet keys, RLock lock) {
+	private void completeLeaderAfterCommit(KeySet keys, RLock lock, Object result) {
 		if (!TransactionSynchronizationManager.isSynchronizationActive()) {
-			releaseThenPublishDone(keys, lock);
+			releaseThenPublishDone(keys, lock, result);
 			return;
 		}
 
 		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
 			@Override
 			public void afterCommit() {
-				releaseThenPublishDone(keys, lock);
+				releaseThenPublishDone(keys, lock, result);
 			}
 
 			@Override
@@ -223,25 +240,25 @@ public class WordSingleFlightRedisCoordinator {
 
 	private void completeLeaderAfterCompletion(KeySet keys, RLock lock) {
 		if (!TransactionSynchronizationManager.isSynchronizationActive()) {
-			releaseThenPublishDone(keys, lock);
+			releaseThenPublishDone(keys, lock, null);
 			return;
 		}
 
 		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
 			@Override
 			public void afterCompletion(int status) {
-				releaseThenPublishDone(keys, lock);
+				releaseThenPublishDone(keys, lock, null);
 			}
 		});
 	}
 
-	private void releaseThenPublishDone(KeySet keys, RLock lock) {
+	private void releaseThenPublishDone(KeySet keys, RLock lock, Object result) {
 		releaseLock(lock, keys.lockKey());
-		publishDone(keys.channel());
+		publishDone(keys.channel(), result);
 	}
 
-	private void publishDone(String channel) {
-		stringRedisTemplate.convertAndSend(channel, "done");
+	private void publishDone(String channel, Object result) {
+		stringRedisTemplate.convertAndSend(channel, createCompletionMessage(result));
 	}
 
 	private void releaseLock(RLock lock, String lockKey) {
@@ -262,16 +279,16 @@ public class WordSingleFlightRedisCoordinator {
 		return redissonClient.getLock(lockKey);
 	}
 
-	private void registerWaiter(String channel, CompletableFuture<Void> signal) {
+	private void registerWaiter(String channel, CompletableFuture<CompletionSignal> signal) {
 		channelWaiters.compute(channel, (key, waiters) -> {
-			CopyOnWriteArrayList<CompletableFuture<Void>> values = waiters == null ? new CopyOnWriteArrayList<>()
-					: waiters;
+			CopyOnWriteArrayList<CompletableFuture<CompletionSignal>> values = waiters == null
+					? new CopyOnWriteArrayList<>() : waiters;
 			values.add(signal);
 			return values;
 		});
 	}
 
-	private void unregisterWaiter(String channel, CompletableFuture<Void> signal) {
+	private void unregisterWaiter(String channel, CompletableFuture<CompletionSignal> signal) {
 		channelWaiters.computeIfPresent(channel, (key, waiters) -> {
 			waiters.remove(signal);
 			return waiters.isEmpty() ? null : waiters;
@@ -280,13 +297,55 @@ public class WordSingleFlightRedisCoordinator {
 
 	private void onDoneMessage(Message message, byte[] pattern) {
 		String channel = new String(message.getChannel(), StandardCharsets.UTF_8);
-		List<CompletableFuture<Void>> waiters = channelWaiters.remove(channel);
+		List<CompletableFuture<CompletionSignal>> waiters = channelWaiters.remove(channel);
 		if (waiters == null || waiters.isEmpty()) {
 			return;
 		}
 
-		for (CompletableFuture<Void> waiter : waiters) {
-			waiter.complete(null);
+		CompletionSignal completionSignal = parseCompletionSignal(message);
+		for (CompletableFuture<CompletionSignal> waiter : waiters) {
+			waiter.complete(completionSignal);
+		}
+	}
+
+	private String createCompletionMessage(Object result) {
+		if (result == null) {
+			return "{\"status\":\"done\"}";
+		}
+
+		try {
+			return objectMapper.writeValueAsString(Map.of("status", "success", "result", result));
+		}
+		catch (JsonProcessingException e) {
+			log.warn("Failed to serialize single-flight completion result. Falling back to DB lookup.", e);
+			return "{\"status\":\"done\"}";
+		}
+	}
+
+	private CompletionSignal parseCompletionSignal(Message message) {
+		try {
+			JsonNode root = objectMapper.readTree(new String(message.getBody(), StandardCharsets.UTF_8));
+			JsonNode result = root.path("result");
+			return result.isMissingNode() || result.isNull() ? CompletionSignal.withoutResult()
+					: CompletionSignal.withResult(result);
+		}
+		catch (JsonProcessingException e) {
+			log.warn("Failed to parse single-flight completion message. Falling back to DB lookup.", e);
+			return CompletionSignal.withoutResult();
+		}
+	}
+
+	private <T> T deserializeSharedResult(CompletionSignal completionSignal, TypeReference<T> resultType) {
+		if (!completionSignal.hasResult() || resultType == null) {
+			return null;
+		}
+
+		try {
+			return objectMapper.convertValue(completionSignal.result(), resultType);
+		}
+		catch (IllegalArgumentException e) {
+			log.warn("Failed to deserialize single-flight completion result. Falling back to DB lookup.", e);
+			return null;
 		}
 	}
 
@@ -313,6 +372,21 @@ public class WordSingleFlightRedisCoordinator {
 	}
 
 	private record KeySet(String lockKey, String channel, String digest) {
+	}
+
+	private record CompletionSignal(JsonNode result) {
+
+		static CompletionSignal withResult(JsonNode result) {
+			return new CompletionSignal(result);
+		}
+
+		static CompletionSignal withoutResult() {
+			return new CompletionSignal(null);
+		}
+
+		boolean hasResult() {
+			return result != null;
+		}
 	}
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -66,6 +66,7 @@ spring.data.redis.ssl.enabled=false
 # Word single-flight (Redis lock + Pub/Sub + DB lookup fallback)
 word.single-flight.enabled=true
 word.single-flight.wait-timeout-ms=10000
+word.single-flight.result-cache-ttl-ms=30000
 word.single-flight.result-schema-version=v2
 
 # AWS S3 (AI Input/Output buckets)

--- a/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordServiceTest.java
@@ -1,5 +1,6 @@
 package com.linglevel.api.word.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.linglevel.api.bookmark.repository.WordBookmarkRepository;
 import com.linglevel.api.i18n.LanguageCode;
 import com.linglevel.api.word.dto.*;
@@ -78,7 +79,9 @@ class WordServiceTest {
 				invalidWordRepository, wordAiService, singleFlightCoordinator, wordPersistenceService,
 				wordResponseMapper, wordGenerationMetrics);
 
-		lenient().when(singleFlightCoordinator.execute(anyString(), any(LanguageCode.class), any(), any()))
+		lenient()
+			.when(singleFlightCoordinator.execute(anyString(), any(LanguageCode.class), any(), any(),
+					any(TypeReference.class)))
 			.thenAnswer(invocation -> {
 				Supplier<Optional<?>> lookup = invocation.getArgument(3);
 				Optional<?> existing = lookup.get();
@@ -305,7 +308,7 @@ class WordServiceTest {
 
 		when(wordVariantRepository.findAllByWord(word)).thenReturn(List.of());
 		when(invalidWordRepository.findByWord(word)).thenReturn(Optional.empty());
-		when(singleFlightCoordinator.execute(eq(word), eq(LanguageCode.KO), any(), any()))
+		when(singleFlightCoordinator.execute(eq(word), eq(LanguageCode.KO), any(), any(), any(TypeReference.class)))
 			.thenThrow(new WordsException(WordsErrorCode.WORD_ANALYSIS_TIMEOUT));
 
 		assertThatThrownBy(() -> wordService.getOrCreateWords(userId, word, LanguageCode.KO))
@@ -330,7 +333,8 @@ class WordServiceTest {
 		when(wordVariantRepository.findAllByWord(inputWord)).thenReturn(List.of(wordVariant));
 		when(wordRepository.findByWordAndTargetLanguageCode(originalForm, LanguageCode.KO))
 			.thenReturn(Optional.empty());
-		when(singleFlightCoordinator.execute(eq(originalForm), eq(LanguageCode.KO), any(), any()))
+		when(singleFlightCoordinator.execute(eq(originalForm), eq(LanguageCode.KO), any(), any(),
+				any(TypeReference.class)))
 			.thenThrow(new WordsException(WordsErrorCode.WORD_ANALYSIS_TIMEOUT));
 
 		assertThatThrownBy(() -> wordService.getOrCreateWords(userId, inputWord, LanguageCode.KO))
@@ -455,7 +459,8 @@ class WordServiceTest {
 		when(wordVariantRepository.findAllByWord(inputWord)).thenReturn(List.of(wordVariant));
 		when(wordRepository.findByWordAndTargetLanguageCode(originalForm, LanguageCode.KO))
 			.thenReturn(Optional.empty());
-		when(singleFlightCoordinator.execute(eq(originalForm), eq(LanguageCode.KO), any(), any()))
+		when(singleFlightCoordinator.execute(eq(originalForm), eq(LanguageCode.KO), any(), any(),
+				any(TypeReference.class)))
 			.thenThrow(new WordsException(WordsErrorCode.WORD_IS_MEANINGLESS));
 
 		assertThatThrownBy(() -> wordService.getOrCreateWords(userId, inputWord, LanguageCode.KO))

--- a/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorIntegrationTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.linglevel.api.word.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linglevel.api.common.AbstractRedisTest;
 import com.linglevel.api.i18n.LanguageCode;
 import com.linglevel.api.word.config.WordSingleFlightProperties;
@@ -163,8 +164,9 @@ class WordSingleFlightRedisCoordinatorIntegrationTest extends AbstractRedisTest 
 		properties.setWaitTimeoutMs(waitTimeoutMs);
 		properties.setResultSchemaVersion("v2");
 
-		WordSingleFlightRedisCoordinator coordinator = new WordSingleFlightRedisCoordinator(template, listenerContainer,
-				redissonClient, properties, new WordGenerationMetrics(new SimpleMeterRegistry()));
+		WordSingleFlightRedisCoordinator coordinator = new WordSingleFlightRedisCoordinator(template,
+				new ObjectMapper(), listenerContainer, redissonClient, properties,
+				new WordGenerationMetrics(new SimpleMeterRegistry()));
 		ReflectionTestUtils.invokeMethod(coordinator, "initialize");
 
 		return new CoordinatorFixture(connectionFactory, template, listenerContainer, redissonClient, coordinator);

--- a/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
@@ -1,5 +1,7 @@
 package com.linglevel.api.word.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.linglevel.api.i18n.LanguageCode;
 import com.linglevel.api.word.config.WordSingleFlightProperties;
 import com.linglevel.api.word.dto.WordAnalysisResult;
@@ -16,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.connection.Message;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
@@ -24,6 +27,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -36,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -73,8 +78,8 @@ class WordSingleFlightRedisCoordinatorTest {
 		when(redissonLock.isHeldByCurrentThread()).thenReturn(true);
 
 		meterRegistry = new SimpleMeterRegistry();
-		coordinator = new WordSingleFlightRedisCoordinator(stringRedisTemplate, redisMessageListenerContainer,
-				redissonClient, properties, new WordGenerationMetrics(meterRegistry));
+		coordinator = new WordSingleFlightRedisCoordinator(stringRedisTemplate, new ObjectMapper(),
+				redisMessageListenerContainer, redissonClient, properties, new WordGenerationMetrics(meterRegistry));
 		ReflectionTestUtils.invokeMethod(coordinator, "initialize");
 	}
 
@@ -124,6 +129,67 @@ class WordSingleFlightRedisCoordinatorTest {
 				.count()).isEqualTo(1);
 			assertThat(meterRegistry.counter("word.single.flight.requests", "role", "follower", "outcome", "success")
 				.count()).isEqualTo(1);
+		}
+		finally {
+			executor.shutdownNow();
+		}
+	}
+
+	@Test
+	@DisplayName("결과 payload를 수신한 follower는 DB 조회 없이 leader 결과를 반환한다")
+	void execute_returnsSharedResultWithoutFollowerLookup() throws Exception {
+		AtomicInteger lockAttempts = new AtomicInteger();
+		CountDownLatch leaderActionEntered = new CountDownLatch(1);
+		CountDownLatch followerWaiting = new CountDownLatch(1);
+		CountDownLatch allowLeaderCompletion = new CountDownLatch(1);
+		AtomicInteger lookupCalls = new AtomicInteger();
+
+		when(redissonLock.tryLock(0, TimeUnit.MILLISECONDS)).thenAnswer(invocation -> {
+			int attempt = lockAttempts.getAndIncrement();
+			if (attempt == 0) {
+				return true;
+			}
+			if (attempt == 2) {
+				followerWaiting.countDown();
+			}
+			return false;
+		});
+		doAnswer(invocation -> {
+			Message message = org.mockito.Mockito.mock(Message.class);
+			when(message.getChannel())
+				.thenReturn(invocation.getArgument(0, String.class).getBytes(StandardCharsets.UTF_8));
+			when(message.getBody())
+				.thenReturn(invocation.getArgument(1, String.class).getBytes(StandardCharsets.UTF_8));
+			ReflectionTestUtils.invokeMethod(coordinator, "onDoneMessage", message, null);
+			return 1L;
+		}).when(stringRedisTemplate).convertAndSend(anyString(), anyString());
+
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		try {
+			Future<String> leader = executor.submit(() -> coordinator.execute("rabbit", LanguageCode.KO, () -> {
+				leaderActionEntered.countDown();
+				await(allowLeaderCompletion);
+				return "shared-result";
+			}, () -> {
+				lookupCalls.incrementAndGet();
+				return Optional.empty();
+			}, new TypeReference<>() {
+			}));
+
+			assertThat(leaderActionEntered.await(1, TimeUnit.SECONDS)).isTrue();
+			Future<String> follower = executor
+				.submit(() -> coordinator.execute("rabbit", LanguageCode.KO, () -> "unexpected-leader-result", () -> {
+					lookupCalls.incrementAndGet();
+					return Optional.empty();
+				}, new TypeReference<>() {
+				}));
+			assertThat(followerWaiting.await(1, TimeUnit.SECONDS)).isTrue();
+
+			allowLeaderCompletion.countDown();
+
+			assertThat(leader.get(1, TimeUnit.SECONDS)).isEqualTo("shared-result");
+			assertThat(follower.get(1, TimeUnit.SECONDS)).isEqualTo("shared-result");
+			assertThat(lookupCalls.get()).isEqualTo(1);
 		}
 		finally {
 			executor.shutdownNow();
@@ -274,6 +340,16 @@ class WordSingleFlightRedisCoordinatorTest {
 	private void sleep(long millis) {
 		try {
 			Thread.sleep(millis);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException(e);
+		}
+	}
+
+	private void await(CountDownLatch latch) {
+		try {
+			latch.await(1, TimeUnit.SECONDS);
 		}
 		catch (InterruptedException e) {
 			Thread.currentThread().interrupt();

--- a/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
+++ b/src/test/java/com/linglevel/api/word/service/WordSingleFlightRedisCoordinatorTest.java
@@ -21,6 +21,7 @@ import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.connection.Message;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -39,6 +40,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
@@ -51,6 +55,9 @@ class WordSingleFlightRedisCoordinatorTest {
 
 	@Mock
 	private StringRedisTemplate stringRedisTemplate;
+
+	@Mock
+	private ValueOperations<String, String> valueOperations;
 
 	@Mock
 	private RedisMessageListenerContainer redisMessageListenerContainer;
@@ -72,7 +79,9 @@ class WordSingleFlightRedisCoordinatorTest {
 		properties = new WordSingleFlightProperties();
 		properties.setEnabled(true);
 		properties.setWaitTimeoutMs(120);
+		properties.setResultCacheTtlMs(30_000);
 		properties.setResultSchemaVersion("v2");
+		when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
 
 		when(redissonClient.getLock(anyString())).thenReturn(redissonLock);
 		when(redissonLock.isHeldByCurrentThread()).thenReturn(true);
@@ -136,13 +145,19 @@ class WordSingleFlightRedisCoordinatorTest {
 	}
 
 	@Test
-	@DisplayName("결과 payload를 수신한 follower는 DB 조회 없이 leader 결과를 반환한다")
-	void execute_returnsSharedResultWithoutFollowerLookup() throws Exception {
+	@DisplayName("완료 신호를 수신한 follower는 결과 cache에서 leader 결과를 반환한다")
+	void execute_returnsCachedResultWithoutFollowerLookup() throws Exception {
 		AtomicInteger lockAttempts = new AtomicInteger();
 		CountDownLatch leaderActionEntered = new CountDownLatch(1);
 		CountDownLatch followerWaiting = new CountDownLatch(1);
 		CountDownLatch allowLeaderCompletion = new CountDownLatch(1);
 		AtomicInteger lookupCalls = new AtomicInteger();
+		AtomicReference<String> cachedResult = new AtomicReference<>();
+		when(valueOperations.get(anyString())).thenAnswer(invocation -> cachedResult.get());
+		doAnswer(invocation -> {
+			cachedResult.set(invocation.getArgument(1, String.class));
+			return null;
+		}).when(valueOperations).set(anyString(), anyString(), anyLong(), any(TimeUnit.class));
 
 		when(redissonLock.tryLock(0, TimeUnit.MILLISECONDS)).thenAnswer(invocation -> {
 			int attempt = lockAttempts.getAndIncrement();
@@ -282,22 +297,23 @@ class WordSingleFlightRedisCoordinatorTest {
 	}
 
 	@Test
-	@DisplayName("leader 완료 시 lock을 해제한 뒤 done을 발행한다")
-	void execute_releasesLeaderLockBeforePublishingDone() {
+	@DisplayName("leader 완료 시 결과를 cache에 저장하고 done을 발행한 뒤 lock을 해제한다")
+	void execute_cachesResultAndPublishesDoneBeforeReleasingLeaderLock() {
 		stubTryLock(true);
 
 		List<WordAnalysisResult> result = coordinator.execute("run", LanguageCode.KO, () -> List.of(sample("run")),
 				Optional::empty);
 
 		assertThat(result).hasSize(1);
-		InOrder inOrder = inOrder(redissonLock, stringRedisTemplate);
-		inOrder.verify(redissonLock).unlock();
+		InOrder inOrder = inOrder(valueOperations, stringRedisTemplate, redissonLock);
+		inOrder.verify(valueOperations).set(anyString(), anyString(), eq(30_000L), eq(TimeUnit.MILLISECONDS));
 		inOrder.verify(stringRedisTemplate).convertAndSend(anyString(), anyString());
+		inOrder.verify(redissonLock).unlock();
 	}
 
 	@Test
-	@DisplayName("done publish가 실패해도 leader lock은 먼저 해제되어 있다")
-	void execute_releasesLeaderLockBeforePublishFailure() {
+	@DisplayName("done publish가 실패해도 leader lock은 해제된다")
+	void execute_releasesLeaderLockWhenPublishFails() {
 		stubTryLock(true);
 
 		RuntimeException publishFailure = new RuntimeException("redis publish failed");
@@ -307,9 +323,10 @@ class WordSingleFlightRedisCoordinatorTest {
 				() -> coordinator.execute("run", LanguageCode.KO, () -> List.of(sample("run")), Optional::empty))
 			.isSameAs(publishFailure);
 
-		InOrder inOrder = inOrder(redissonLock, stringRedisTemplate);
-		inOrder.verify(redissonLock).unlock();
+		InOrder inOrder = inOrder(valueOperations, stringRedisTemplate, redissonLock);
+		inOrder.verify(valueOperations).set(anyString(), anyString(), eq(30_000L), eq(TimeUnit.MILLISECONDS));
 		inOrder.verify(stringRedisTemplate).convertAndSend(anyString(), anyString());
+		inOrder.verify(redissonLock).unlock();
 	}
 
 	@Test
@@ -324,9 +341,10 @@ class WordSingleFlightRedisCoordinatorTest {
 		}, () -> Optional.of(List.of(sample)));
 
 		assertThat(result).hasSize(1);
-		InOrder inOrder = inOrder(redissonLock, stringRedisTemplate);
-		inOrder.verify(redissonLock).unlock();
+		InOrder inOrder = inOrder(valueOperations, stringRedisTemplate, redissonLock);
+		inOrder.verify(valueOperations).set(anyString(), anyString(), eq(30_000L), eq(TimeUnit.MILLISECONDS));
 		inOrder.verify(stringRedisTemplate).convertAndSend(anyString(), anyString());
+		inOrder.verify(redissonLock).unlock();
 	}
 
 	private WordAnalysisResult sample(String originalForm) {


### PR DESCRIPTION
## Summary
Word single-flight follower가 Pub/Sub payload 대신 30초 TTL의 Redis 결과 cache에서 생성 결과를 읽도록 변경했습니다.

## Problem
완료 Pub/Sub 메시지는 영속적이지 않아 메시지 유실 시 결과 payload를 다시 사용할 수 없었습니다. 결과를 전달 채널에 직접 넣는 구조는 늦게 합류한 동일 요청의 재사용도 지원하지 못합니다.

## Solution
leader는 DB 저장이 완료된 뒤 결과를 Redis에 30초간 저장하고, done Pub/Sub을 발행한 뒤 RLock을 해제합니다. follower는 완료 신호를 받은 뒤 결과 cache를 읽고, cache miss 또는 읽기 실패 시 DB 조회로 복구합니다.

## Changes
- `word.single-flight.result-cache-ttl-ms=30000` 설정 추가
- 결과 cache 키(`sf:word:result:*`)와 JSON 직렬화 추가
- Pub/Sub 메시지에서 결과 payload 제거, 완료 신호로 축소
- follower의 cache hit 및 DB fallback 경로 테스트 추가/갱신
- cache 저장 → done 발행 → RLock 해제 순서 보장

## Example
```text
leader: DB save → Redis result cache (30s) → done publish → unlock
follower: done receive → Redis result cache GET → return
fallback: cache miss / message timeout → DB lookup
```

## Related Issues
없음

## Validation
- `./gradlew test --tests com.linglevel.api.word.service.WordSingleFlightRedisCoordinatorTest`
- `./gradlew checkFormat`
- Redis 통합 테스트는 현 환경의 Docker/Testcontainers 초기화 오류로 실행하지 못했습니다.